### PR TITLE
♻️ refactor(type-one-report): Update SharePoint folder links in EOIO and WPS progress components

### DIFF
--- a/onecgiar-pr-client/src/app/pages/type-one-report/pages/tor-progress-eoio/tor-progress-eoio.component.html
+++ b/onecgiar-pr-client/src/app/pages/type-one-report/pages/tor-progress-eoio/tor-progress-eoio.component.html
@@ -9,7 +9,7 @@
       </p>
 
       <a
-        href="https://cgiar.sharepoint.com/:f:/s/WGonpoolednon-pooledalignment/Eu4wuo-poeRNru3T-z9heKYBxF52gUUeg0TBU4Yy3t2bjA?e=usOMKZ"
+        href="https://cgiar.sharepoint.com/:f:/s/PRMSProject/EulWCZAB9NpJih0pHKcrC_UB3DrKckmL51fSw57rbJPE1w?e=Mw8aMs"
         target="_blank"
         rel="noopener noreferrer">
         <app-pr-button text="Go to folder" icon="folder"></app-pr-button>

--- a/onecgiar-pr-client/src/app/pages/type-one-report/pages/tor-progress-wps/tor-progress-wps.component.html
+++ b/onecgiar-pr-client/src/app/pages/type-one-report/pages/tor-progress-wps/tor-progress-wps.component.html
@@ -14,7 +14,7 @@
       </p>
 
       <a
-        href="https://cgiar.sharepoint.com/:f:/s/WGonpoolednon-pooledalignment/Eu4wuo-poeRNru3T-z9heKYBxF52gUUeg0TBU4Yy3t2bjA?e=usOMKZ"
+        href="https://cgiar.sharepoint.com/:f:/s/PRMSProject/EulWCZAB9NpJih0pHKcrC_UB3DrKckmL51fSw57rbJPE1w?e=Mw8aMs"
         target="_blank"
         rel="noopener noreferrer">
         <app-pr-button text="Go to folder" icon="folder"></app-pr-button>


### PR DESCRIPTION
This pull request includes updates to URLs in two HTML files to point to a new SharePoint folder.

Updated SharePoint URLs:

* [`onecgiar-pr-client/src/app/pages/type-one-report/pages/tor-progress-eoio/tor-progress-eoio.component.html`](diffhunk://#diff-7311204ddf0654ee114b7afda82f966d63765b33c47397a17c383972eae247b7L12-R12): Changed the URL in the anchor tag to the new SharePoint folder link.
* [`onecgiar-pr-client/src/app/pages/type-one-report/pages/tor-progress-wps/tor-progress-wps.component.html`](diffhunk://#diff-4e2e4114ebc5d163cf9260a838286123af55c05adb8d9546b0f5588c276e7f97L17-R17): Changed the URL in the anchor tag to the new SharePoint folder link.