### PR TITLE
* Feat Added QA Tracking Fields

### DIFF
--- a/onecgiar-pr-server/src/api/results/entities/result.entity.ts
+++ b/onecgiar-pr-server/src/api/results/entities/result.entity.ts
@@ -351,6 +351,34 @@ export class Result {
   // helpers??
   initiative_id!: number;
 
+  // *** QA tracking fields
+  @Column({
+    name: 'qaed_date',
+    type: 'timestamp',
+    nullable: true,
+  })
+  qaed_date: Date;
+
+  @Column({
+    name: 'qaed_comment',
+    type: 'text',
+    nullable: true,
+  })
+  qaed_comment: string;
+
+  @Column({
+    name: 'qaed_user',
+    type: 'int',
+    nullable: true,
+  })
+  qaed_user: number;
+
+  @ManyToOne(() => User, (u) => u.obj_qaed_user, { nullable: true })
+  @JoinColumn({
+    name: 'qaed_user',
+  })
+  obj_qaed_user: User;
+
   @OneToMany(() => ResultsKnowledgeProduct, (rkp) => rkp.result_object)
   result_knowledge_product_array: ResultsKnowledgeProduct[];
 

--- a/onecgiar-pr-server/src/api/user-notification-settings/user-notification-settings.service.spec.ts
+++ b/onecgiar-pr-server/src/api/user-notification-settings/user-notification-settings.service.spec.ts
@@ -407,6 +407,7 @@ describe('UserNotificationSettingsService', () => {
             obj_user_notification_setting: [],
             obj_target_user_notification: [],
             obj_emitter_user_notification: [],
+            obj_qaed_user: [],
           },
           obj_initiative: {} as any,
           action_area_id: 1,

--- a/onecgiar-pr-server/src/auth/modules/user/entities/user.entity.ts
+++ b/onecgiar-pr-server/src/auth/modules/user/entities/user.entity.ts
@@ -11,6 +11,7 @@ import {
 } from 'typeorm';
 import { Notification } from '../../../../api/notification/entities/notification.entity';
 import { UserNotificationSetting } from '../../../../api/user-notification-settings/entities/user-notification-settings.entity';
+import { Result } from '../../../../api/results/entities/result.entity';
 
 @Entity('users')
 @Index(['email'], { unique: true })
@@ -101,4 +102,10 @@ export class User {
     (notificationSetting) => notificationSetting.obj_emitter_user,
   )
   obj_emitter_user_notification: Notification[];
+
+  @OneToMany(
+    () => Result,
+    (r) => r.obj_qaed_user,
+  )
+  obj_qaed_user: Result[];
 }

--- a/onecgiar-pr-server/src/migrations/1729692807743-AddedQATrackingColumnsForResults.ts
+++ b/onecgiar-pr-server/src/migrations/1729692807743-AddedQATrackingColumnsForResults.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddedQATrackingColumnsForResults1729692807743
+  implements MigrationInterface
+{
+  name = 'AddedQATrackingColumnsForResults1729692807743';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`result\` ADD \`qaed_date\` timestamp NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`result\` ADD \`qaed_comment\` text NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`result\` ADD \`qaed_user\` int NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`result\` ADD CONSTRAINT \`FK_ff2513072e955aacb72e9041790\` FOREIGN KEY (\`qaed_user\`) REFERENCES \`users\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`result\` DROP FOREIGN KEY \`FK_ff2513072e955aacb72e9041790\``,
+    );
+    await queryRunner.query(`ALTER TABLE \`result\` DROP COLUMN \`qaed_user\``);
+    await queryRunner.query(
+      `ALTER TABLE \`result\` DROP COLUMN \`qaed_comment\``,
+    );
+    await queryRunner.query(`ALTER TABLE \`result\` DROP COLUMN \`qaed_date\``);
+  }
+}


### PR DESCRIPTION
This pull request introduces QA tracking fields to the `Result` entity, updates related entities, and includes a migration script to handle the new database schema changes.

### QA Tracking Fields Addition:
* [`onecgiar-pr-server/src/api/results/entities/result.entity.ts`](diffhunk://#diff-8bb1e13a6a4d42010507c4756306dede49254ad3a6414fd123436546404e3d08R354-R381): Added new columns `qaed_date`, `qaed_comment`, and `qaed_user` to the `Result` entity. Also established a relationship with the `User` entity for the `qaed_user` field.

### Related Entities Update:
* [`onecgiar-pr-server/src/auth/modules/user/entities/user.entity.ts`](diffhunk://#diff-b247fcdbc6ae4ba1d7aceec868c0edb79cf030b0c43935a8c3df1c6b246a616dR14): Imported the `Result` entity and added a one-to-many relationship for `obj_qaed_user`. [[1]](diffhunk://#diff-b247fcdbc6ae4ba1d7aceec868c0edb79cf030b0c43935a8c3df1c6b246a616dR14) [[2]](diffhunk://#diff-b247fcdbc6ae4ba1d7aceec868c0edb79cf030b0c43935a8c3df1c6b246a616dR105-R110)
* [`onecgiar-pr-server/src/api/user-notification-settings/user-notification-settings.service.spec.ts`](diffhunk://#diff-400a4f2caf4038776deac313819ef9d304d147fb8dd0938f7d15009abd39c646R410): Updated the test data to include `obj_qaed_user`.

### Database Migration:
* [`onecgiar-pr-server/src/migrations/1729692807743-AddedQATrackingColumnsForResults.ts`](diffhunk://#diff-2edbf402d8fbf0cb4a436d49ff96ee6a2f5e186dbaca5e25ddef778df87dcb6fR1-R33): Created a migration script to add the new QA tracking columns to the `result` table and establish the foreign key constraint for `qaed_user`.