### PR TITLE
♻️ Update Jenkins trigger workflow to specify branch and improve URL construction

### DIFF
--- a/.github/workflows/jenkins-trigger.yml
+++ b/.github/workflows/jenkins-trigger.yml
@@ -1,29 +1,32 @@
-name: Trigger Jenkins Job
+name: Trigger Jenkins Docker
 
 on:
   push:
     branches:
-      - '**'  # This will trigger the workflow on any branch that receives a push
-  workflow_dispatch:  # This allows the workflow to be manually triggered if needed
+      - dev
+  pull_request:
+    branches:
+      - dev
+  workflow_dispatch:
 
 jobs:
-  trigger-job:
+  trigger:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        jenkins_job:
+          - prms-reporting-tool-dev-docker
+          - prms-reporting-tool-dev-client-docker
     steps:
-      # Step 1: Get the branch name and build the URL for Jenkins
-      - name: Get branch name and build Jenkins URL
+      - name: Build Jenkins URL
         run: |
-          BRANCH_NAME=${GITHUB_REF#refs/heads/}  # Remove 'refs/heads/' from GITHUB_REF
-          JENKINS_URL="https://automation.prms.cgiar.org/job/prms-reporting-tool-${BRANCH_NAME}/build"
-          echo "Jenkins job URL for the branch $BRANCH_NAME is: $JENKINS_URL"
-          echo "JENKINS_URL=${JENKINS_URL}" >> $GITHUB_ENV
-        
-      # Step 2: Execute the curl command to trigger the job in Jenkins with the dynamically built URL
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}
+          JENKINS_URL="https://automation.prms.cgiar.org/job/${{ matrix.jenkins_job }}/buildWithParameters?branch=$BRANCH_NAME"
+          echo "JENKINS_URL=$JENKINS_URL" >> $GITHUB_ENV
       - name: Trigger Jenkins Job
         run: |
-          curl -X POST ${{ env.JENKINS_URL }} --user ${{ secrets.JENKINS_USERNAME }}:${{ secrets.JENKINS_API_TOKEN }}
+          curl -X POST "$JENKINS_URL" \
+               --user "$JENKINS_USERNAME:$JENKINS_API_TOKEN"
         env:
-          JENKINS_URL: ${{ env.JENKINS_URL }}
           JENKINS_USERNAME: ${{ secrets.JENKINS_USERNAME }}
           JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}

--- a/.github/workflows/jenkins-triggeryml.backup
+++ b/.github/workflows/jenkins-triggeryml.backup
@@ -1,0 +1,29 @@
+name: Trigger Jenkins Job
+
+on:
+  push:
+    branches:
+      - '**'  # This will trigger the workflow on any branch that receives a push
+  workflow_dispatch:  # This allows the workflow to be manually triggered if needed
+
+jobs:
+  trigger-job:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Get the branch name and build the URL for Jenkins
+      - name: Get branch name and build Jenkins URL
+        run: |
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}  # Remove 'refs/heads/' from GITHUB_REF
+          JENKINS_URL="https://automation.prms.cgiar.org/job/prms-reporting-tool-${BRANCH_NAME}/build"
+          echo "Jenkins job URL for the branch $BRANCH_NAME is: $JENKINS_URL"
+          echo "JENKINS_URL=${JENKINS_URL}" >> $GITHUB_ENV
+        
+      # Step 2: Execute the curl command to trigger the job in Jenkins with the dynamically built URL
+      - name: Trigger Jenkins Job
+        run: |
+          curl -X POST ${{ env.JENKINS_URL }} --user ${{ secrets.JENKINS_USERNAME }}:${{ secrets.JENKINS_API_TOKEN }}
+        env:
+          JENKINS_URL: ${{ env.JENKINS_URL }}
+          JENKINS_USERNAME: ${{ secrets.JENKINS_USERNAME }}
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}


### PR DESCRIPTION
This pull request updates the Jenkins workflow configuration to support matrix builds and streamline triggering for specific branches. Additionally, a backup of the original workflow configuration has been added for reference.

### Updates to Jenkins Workflow Configuration:

* **Matrix Builds for Jenkins Jobs**: The workflow now uses a matrix strategy to trigger multiple Jenkins jobs (`prms-reporting-tool-dev-docker` and `prms-reporting-tool-dev-client-docker`) with parameters. This allows for more flexible and parallelized builds. (`.github/workflows/jenkins-trigger.yml`, [.github/workflows/jenkins-trigger.ymlL1-L27](diffhunk://#diff-ece632ebc3c8f5f8c8fff3f5547d814124811ea82711e33ee81616f8bcd784bfL1-L27))

* **Branch-Specific Triggers**: The workflow has been updated to trigger only on the `dev` branch for both `push` and `pull_request` events, instead of triggering on all branches. (`.github/workflows/jenkins-trigger.yml`, [.github/workflows/jenkins-trigger.ymlL1-L27](diffhunk://#diff-ece632ebc3c8f5f8c8fff3f5547d814124811ea82711e33ee81616f8bcd784bfL1-L27))

* **Simplified Jenkins URL Construction**: The Jenkins URL now dynamically incorporates the matrix job name and branch as parameters, improving clarity and reducing redundancy. (`.github/workflows/jenkins-trigger.yml`, [.github/workflows/jenkins-trigger.ymlL1-L27](diffhunk://#diff-ece632ebc3c8f5f8c8fff3f5547d814124811ea82711e33ee81616f8bcd784bfL1-L27))

### Backup of Original Workflow:

* **Backup File Added**: A backup of the original Jenkins workflow configuration has been added as `.github/workflows/jenkins-triggeryml.backup` for archival purposes. This retains the previous approach of triggering jobs on any branch without a matrix strategy. (`.github/workflows/jenkins-triggeryml.backup`, [.github/workflows/jenkins-triggeryml.backupR1-R29](diffhunk://#diff-15a93a444179f939dc444390969c0cfea41fbf6dcba7b59004a11cc3d3d4e835R1-R29))