### PR TITLE
* Feat Conditionally map work packages to initiative based on TOC flag

### DIFF
--- a/onecgiar-pr-server/src/api/results/share-result-request/share-result-request.service.ts
+++ b/onecgiar-pr-server/src/api/results/share-result-request/share-result-request.service.ts
@@ -951,6 +951,15 @@ export class ShareResultRequestService {
       } else {
         await this.activateExistingInitiativeEntry(exists, user);
         await this.createOrUpdateBudgetForInitiative(exists.id, user);
+        if (!is_map_to_toc) {
+          await this.mapWorkPackagesToInitiative(
+            rtr.result_toc_results,
+            result_id,
+            shared_inititiative_id,
+            user,
+            rtr?.planned_result,
+          );
+        }
         await this.saveIndicatorsForPrimarySubmitter(dto, result_id);
       }
     } catch (error) {


### PR DESCRIPTION
This pull request includes a change to the `ShareResultRequestService` class in the `share-result-request.service.ts` file. The change adds a conditional block to map work packages to an initiative if `is_map_to_toc` is not true.

* [`onecgiar-pr-server/src/api/results/share-result-request/share-result-request.service.ts`](diffhunk://#diff-616a4d09d4dba5dfa8d0cfeaaa05a06a6eabe60d5e019105af9371a97fccca24R954-R962): Added a conditional block to call `mapWorkPackagesToInitiative` if `is_map_to_toc` is false.