### PR TITLE
♻️ Update Jenkins trigger workflow to improve URL construction for frontend and backend jobs

### DIFF
--- a/.github/workflows/jenkins-trigger.yml
+++ b/.github/workflows/jenkins-trigger.yml
@@ -10,23 +10,39 @@ on:
   workflow_dispatch:
 
 jobs:
-  trigger:
+  trigger-job:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        jenkins_job:
-          - prms-reporting-tool-dev-docker
-          - prms-reporting-tool-dev-client-docker
+
     steps:
-      - name: Build Jenkins URL
+      # Step 1: Get the branch name and build the URL for Jenkins
+      - name: Get branch name and build Jenkins URL (BACKEND)
         run: |
-          BRANCH_NAME=${GITHUB_REF#refs/heads/}
-          JENKINS_URL="https://automation.prms.cgiar.org/job/${{ matrix.jenkins_job }}/buildWithParameters?branch=$BRANCH_NAME"
-          echo "JENKINS_URL=$JENKINS_URL" >> $GITHUB_ENV
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}  # Remove 'refs/heads/' from GITHUB_REF
+          JENKINS_URL="https://automation.prms.cgiar.org/job/prms-reporting-tool-dev-docker/build"
+          echo "Jenkins job URL for the branch $BRANCH_NAME is: $JENKINS_URL"
+          echo "JENKINS_URL=${JENKINS_URL}" >> $GITHUB_ENV
+
+      # Step 2: Execute the curl command to trigger the job in Jenkins with the dynamically built URL
       - name: Trigger Jenkins Job
         run: |
-          curl -X POST "$JENKINS_URL" \
-               --user "$JENKINS_USERNAME:$JENKINS_API_TOKEN"
+          curl -X POST ${{ env.JENKINS_URL }} --user ${{ secrets.JENKINS_USERNAME }}:${{ secrets.JENKINS_API_TOKEN }}
         env:
+          JENKINS_URL: ${{ env.JENKINS_URL }}
+          JENKINS_USERNAME: ${{ secrets.JENKINS_USERNAME }}
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}
+
+      - name: Get branch name and build Jenkins URL (FRONTEND)
+        run: |
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}  # Remove 'refs/heads/' from GITHUB_REF
+          JENKINS_URL="https://automation.prms.cgiar.org/job/prms-reporting-tool-dev-client-docker/build"
+          echo "Jenkins job URL for the branch $BRANCH_NAME is: $JENKINS_URL"
+          echo "JENKINS_URL=${JENKINS_URL}" >> $GITHUB_ENV
+
+      # Step 2: Execute the curl command to trigger the job in Jenkins with the dynamically built URL
+      - name: Trigger Jenkins Job
+        run: |
+          curl -X POST ${{ env.JENKINS_URL }} --user ${{ secrets.JENKINS_USERNAME }}:${{ secrets.JENKINS_API_TOKEN }}
+        env:
+          JENKINS_URL: ${{ env.JENKINS_URL }}
           JENKINS_USERNAME: ${{ secrets.JENKINS_USERNAME }}
           JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}


### PR DESCRIPTION
This pull request updates the Jenkins trigger workflow in `.github/workflows/jenkins-trigger.yml` to simplify the job execution process and improve readability by removing the matrix strategy and explicitly defining separate steps for backend and frontend Jenkins jobs.

### Workflow improvements:
* Renamed the job from `trigger` to `trigger-job` for better clarity.
* Removed the matrix strategy and replaced it with explicit steps for backend and frontend Jenkins job triggers, simplifying the workflow.
* Added descriptive comments to clarify the purpose of each step, such as building the Jenkins URL and triggering the job using `curl`.
* Explicitly defined separate Jenkins URLs for backend (`prms-reporting-tool-dev-docker`) and frontend (`prms-reporting-tool-dev-client-docker`) jobs, improving maintainability.