### PR TITLE
♻️ Refactor: Update Jenkins trigger workflow for specific branch handling and improve job naming

### DIFF
--- a/.github/workflows/jenkins-trigger.yml
+++ b/.github/workflows/jenkins-trigger.yml
@@ -1,10 +1,13 @@
-name: Trigger Jenkins Job
+name: Trigger Jenkins Docker
 
 on:
   push:
     branches:
-      - '**'  # This will trigger the workflow on any branch that receives a push
-  workflow_dispatch:  # This allows the workflow to be manually triggered if needed
+      - dev
+  pull_request:
+    branches:
+      - dev
+  workflow_dispatch:
 
 jobs:
   trigger-job:
@@ -12,13 +15,29 @@ jobs:
 
     steps:
       # Step 1: Get the branch name and build the URL for Jenkins
-      - name: Get branch name and build Jenkins URL
+      - name: Get branch name and build Jenkins URL (BACKEND)
         run: |
           BRANCH_NAME=${GITHUB_REF#refs/heads/}  # Remove 'refs/heads/' from GITHUB_REF
-          JENKINS_URL="https://automation.prms.cgiar.org/job/prms-reporting-tool-${BRANCH_NAME}/build"
+          JENKINS_URL="https://automation.prms.cgiar.org/job/prms-reporting-tool-dev-docker/build"
           echo "Jenkins job URL for the branch $BRANCH_NAME is: $JENKINS_URL"
           echo "JENKINS_URL=${JENKINS_URL}" >> $GITHUB_ENV
-        
+
+      # Step 2: Execute the curl command to trigger the job in Jenkins with the dynamically built URL
+      - name: Trigger Jenkins Job
+        run: |
+          curl -X POST ${{ env.JENKINS_URL }} --user ${{ secrets.JENKINS_USERNAME }}:${{ secrets.JENKINS_API_TOKEN }}
+        env:
+          JENKINS_URL: ${{ env.JENKINS_URL }}
+          JENKINS_USERNAME: ${{ secrets.JENKINS_USERNAME }}
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}
+
+      - name: Get branch name and build Jenkins URL (FRONTEND)
+        run: |
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}  # Remove 'refs/heads/' from GITHUB_REF
+          JENKINS_URL="https://automation.prms.cgiar.org/job/prms-reporting-tool-dev-client-docker/build"
+          echo "Jenkins job URL for the branch $BRANCH_NAME is: $JENKINS_URL"
+          echo "JENKINS_URL=${JENKINS_URL}" >> $GITHUB_ENV
+
       # Step 2: Execute the curl command to trigger the job in Jenkins with the dynamically built URL
       - name: Trigger Jenkins Job
         run: |


### PR DESCRIPTION
This pull request updates the Jenkins workflow configuration in `.github/workflows/jenkins-trigger.yml` to better align with the branching strategy and introduces separate steps for triggering backend and frontend Jenkins jobs.

### Workflow updates:
* Changed the workflow name from "Trigger Jenkins Job" to "Trigger Jenkins Docker" to reflect its purpose more accurately.
* Limited the workflow triggers to the `dev` branch for both `push` and `pull_request` events, instead of triggering on all branches.

### Jenkins job execution:
* Added a new step specifically for triggering the backend Jenkins job (`prms-reporting-tool-dev-docker`) with a dynamically built URL. This includes setting the `JENKINS_URL` environment variable and using `curl` with Jenkins credentials from GitHub secrets.
* Updated the existing frontend Jenkins job step to use the correct URL for the `prms-reporting-tool-dev-client-docker` job.