### PR TITLE
🐛 fix(dockerfile): Ensure npm ci is executed after copying package files in both build and test stages

### DIFF
--- a/onecgiar-pr-client/Dockerfile
+++ b/onecgiar-pr-client/Dockerfile
@@ -10,10 +10,11 @@ RUN apk add --no-cache tzdata && \
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-RUN npm ci
+
 #RUN npm i
 
 COPY . .
+RUN npm ci
 
 # Build in dev mode as per team requirement
 RUN npm run build:dev
@@ -30,10 +31,11 @@ RUN apk add --no-cache tzdata && \
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-RUN npm ci
+
 #RUN npm i
 
 COPY . .
+RUN npm ci
 
 # Run tests (adjust the script if needed)
 CMD ["npm", "run", "test:coverage"]


### PR DESCRIPTION
This pull request makes a minor adjustment to the Docker build process for the `onecgiar-pr-client` project. The main change is moving the `npm ci` command to run after copying all source files, ensuring that dependencies are installed with the complete project context.

* Dockerfile build process:
  - Moved the `npm ci` command to after copying all files, so dependencies are installed with the full source code present, which can help with monorepos or local package linking. (`onecgiar-pr-client/Dockerfile`, [[1]](diffhunk://#diff-1de450f85dadad709fd1a742606a84460d76f0b4f3b886523e2ae5322f49bbddL13-R17) [[2]](diffhunk://#diff-1de450f85dadad709fd1a742606a84460d76f0b4f3b886523e2ae5322f49bbddL33-R38)