### PR TITLE
* Feat performance improvements and bug fixes

### DIFF
--- a/onecgiar-pr-server/src/api/results/evidences/evidences.repository.ts
+++ b/onecgiar-pr-server/src/api/results/evidences/evidences.repository.ts
@@ -300,34 +300,39 @@ export class EvidencesRepository
     is_supplementary: boolean,
     type: number,
   ) {
+    evidenceIdList = evidenceIdList ?? [];
     const evidenceIdListString = evidenceIdList.filter((e) => e).join(',');
 
-    evidenceIdList = evidenceIdList ?? [];
     const inactiveAll = `
-      update evidence
-      set is_active = 0,
-        last_updated_date  = NOW(),
-        last_updated_by  = ${userId}
-      where is_active  > 0
-        and result_id = ${resultId}
-        and is_supplementary = ${is_supplementary}
-        and evidence_type_id = ${type};
+      UPDATE evidence
+      SET is_active = 0,
+        last_updated_date = NOW(),
+        last_updated_by = ${userId}
+      WHERE is_active > 0
+        AND result_id = ${resultId}
+        AND is_supplementary = ${is_supplementary}
+        AND evidence_type_id = ${type};
     `;
 
-    const justActivateList = `
-      update evidence
-      set is_active = 1,
-        last_updated_date  = NOW(),
-        last_updated_by  = ${userId}
-      where result_id = ${resultId}
-        and id in (${evidenceIdListString})
-        and is_supplementary = ${is_supplementary}
-        and evidence_type_id = ${type};
-    `;
+    let justActivateList = '';
+    if (evidenceIdListString) {
+      justActivateList = `
+        UPDATE evidence
+        SET is_active = 1,
+          last_updated_date = NOW(),
+          last_updated_by = ${userId}
+        WHERE result_id = ${resultId}
+          AND id IN (${evidenceIdListString})
+          AND is_supplementary = ${is_supplementary}
+          AND evidence_type_id = ${type};
+      `;
+    }
 
     try {
       await this.query(inactiveAll);
-      await this.query(justActivateList);
+      if (justActivateList) {
+        await this.query(justActivateList);
+      }
     } catch (error) {
       throw this._handlersError.returnErrorRepository({
         className: EvidencesRepository.name,

--- a/onecgiar-pr-server/src/api/results/evidences/evidences.repository.ts
+++ b/onecgiar-pr-server/src/api/results/evidences/evidences.repository.ts
@@ -334,6 +334,7 @@ export class EvidencesRepository
         await this.query(justActivateList);
       }
     } catch (error) {
+      this._logger.error(error);
       throw this._handlersError.returnErrorRepository({
         className: EvidencesRepository.name,
         error: error,


### PR DESCRIPTION
### PR Summary 🛠️🐛

#### Bugfix: Handling Empty Evidence List in `updateEvidences` SQL Query
We’ve fixed a pesky bug where an empty evidence list would sneak in and break the SQL query. If the evidence list (`evidenceIdList`) was empty, it would generate an invalid SQL query like `id IN ()`, causing a syntax error. No more! We’ve plugged that hole.

#### Conditional SQL Query Execution for Evidence Activation
Now, the activation query for evidences only runs if the list of evidence IDs actually contains something. If `evidenceIdList` is empty, we skip the activation query entirely and only deactivate the necessary evidences. It’s like making sure you don’t order pizza when you’re not even hungry!

#### Validation and Error Prevention for Empty Lists
By checking if the `evidenceIdListString` is empty before constructing the SQL query, we’ve ensured no invalid `IN ()` clauses can be executed. This small change means you’ll no longer see SQL errors like:

```
QueryFailedError: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')'
```

#### Why Does This Matter? 💡
- **Error-Free Execution:** No more SQL syntax errors due to empty evidence lists.
- **Improved Code Stability:** We’re adding an extra layer of robustness, ensuring the system handles empty lists gracefully.
- **Performance Boost:** By skipping unnecessary queries, we’re keeping things efficient—no more activating empty lists of evidences!
