### PR TITLE
🐛 fix(dockerfile): Enable npm ci for consistent package installation in build and test stages

### DIFF
--- a/onecgiar-pr-client/Dockerfile
+++ b/onecgiar-pr-client/Dockerfile
@@ -10,8 +10,8 @@ RUN apk add --no-cache tzdata && \
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-# RUN npm ci
-RUN npm i
+RUN npm ci
+#RUN npm i
 
 COPY . .
 
@@ -30,8 +30,8 @@ RUN apk add --no-cache tzdata && \
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-# RUN npm ci
-RUN npm i
+RUN npm ci
+#RUN npm i
 
 COPY . .
 


### PR DESCRIPTION
This pull request makes a minor change to the Docker build process for the `onecgiar-pr-client` application. The main change is switching from `npm i` to `npm ci` for installing dependencies, which is a best practice for reproducible builds in CI environments. [[1]](diffhunk://#diff-1de450f85dadad709fd1a742606a84460d76f0b4f3b886523e2ae5322f49bbddL13-R14) [[2]](diffhunk://#diff-1de450f85dadad709fd1a742606a84460d76f0b4f3b886523e2ae5322f49bbddL33-R34)