### PR TITLE
🐛 fix(results-list): Update Excel export column count for PDF link

### DIFF
--- a/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/results-list.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/results-list.component.spec.ts
@@ -291,7 +291,7 @@ describe('ResultsListComponent', () => {
 
       expect(spyExportExcel).toHaveBeenCalledWith([], 'results_list', wscols, [
         {
-          cellNumber: 22,
+          cellNumber: 23,
           cellKey: 'pdf_link'
         }
       ]);

--- a/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/results-list.component.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/results-list.component.ts
@@ -142,7 +142,7 @@ export class ResultsListComponent implements OnInit, OnDestroy {
 
         this.exportTablesSE.exportExcel(response, 'results_list', wscols, [
           {
-            cellNumber: 22,
+            cellNumber: 23,
             cellKey: 'pdf_link'
           }
         ]);


### PR DESCRIPTION
This pull request includes changes to the `ResultsListComponent` to update the cell number for the `pdf_link` key in the export to Excel functionality.

* [`onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/results-list.component.spec.ts`](diffhunk://#diff-7b1dde36da3a1e76e3ab9dca2bf7769c202c03b4f188a6c5db1b6347e6367c16L294-R294): Updated the expected cell number for `pdf_link` from 22 to 23 in the test case.
* [`onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/results-list.component.ts`](diffhunk://#diff-a7dc5bb80e2120a4871101ce862973d571ef7d62e0c85ea16f29232f585eb86bL145-R145): Updated the cell number for `pdf_link` from 22 to 23 in the export to Excel method.