### PR TITLE
*Feat. New alerts validation on evidences section and narrative changes

### DIFF
--- a/onecgiar-pr-server/src/api/results/entities/result.entity.ts
+++ b/onecgiar-pr-server/src/api/results/entities/result.entity.ts
@@ -351,6 +351,34 @@ export class Result {
   // helpers??
   initiative_id!: number;
 
+  // *** QA tracking fields
+  @Column({
+    name: 'qaed_date',
+    type: 'timestamp',
+    nullable: true,
+  })
+  qaed_date: Date;
+
+  @Column({
+    name: 'qaed_comment',
+    type: 'text',
+    nullable: true,
+  })
+  qaed_comment: string;
+
+  @Column({
+    name: 'qaed_user',
+    type: 'int',
+    nullable: true,
+  })
+  qaed_user: number;
+
+  @ManyToOne(() => User, (u) => u.obj_qaed_user, { nullable: true })
+  @JoinColumn({
+    name: 'qaed_user',
+  })
+  obj_qaed_user: User;
+
   @OneToMany(() => ResultsKnowledgeProduct, (rkp) => rkp.result_object)
   result_knowledge_product_array: ResultsKnowledgeProduct[];
 

--- a/onecgiar-pr-server/src/api/user-notification-settings/user-notification-settings.service.spec.ts
+++ b/onecgiar-pr-server/src/api/user-notification-settings/user-notification-settings.service.spec.ts
@@ -407,6 +407,7 @@ describe('UserNotificationSettingsService', () => {
             obj_user_notification_setting: [],
             obj_target_user_notification: [],
             obj_emitter_user_notification: [],
+            obj_qaed_user: [],
           },
           obj_initiative: {} as any,
           action_area_id: 1,

--- a/onecgiar-pr-server/src/auth/modules/user/entities/user.entity.ts
+++ b/onecgiar-pr-server/src/auth/modules/user/entities/user.entity.ts
@@ -11,6 +11,7 @@ import {
 } from 'typeorm';
 import { Notification } from '../../../../api/notification/entities/notification.entity';
 import { UserNotificationSetting } from '../../../../api/user-notification-settings/entities/user-notification-settings.entity';
+import { Result } from '../../../../api/results/entities/result.entity';
 
 @Entity('users')
 @Index(['email'], { unique: true })
@@ -101,4 +102,10 @@ export class User {
     (notificationSetting) => notificationSetting.obj_emitter_user,
   )
   obj_emitter_user_notification: Notification[];
+
+  @OneToMany(
+    () => Result,
+    (r) => r.obj_qaed_user,
+  )
+  obj_qaed_user: Result[];
 }

--- a/onecgiar-pr-server/src/migrations/1729692807743-AddedQATrackingColumnsForResults.ts
+++ b/onecgiar-pr-server/src/migrations/1729692807743-AddedQATrackingColumnsForResults.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddedQATrackingColumnsForResults1729692807743
+  implements MigrationInterface
+{
+  name = 'AddedQATrackingColumnsForResults1729692807743';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`result\` ADD \`qaed_date\` timestamp NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`result\` ADD \`qaed_comment\` text NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`result\` ADD \`qaed_user\` int NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`result\` ADD CONSTRAINT \`FK_ff2513072e955aacb72e9041790\` FOREIGN KEY (\`qaed_user\`) REFERENCES \`users\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`result\` DROP FOREIGN KEY \`FK_ff2513072e955aacb72e9041790\``,
+    );
+    await queryRunner.query(`ALTER TABLE \`result\` DROP COLUMN \`qaed_user\``);
+    await queryRunner.query(
+      `ALTER TABLE \`result\` DROP COLUMN \`qaed_comment\``,
+    );
+    await queryRunner.query(`ALTER TABLE \`result\` DROP COLUMN \`qaed_date\``);
+  }
+}


### PR DESCRIPTION
This pull request focuses on enhancing the validation and alert mechanisms for innovation readiness evidence in the `RdEvidencesComponent`, as well as making a minor label change in the `AnticipatedInnovationUserComponent`. The most important changes include the addition of a new validation method, updates to the component's template, and corresponding unit tests.

Improvements to validation and alerts:

* [`onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.html`](diffhunk://#diff-a990f03a7adefdd318534e530ace0ec81bc371c6e59d3865aca2eec36e8cb232R9-R15): Added a conditional alert status message to prompt users to provide evidence for innovation readiness unless the readiness level is set to 0.
* [`onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.ts`](diffhunk://#diff-9108f6bada7868034992f3f6248c28a0d850172763d8c63a4a7377533060d937R16): Introduced the `isOptionalReadinessLevel` property and the `validateHasInnoReadinessLevelEvidence` method to check if evidence is required based on the readiness level. [[1]](diffhunk://#diff-9108f6bada7868034992f3f6248c28a0d850172763d8c63a4a7377533060d937R16) [[2]](diffhunk://#diff-9108f6bada7868034992f3f6248c28a0d850172763d8c63a4a7377533060d937R154-R159)
* [`onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.ts`](diffhunk://#diff-9108f6bada7868034992f3f6248c28a0d850172763d8c63a4a7377533060d937R57): Updated the `ngOnInit` method to set the `isOptionalReadinessLevel` based on the readiness level.

Unit tests for new validation method:

* [`onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.spec.ts`](diffhunk://#diff-d38253822ac4b573082f6702db95285777599cd6fdcda9e3cd6a3f03b0f1241cR393-R427): Added unit tests for the `validateHasInnoReadinessLevelEvidence` method to ensure it correctly validates the presence of innovation readiness evidence.

Minor label update:

* [`onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-result-types-pages/innovation-dev-info/components/anticipated-innovation-user/anticipated-innovation-user.component.html`](diffhunk://#diff-3fb9e06b863a727a8663c81dd55b11dc7ffc7ac819b0f2c69f4c2280b4c3b706L227-R227): Updated the label text to improve clarity.