### PR TITLE
P2 1663 hyperlink for video guide on evidence section

### DIFF
--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.ts
@@ -25,7 +25,7 @@ export class RdEvidencesComponent implements OnInit {
     <li>Links to SharePoint, One Drive, Google Drive, DropBox and other file storage platforms are not allowed.</li>
     <li>Files can be also uploaded to the PRMS repository.</li>
     <li>For confidential evidence, select “Upload file” and then “No” to indicate that it should not be public.</li>
-    <li>If you need additional information or guidance on how to create an evidence entry, you can find a video tutorial at the following a <a class="link" href="https://cgiar.sharepoint.com/:v:/s/OneCGIARPRMSRepository/ETb3eWyBPm9FumJV75XyUDABeVD57nTvz9zz1kNzL_Ob9w?e=kvLk2t" target="_blank">link</a>.</li>
+    <li>If you need additional information or guidance on how to create an evidence entry, you can find a video tutorial at the following a <a class="open_route" href="https://cgiar.sharepoint.com/:v:/s/OneCGIARPRMSRepository/ETb3eWyBPm9FumJV75XyUDABeVD57nTvz9zz1kNzL_Ob9w?e=kvLk2t" target="_blank">link</a>.</li>
     `;
 
     if (this.api.dataControlSE?.currentResult?.result_type_id === 7)


### PR DESCRIPTION
This pull request adds a new instructional resource to the `RdEvidencesComponent` for users creating evidence entries. The most important change introduces a video tutorial link to provide additional guidance.

### Enhancements to user guidance:

* [`onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.ts`](diffhunk://#diff-9108f6bada7868034992f3f6248c28a0d850172763d8c63a4a7377533060d937L27-R29): Added a new list item with a video tutorial link to assist users in creating evidence entries. The link opens in a new tab and is hosted on SharePoint.