### PR TITLE
* Feat Remove User roles section and route from admin module

### DIFF
--- a/onecgiar-pr-client/src/app/pages/admin-section/admin-section.component.ts
+++ b/onecgiar-pr-client/src/app/pages/admin-section/admin-section.component.ts
@@ -9,7 +9,6 @@ import { DataControlService } from '../../shared/services/data-control.service';
 export class AdminSectionComponent implements OnInit {
   sections = [
     { name: 'Completeness status', icon: 'check_circle', path: '/admin-module/completeness-status' },
-    { name: 'User roles', icon: 'people', path: '/admin-module/user-report' },
     { name: 'Phase management', icon: 'move_up', path: '/admin-module/phase-management' },
     { name: 'Knowledge Products', icon: 'auto_stories', path: '/admin-module/knowledge-products' },
     { name: 'Tickets Dashboard', icon: 'query_stats', path: '/admin-module/tickets-dashboard' },

--- a/onecgiar-pr-client/src/app/shared/routing/routing-data.ts
+++ b/onecgiar-pr-client/src/app/shared/routing/routing-data.ts
@@ -120,11 +120,6 @@ export const adminModuleRouting: PrRoute[] = [
     loadChildren: () => import('../../pages/admin-section/pages/completeness-status/completeness-status.module').then(m => m.CompletenessStatusModule)
   },
   {
-    prName: 'User report',
-    path: 'user-report',
-    loadChildren: () => import('../../pages/admin-section/pages/user-report/user-report.module').then(m => m.UserReportModule)
-  },
-  {
     prName: 'Phase management',
     path: 'phase-management',
     loadChildren: () => import('../../pages/admin-section/pages/phase-management/phase-management.module').then(m => m.PhaseManagementModule)


### PR DESCRIPTION
The 'User roles' section and its corresponding route ('user-report') have been removed from the admin section navigation and routing configuration. This streamlines the admin interface by eliminating the user report feature.