### PR TITLE
* Feat Introduce ResultQaedLog entity and related module, removing obsolete QA fields from Result entity

### DIFF
--- a/onecgiar-pr-server/src/api/result-qaed/entities/result-qaed-log.entity.ts
+++ b/onecgiar-pr-server/src/api/result-qaed/entities/result-qaed-log.entity.ts
@@ -1,0 +1,55 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { User } from '../../../auth/modules/user/entities/user.entity';
+import { Result } from '../../results/entities/result.entity';
+
+@Entity('result_qaed_log')
+export class ResultQaedLog {
+  @PrimaryGeneratedColumn({
+    name: 'id',
+    type: 'bigint',
+  })
+  id: number;
+
+  @Column({
+    name: 'result_id',
+    type: 'bigint',
+  })
+  result_id: number;
+
+  @Column({
+    name: 'qaed_date',
+    type: 'date',
+  })
+  qaed_date: Date;
+
+  @Column({
+    name: 'qaed_comments',
+    type: 'text',
+    nullable: true,
+  })
+  qaed_comments: string;
+
+  @Column({
+    name: 'qaed_user',
+    type: 'bigint',
+  })
+  qaed_user: number;
+
+  @ManyToOne(() => Result, (r) => r.obj_result_qaed, { nullable: true })
+  @JoinColumn({
+    name: 'result_id',
+  })
+  obj_result_id_qaed: Result;
+
+  @ManyToOne(() => User, (u) => u.obj_qaed_user, { nullable: true })
+  @JoinColumn({
+    name: 'qaed_user',
+  })
+  obj_qaed_user: User;
+}

--- a/onecgiar-pr-server/src/api/result-qaed/result-qaed.controller.spec.ts
+++ b/onecgiar-pr-server/src/api/result-qaed/result-qaed.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ResultQaedController } from './result-qaed.controller';
+import { ResultQaedService } from './result-qaed.service';
+
+describe('ResultQaedController', () => {
+  let controller: ResultQaedController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ResultQaedController],
+      providers: [ResultQaedService],
+    }).compile();
+
+    controller = module.get<ResultQaedController>(ResultQaedController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/onecgiar-pr-server/src/api/result-qaed/result-qaed.controller.ts
+++ b/onecgiar-pr-server/src/api/result-qaed/result-qaed.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { ResultQaedService } from './result-qaed.service';
+
+@Controller('result-qaed')
+export class ResultQaedController {
+  constructor(private readonly resultQaedService: ResultQaedService) {}
+}

--- a/onecgiar-pr-server/src/api/result-qaed/result-qaed.module.ts
+++ b/onecgiar-pr-server/src/api/result-qaed/result-qaed.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ResultQaedService } from './result-qaed.service';
+import { ResultQaedController } from './result-qaed.controller';
+
+@Module({
+  controllers: [ResultQaedController],
+  providers: [ResultQaedService],
+})
+export class ResultQaedModule {}

