### PR TITLE
♻️ Refactor: Add timezone configuration to Dockerfile for build and test stages

### DIFF
--- a/onecgiar-pr-client/Dockerfile
+++ b/onecgiar-pr-client/Dockerfile
@@ -1,10 +1,16 @@
 #################### BUILD STAGE ####################
 FROM node:20-alpine AS build
 
+# Set timezone to Europe/Berlin (CET)
+ENV TZ=Europe/Berlin
+RUN apk add --no-cache tzdata && \
+    cp /usr/share/zoneinfo/$TZ /etc/localtime && \
+    echo $TZ > /etc/timezone
+
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-#RUN npm ci
+# RUN npm ci
 RUN npm i
 
 COPY . .
@@ -15,10 +21,16 @@ RUN npm run build:dev
 #################### TESTING STAGE ####################
 FROM node:20-alpine AS test
 
+# Set timezone to Europe/Berlin (CET)
+ENV TZ=Europe/Berlin
+RUN apk add --no-cache tzdata && \
+    cp /usr/share/zoneinfo/$TZ /etc/localtime && \
+    echo $TZ > /etc/timezone
+
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-#RUN npm ci
+# RUN npm ci
 RUN npm i
 
 COPY . .


### PR DESCRIPTION
This pull request updates the `onecgiar-pr-client/Dockerfile` to set the timezone to Europe/Berlin (CET) in both the build and testing stages. This ensures consistent timezone settings across the application environment.

Environment configuration updates:

* Added timezone configuration (`Europe/Berlin`) to the build stage of the Dockerfile to standardize the environment.
* Added timezone configuration (`Europe/Berlin`) to the testing stage of the Dockerfile to maintain consistency during testing.