### PR TITLE
* Feat Improved queries for Contribution to Indicators

### DIFF
--- a/onecgiar-pr-server/src/api/contribution-to-indicators/repositories/contribution-to-indicator-result.repository.ts
+++ b/onecgiar-pr-server/src/api/contribution-to-indicators/repositories/contribution-to-indicator-result.repository.ts
@@ -42,13 +42,15 @@ export class ContributionToIndicatorResultsRepository extends Repository<Contrib
       	and ctis.is_active
       left join ${env.DB_NAME}.result_status indicator_s on ctis.status_id = indicator_s.result_status_id
       left join ${env.DB_TOC}.toc_results_indicators tri on tri.is_active
-        and convert(tri.toc_result_indicator_id using utf8mb4) = convert(cti.toc_result_id using utf8mb4) 
+        and convert(tri.related_node_id using utf8mb4) = convert(cti.toc_result_id using utf8mb4) 
       left join ${env.DB_TOC}.toc_result_indicator_target trit 
         on tri.related_node_id = trit.toc_result_indicator_id and left(trit.target_date,4) = 2024
       right join ${env.DB_TOC}.toc_results tr on tr.id = tri.toc_results_id
       left join ${env.DB_NAME}.clarisa_initiatives ci on ci.toc_id = tr.id_toc_initiative
       left join ${env.DB_TOC}.work_packages wp on tr.work_packages_id = wp.id
       where cti.toc_result_id = ? and cti.is_active
+      order by
+        tr.id desc
     `;
 
     return this.dataSource
@@ -74,7 +76,7 @@ export class ContributionToIndicatorResultsRepository extends Repository<Contrib
     tocId: string,
   ): Promise<ContributionToIndicatorResultsDto[]> {
     const dataQuery = `
-      select main_ctir.id as contribution_id, main_ctir.is_active, main_r.id as result_id, main_r.result_code, main_r.title,
+      select distinct main_ctir.id as contribution_id, main_ctir.is_active, main_r.id as result_id, main_r.result_code, main_r.title,
       main_v.phase_name, main_v.id as version_id, main_rt.name as result_type, main_ci.official_code as result_submitter, 
       main_rs.status_name, date_format(main_r.created_date, '%Y-%m-%d') as created_date, false as is_manually_mapped
     from ${env.DB_TOC}.toc_results_indicators tri
@@ -94,7 +96,7 @@ export class ContributionToIndicatorResultsRepository extends Repository<Contrib
     left join ${env.DB_NAME}.result_status main_rs on main_rs.result_status_id = main_r.status_id
     where tri.toc_result_indicator_id = ? and tri.is_active and main_r.id is not null
     union all
-    select main_ctir.id as contribution_id, main_ctir.is_active, main_r.id as result_id, main_r.result_code, main_r.title,
+    select distinct main_ctir.id as contribution_id, main_ctir.is_active, main_r.id as result_id, main_r.result_code, main_r.title,
       main_v.phase_name, main_v.id as version_id, main_rt.name as result_type, main_ci.official_code as result_submitter, 
       main_rs.status_name, date_format(main_r.created_date, '%Y-%m-%d') as created_date, true as is_manually_mapped
     from ${env.DB_NAME}.contribution_to_indicator_results main_ctir

--- a/onecgiar-pr-server/src/api/contribution-to-indicators/repositories/contribution-to-indicators.repository.ts
+++ b/onecgiar-pr-server/src/api/contribution-to-indicators/repositories/contribution-to-indicators.repository.ts
@@ -129,7 +129,7 @@ export class ContributionToIndicatorsRepository extends Repository<ContributionT
           "indicators", (
             select json_arrayagg(json_object(
               "indicator_id", oi.id,
-              "indicator_uuid", oi.toc_result_indicator_id,
+              "indicator_uuid", oi.related_node_id,
               "indicator_description", REGEXP_REPLACE(oi.indicator_description, '^[[:space:]]+|[[:space:]]+$', ''),
               "indicator_name", REGEXP_REPLACE(oi.type_name, '^[[:space:]]+|[[:space:]]+$', ''),
               "is_indicator_custom", if(trim(oi.type_value) like 'custom', true, false),
@@ -150,7 +150,7 @@ export class ContributionToIndicatorsRepository extends Repository<ContributionT
             left join ${env.DB_TOC}.toc_result_indicator_target trit 
               on oi.related_node_id = trit.toc_result_indicator_id and left(trit.target_date,4) = 2024
             left join ${env.DB_NAME}.contribution_to_indicators cti on cti.is_active
-              and convert(cti.toc_result_id using utf8mb4) = convert(oi.toc_result_indicator_id using utf8mb4)
+              and convert(cti.toc_result_id using utf8mb4) = convert(oi.related_node_id using utf8mb4)
             left join ${env.DB_NAME}.contribution_to_indicator_submissions ctis on ctis.contribution_to_indicator_id = cti.id
             	and ctis.is_active
             left join ${env.DB_NAME}.result_status indicator_s on ctis.status_id = indicator_s.result_status_id


### PR DESCRIPTION
This pull request includes several changes to the `ContributionToIndicatorResultsRepository` and `ContributionToIndicatorsRepository` classes in the `onecgiar-pr-server/src/api/contribution-to-indicators/repositories` directory. The main focus is on updating the database queries to use the correct field names and adding distinct selection and ordering to improve query results.

Changes to database queries:

* Updated the field used in the `left join` clause from `toc_result_indicator_id` to `related_node_id` in the `ContributionToIndicatorResultsRepository` class.
* Added `order by tr.id desc` to the query in the `ContributionToIndicatorResultsRepository` class to ensure results are ordered by the `id` field in descending order.
* Added `distinct` to the `select` statements to ensure unique results in the `ContributionToIndicatorResultsRepository` class. [[1]](diffhunk://#diff-b9bcd224b96e07a95954de4afedffa682e35adb5d39cb191e8a21cdc8cd32bbaL77-R79) [[2]](diffhunk://#diff-b9bcd224b96e07a95954de4afedffa682e35adb5d39cb191e8a21cdc8cd32bbaL97-R99)
* Updated the field used in the `json_object` and `left join` clauses from `toc_result_indicator_id` to `related_node_id` in the `ContributionToIndicatorsRepository` class. [[1]](diffhunk://#diff-7fa71481438363f8bf8b39272b89cdf39bd8f21fb11ca541274828a2be0f5d58L132-R132) [[2]](diffhunk://#diff-7fa71481438363f8bf8b39272b89cdf39bd8f21fb11ca541274828a2be0f5d58L153-R153)