--- a/onecgiar-pr-server/src/api/result-qaed/result-qaed.service.spec.ts
+++ b/onecgiar-pr-server/src/api/result-qaed/result-qaed.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ResultQaedService } from './result-qaed.service';
+
+describe('ResultQaedService', () => {
+  let service: ResultQaedService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ResultQaedService],
+    }).compile();
+
+    service = module.get<ResultQaedService>(ResultQaedService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/onecgiar-pr-server/src/api/result-qaed/result-qaed.service.ts
+++ b/onecgiar-pr-server/src/api/result-qaed/result-qaed.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ResultQaedService {}

--- a/onecgiar-pr-server/src/api/results/entities/result.entity.ts
+++ b/onecgiar-pr-server/src/api/results/entities/result.entity.ts
@@ -29,6 +29,7 @@ import { ResultsByInstitution } from '../results_by_institutions/entities/result
 import { ShareResultRequest } from '../share-result-request/entities/share-result-request.entity';
 import { ResultsTocResult } from '../results-toc-results/entities/results-toc-result.entity';
 import { Notification } from '../../notification/entities/notification.entity';
+import { ResultQaedLog } from '../../result-qaed/entities/result-qaed-log.entity';
 
 @Entity()
 export class Result {
@@ -351,34 +352,6 @@ export class Result {
   // helpers??
   initiative_id!: number;
 
-  // *** QA tracking fields
-  @Column({
-    name: 'qaed_date',
-    type: 'timestamp',
-    nullable: true,
-  })
-  qaed_date: Date;
-
-  @Column({
-    name: 'qaed_comment',
-    type: 'text',
-    nullable: true,
-  })
-  qaed_comment: string;
-
-  @Column({
-    name: 'qaed_user',
-    type: 'int',
-    nullable: true,
-  })
-  qaed_user: number;
-
-  @ManyToOne(() => User, (u) => u.obj_qaed_user, { nullable: true })
-  @JoinColumn({
-    name: 'qaed_user',
-  })
-  obj_qaed_user: User;
-
   @OneToMany(() => ResultsKnowledgeProduct, (rkp) => rkp.result_object)
   result_knowledge_product_array: ResultsKnowledgeProduct[];
 
@@ -420,4 +393,7 @@ export class Result {
 
   @OneToMany(() => Notification, (ra) => ra.obj_result)
   obj_result_notification: Notification[];
+
+  @OneToMany(() => ResultQaedLog, (ra) => ra.obj_result_id_qaed)
+  obj_result_qaed: Notification[];
 }

--- a/onecgiar-pr-server/src/app.module.ts
+++ b/onecgiar-pr-server/src/app.module.ts
@@ -41,6 +41,7 @@ import { SharePointModule } from './shared/services/share-point/share-point.modu
 import { NotificationModule } from './api/notification/notification.module';
 import { UserNotificationSettingsModule } from './api/user-notification-settings/user-notification-settings.module';
 import { EmailNotificationManagementModule } from './shared/microservices/email-notification-management/email-notification-management.module';
+import { ResultQaedModule } from './api/result-qaed/result-qaed.module';
 
 @Module({
   imports: [
@@ -78,6 +79,7 @@ import { EmailNotificationManagementModule } from './shared/microservices/email-
     UserNotificationSettingsModule,
     EmailNotificationManagementModule,
     NotificationModule,
+    ResultQaedModule,
   ],
   controllers: [AppController],
   providers: [

--- a/onecgiar-pr-server/src/auth/modules/user/entities/user.entity.ts
+++ b/onecgiar-pr-server/src/auth/modules/user/entities/user.entity.ts
@@ -11,7 +11,7 @@ import {
 } from 'typeorm';
 import { Notification } from '../../../../api/notification/entities/notification.entity';
 import { UserNotificationSetting } from '../../../../api/user-notification-settings/entities/user-notification-settings.entity';
-import { Result } from '../../../../api/results/entities/result.entity';
+import { ResultQaedLog } from '../../../../api/result-qaed/entities/result-qaed-log.entity';
 
 @Entity('users')
 @Index(['email'], { unique: true })
@@ -103,6 +103,6 @@ export class User {
   )
   obj_emitter_user_notification: Notification[];
 
-  @OneToMany(() => Result, (r) => r.obj_qaed_user)
-  obj_qaed_user: Result[];
+  @OneToMany(() => ResultQaedLog, (r) => r.obj_qaed_user)
+  obj_qaed_user: ResultQaedLog[];
 }

--- a/onecgiar-pr-server/src/migrations/1731503453561-RemovedQATrackingFieldsFromResult.ts
+++ b/onecgiar-pr-server/src/migrations/1731503453561-RemovedQATrackingFieldsFromResult.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemovedQATrackingFieldsFromResult1731503453561
+  implements MigrationInterface
+{
+  name = 'RemovedQATrackingFieldsFromResult1731503453561';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`result\` DROP FOREIGN KEY \`FK_ff2513072e955aacb72e9041790\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`result\` DROP COLUMN \`qaed_comment\``,
+    );
+    await queryRunner.query(`ALTER TABLE \`result\` DROP COLUMN \`qaed_date\``);
+    await queryRunner.query(`ALTER TABLE \`result\` DROP COLUMN \`qaed_user\``);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`result\` ADD \`qaed_user\` int NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`result\` ADD \`qaed_date\` timestamp NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`result\` ADD \`qaed_comment\` text COLLATE "utf8mb3_unicode_ci" NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`result\` ADD CONSTRAINT \`FK_ff2513072e955aacb72e9041790\` FOREIGN KEY (\`qaed_user\`) REFERENCES \`users\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/onecgiar-pr-server/src/migrations/1731504619556-AddedResultQAedLogTable.ts
+++ b/onecgiar-pr-server/src/migrations/1731504619556-AddedResultQAedLogTable.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddedResultQAedLogTable1731504619556
+  implements MigrationInterface
+{
+  name = 'AddedResultQAedLogTable1731504619556';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE \`result_qaed_log\` (\`id\` bigint NOT NULL AUTO_INCREMENT, \`result_id\` bigint NOT NULL, \`qaed_date\` date NOT NULL, \`qaed_comments\` text NULL, \`qaed_user\` int NOT NULL, PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`result_qaed_log\` ADD CONSTRAINT \`FK_9935d4ce4da5bb7b26cee090987\` FOREIGN KEY (\`result_id\`) REFERENCES \`result\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`result_qaed_log\` ADD CONSTRAINT \`FK_bee9006e35c169af6033da52a04\` FOREIGN KEY (\`qaed_user\`) REFERENCES \`users\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`result_qaed_log\` DROP FOREIGN KEY \`FK_bee9006e35c169af6033da52a04\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`result_qaed_log\` DROP FOREIGN KEY \`FK_9935d4ce4da5bb7b26cee090987\``,
+    );
+    await queryRunner.query(`DROP TABLE \`result_qaed_log\``);
+  }
+}


### PR DESCRIPTION
This pull request introduces a new `ResultQaedLog` entity to handle QA tracking fields separately from the `Result` entity. It includes changes to the database schema, updates to related entities, and the addition of a new module, controller, and service for handling QA logs.

### Introduction of `ResultQaedLog` entity:

* Added `ResultQaedLog` entity with fields for `result_id`, `qaed_date`, `qaed_comments`, and `qaed_user`, along with relationships to `Result` and `User` entities. (`onecgiar-pr-server/src/api/result-qaed/entities/result-qaed-log.entity.ts`)
* Removed QA tracking fields from the `Result` entity and updated the relationship to reference the new `ResultQaedLog` entity. (`onecgiar-pr-server/src/api/results/entities/result.entity.ts`) [[1]](diffhunk://#diff-8bb1e13a6a4d42010507c4756306dede49254ad3a6414fd123436546404e3d08L354-L381) [[2]](diffhunk://#diff-8bb1e13a6a4d42010507c4756306dede49254ad3a6414fd123436546404e3d08R396-R398)
* Updated the `User` entity to reference the new `ResultQaedLog` entity instead of the `Result` entity for QA tracking. (`onecgiar-pr-server/src/auth/modules/user/entities/user.entity.ts`)

### Database schema changes:

* Created a migration to remove QA tracking fields from the `Result` entity. (`onecgiar-pr-server/src/migrations/1731503453561-RemovedQATrackingFieldsFromResult.ts`)
* Created a migration to add the `result_qaed_log` table and set up foreign key constraints. (`onecgiar-pr-server/src/migrations/1731504619556-AddedResultQAedLogTable.ts`)

### New module, controller, and service for QA logs:

* Added `ResultQaedModule`, `ResultQaedController`, and `ResultQaedService` to handle operations related to QA logs. (`onecgiar-pr-server/src/api/result-qaed/result-qaed.module.ts`)
* Added unit tests for `ResultQaedController` and `ResultQaedService`. (`onecgiar-pr-server/src/api/result-qaed/result-qaed.controller.spec.ts`) [[1]](diffhunk://#diff-7c3bae1ae4d91b0f09091c7f52e41f9b3269480355e06f831fb78967cad782ffR1-R20) (`onecgiar-pr-server/src/api/result-qaed/result-qaed.service.spec.ts`) [[2]](diffhunk://#diff-d8f101f4f072c0b144f273ca6b7e98e8884a117aa3626b53158c70d5eafc6db4R1-R18)

### Application module update:

* Updated the main application module to include the new `ResultQaedModule`. (`onecgiar-pr-server/src/app.module.ts`)