### PR TITLE
🐛fix(Section 2): re-adding condition on submitter dropdown. P2-1177

### DIFF
--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-theory-of-change/rd-theory-of-change.component.html
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-theory-of-change/rd-theory-of-change.component.html
@@ -19,7 +19,9 @@
       placeholder="Select Initiative"
       description="Select an initiative or platform"
       [(ngModel)]="this.theoryOfChangeBody.changePrimaryInit"
-      [fieldDisabled]="true">
+      [fieldDisabled]="
+        !!(this.theoryOfChangeBody.contributing_and_primary_initiative?.length === 1 && this.theoryOfChangeBody?.result_toc_result?.initiative_id)
+      ">
     </app-pr-select>
 
     <div


### PR DESCRIPTION
This pull request includes a small change to the `rd-theory-of-change.component.html` file. The change modifies the `fieldDisabled` attribute to dynamically enable or disable the field based on the length of `contributing_and_primary_initiative` and the presence of `result_toc_result.initiative_id`.

* [`onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-theory-of-change/rd-theory-of-change.component.html`](diffhunk://#diff-ab624cf3fc3c8e06195937a2c07c66032a04d72d7fe7d990f8bca1e9656989c1L22-R24): Modified the `fieldDisabled` attribute to dynamically enable or disable the field based on specific conditions.