### PR TITLE
♻️ Improved expiresIn option from JWT middleware

### DIFF
--- a/onecgiar-pr-server/src/auth/Middlewares/jwt.middleware.spec.ts
+++ b/onecgiar-pr-server/src/auth/Middlewares/jwt.middleware.spec.ts
@@ -350,7 +350,6 @@ describe('JwtMiddleware', () => {
         },
         {
           secret: 'test-secret',
-          expiresIn: '7h',
         },
       );
     });

--- a/onecgiar-pr-server/src/auth/Middlewares/jwt.middleware.ts
+++ b/onecgiar-pr-server/src/auth/Middlewares/jwt.middleware.ts
@@ -131,7 +131,6 @@ export class JwtMiddleware implements NestMiddleware {
         },
         {
           secret: env.JWT_SKEY,
-          expiresIn: '7h',
         },
       );
 

--- a/onecgiar-pr-server/src/auth/auth.service.spec.ts
+++ b/onecgiar-pr-server/src/auth/auth.service.spec.ts
@@ -369,7 +369,9 @@ describe('AuthService', () => {
       const result = await service.validateAuthCode(mockAuthCodeDto);
 
       expect(result.status).toBe(HttpStatus.FORBIDDEN);
-      expect(result.message).toContain('The user test@example.com does not have any roles assigned. Please contact the administrator.');
+      expect(result.message).toContain(
+        'The user test@example.com does not have any roles assigned. Please contact the administrator.',
+      );
     });
   });
 


### PR DESCRIPTION
This pull request includes minor changes to the `JwtMiddleware` and `AuthService` files, primarily focused on improving code readability and removing redundant properties.

### Code readability improvements:

* [`onecgiar-pr-server/src/auth/auth.service.spec.ts`](diffhunk://#diff-207c5b522bcf2f212d0bddbfb32ab6dfe07d720418519ceb19f04da0bd1273fbL372-R374): Reformatted the `expect(result.message)` assertion to improve readability by breaking the string into multiple lines.

### Redundant property removal:

* [`onecgiar-pr-server/src/auth/Middlewares/jwt.middleware.spec.ts`](diffhunk://#diff-c6a648ef71eaeed3f9d344449ddf9b9a115bdfc45d280d521c8bdddbaa8c6d99L353): Removed the `expiresIn` property from the test configuration for JWT middleware.
* [`onecgiar-pr-server/src/auth/Middlewares/jwt.middleware.ts`](diffhunk://#diff-7b356069a9ac959d0e8154b813d59040dfc8ce943ac46fe33d758429e33a34bfL134): Removed the `expiresIn` property from the JWT middleware implementation to align with updated requirements.