### PR TITLE
* Fix remove Indicator Target Saving Logic

### DIFF
--- a/onecgiar-pr-server/src/api/results/results-toc-results/repositories/results-toc-results.repository.ts
+++ b/onecgiar-pr-server/src/api/results/results-toc-results/repositories/results-toc-results.repository.ts
@@ -2206,14 +2206,6 @@ select *
               toc?.actionAreaOutcome,
               toc?.result_toc_result_id,
             );
-
-            // * Save Indicators
-            if (toc?.indicators) {
-              await this.saveInditicatorsContributing(
-                toc?.indicators,
-                rtrExist?.result_toc_result_id,
-              );
-            }
           } else {
             return this._handlersError.returnErrorRepository({
               className: ResultsTocResultRepository.name,
@@ -2306,14 +2298,6 @@ select *
       toc?.actionAreaOutcome,
       toc?.result_toc_result_id,
     );
-
-    // * Save Indicators
-    if (toc?.indicators) {
-      await this.saveInditicatorsContributing(
-        toc?.indicators,
-        rtrExist?.result_toc_result_id,
-      );
-    }
   }
 
   async getSdgTargetsByResultId(resultId) {


### PR DESCRIPTION
This pull request includes changes to the `onecgiar-pr-server/src/api/results/results-toc-results/repositories/results-toc-results.repository.ts` file to remove unnecessary code related to saving indicators. 

Codebase simplification:

* Removed the logic for saving indicators (`saveInditicatorsContributing`) from the `ResultsTocResultRepository` class, as it was deemed unnecessary. [[1]](diffhunk://#diff-0d4c3c693c7a4f97b734e63f5836db12a93f1655170a05d02c77f765af449ad0L2209-L2216) [[2]](diffhunk://#diff-0d4c3c693c7a4f97b734e63f5836db12a93f1655170a05d02c77f765af449ad0L2309-L2316)