### PR TITLE
* Fix Update SQL queries to use parameterized inputs and improve query structure

### DIFF
--- a/onecgiar-pr-server/src/api/contribution-to-indicators/repositories/contribution-to-indicator-result.repository.ts
+++ b/onecgiar-pr-server/src/api/contribution-to-indicators/repositories/contribution-to-indicator-result.repository.ts
@@ -76,7 +76,6 @@ export class ContributionToIndicatorResultsRepository extends Repository<Contrib
     tocId: string,
   ): Promise<IndicatorSupportingResult[]> {
     const dataQuery = this.getContributingResultsQuery();
-
     return this.dataSource
       .query(dataQuery, [tocId, tocId])
       .then((result) => result)
@@ -96,7 +95,7 @@ export class ContributionToIndicatorResultsRepository extends Repository<Contrib
     );
   }
 
-  getContributingResultsQuery(tocId?: string): string {
+  getContributingResultsQuery(): string {
     return `
     select
       distinct main_ctir.id as contribution_id,
@@ -131,7 +130,7 @@ export class ContributionToIndicatorResultsRepository extends Repository<Contrib
       left join ${env.DB_NAME}.clarisa_initiatives main_ci on main_ci.id = main_rbi.inititiative_id
       left join ${env.DB_NAME}.result_status main_rs on main_rs.result_status_id = main_r.status_id
     where
-      tri.related_node_id = ${tocId ? `'${tocId}'` : '?'}
+      tri.related_node_id = ?
       and tri.is_active
       and main_r.id is not null
     union
@@ -163,12 +162,12 @@ export class ContributionToIndicatorResultsRepository extends Repository<Contrib
       left join ${env.DB_NAME}.clarisa_initiatives main_ci on main_ci.id = main_rbi.inititiative_id
       left join ${env.DB_NAME}.result_status main_rs on main_rs.result_status_id = main_r.status_id
     where
-      cti.toc_result_id = ${tocId ? `'${tocId}'` : '?'}
+      cti.toc_result_id = ?
       AND NOT EXISTS (
         SELECT
           1
         FROM
-          prdb.results_toc_result rtr
+          ${env.DB_NAME}.results_toc_result rtr
         WHERE
           rtr.is_active
           AND rtr.results_id = main_ctir.result_id


### PR DESCRIPTION
This pull request includes changes to the `ContributionToIndicatorResultsRepository` and `ContributionToIndicatorsRepository` classes to simplify query handling and improve code maintainability. The most important changes include the removal of unnecessary parameters from query methods and the refactoring of query construction.

Improvements to query handling:

* [`onecgiar-pr-server/src/api/contribution-to-indicators/repositories/contribution-to-indicator-result.repository.ts`](diffhunk://#diff-b9bcd224b96e07a95954de4afedffa682e35adb5d39cb191e8a21cdc8cd32bbaL99-R98): Removed the `tocId` parameter from the `getContributingResultsQuery` method and replaced inline parameter substitution with parameterized queries. [[1]](diffhunk://#diff-b9bcd224b96e07a95954de4afedffa682e35adb5d39cb191e8a21cdc8cd32bbaL99-R98) [[2]](diffhunk://#diff-b9bcd224b96e07a95954de4afedffa682e35adb5d39cb191e8a21cdc8cd32bbaL134-R133) [[3]](diffhunk://#diff-b9bcd224b96e07a95954de4afedffa682e35adb5d39cb191e8a21cdc8cd32bbaL166-R170)

Refactoring for maintainability:

* [`onecgiar-pr-server/src/api/contribution-to-indicators/repositories/contribution-to-indicators.repository.ts`](diffhunk://#diff-7fa71481438363f8bf8b39272b89cdf39bd8f21fb11ca541274828a2be0f5d58L176-R185): Refactored the `_flattenedResultsQuery` method to remove the `tocId` parameter and use the `getContributingResultsQuery` method from `ContributionToIndicatorResultsRepository`. [[1]](diffhunk://#diff-7fa71481438363f8bf8b39272b89cdf39bd8f21fb11ca541274828a2be0f5d58L176-R185) [[2]](diffhunk://#diff-7fa71481438363f8bf8b39272b89cdf39bd8f21fb11ca541274828a2be0f5d58L193-R204)
* Updated calls to `query` method in `ContributionToIndicatorsRepository` to pass necessary parameters as an array. [[1]](diffhunk://#diff-7fa71481438363f8bf8b39272b89cdf39bd8f21fb11ca541274828a2be0f5d58L62-R65) [[2]](diffhunk://#diff-7fa71481438363f8bf8b39272b89cdf39bd8f21fb11ca541274828a2be0f5d58L113-R119)