### PR TITLE
* Feat simplify null check and remove commented-out code

### DIFF
--- a/onecgiar-pr-server/src/api/results/results-toc-results/results-toc-results.service.ts
+++ b/onecgiar-pr-server/src/api/results/results-toc-results/results-toc-results.service.ts
@@ -701,8 +701,7 @@ export class ResultsTocResultsService {
     initSubmitter: number,
   ) {
     try {
-      if (!createResultsTocResultDto || !createResultsTocResultDto.length)
-        return;
+      if (!createResultsTocResultDto?.length) return;
 
       const incomingRtRIds = createResultsTocResultDto.flatMap(
         (contributor) =>

--- a/onecgiar-pr-server/src/api/results/share-result-request/share-result-request.service.ts
+++ b/onecgiar-pr-server/src/api/results/share-result-request/share-result-request.service.ts
@@ -951,14 +951,6 @@ export class ShareResultRequestService {
       } else {
         await this.activateExistingInitiativeEntry(exists, user);
         await this.createOrUpdateBudgetForInitiative(exists.id, user);
-
-        // await this.mapWorkPackagesToInitiative(
-        //   rtr.result_toc_results,
-        //   result_id,
-        //   shared_inititiative_id,
-        //   user,
-        //   rtr?.planned_result,
-        // );
         await this.saveIndicatorsForPrimarySubmitter(dto, result_id);
       }
     } catch (error) {


### PR DESCRIPTION
This pull request includes changes to improve the code quality and maintainability in the `onecgiar-pr-server` project. The most important changes involve simplifying conditional checks and removing commented-out code.

Code quality improvements:

* [`onecgiar-pr-server/src/api/results/results-toc-results/results-toc-results.service.ts`](diffhunk://#diff-d37e49c54f4fdd2aa65662c27bdba2bf389aea837bf6a3a58e0aa42d983d89f1L704-R704): Simplified the conditional check for `createResultsTocResultDto` by using optional chaining.

Code maintainability:

* [`onecgiar-pr-server/src/api/results/share-result-request/share-result-request.service.ts`](diffhunk://#diff-616a4d09d4dba5dfa8d0cfeaaa05a06a6eabe60d5e019105af9371a97fccca24L954-L961): Removed unnecessary commented-out code to improve readability and maintainability.… in result services