### PR TITLE
🐛 fix(dockerfile): Add .dockerignore file and ensure npm ci is executed after copying package files in both build and test stages

### DIFF
--- a/onecgiar-pr-client/.dockerignore
+++ b/onecgiar-pr-client/.dockerignore
@@ -1,0 +1,40 @@
+# Dependencies and build artifacts
+node_modules
+dist
+build
+coverage
+.tmp
+temp
+tmp
+.cache
+.eslintcache
+*.tsbuildinfo
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Version control
+.git
+.gitignore
+.gitattributes
+
+# OS / editor files
+.DS_Store
+Thumbs.db
+.vscode
+.idea
+*.swp
+*.swo
+
+# Environment variables (keep an example)
+.env
+.env.*
+!.env.example
+
+# Reports / Sonar / CI artifacts
+reports
+.sonar
+junit*.xml

--- a/onecgiar-pr-client/Dockerfile
+++ b/onecgiar-pr-client/Dockerfile
@@ -10,10 +10,11 @@ RUN apk add --no-cache tzdata && \
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-RUN npm ci
+
 #RUN npm i
 
 COPY . .
+RUN npm ci
 
 # Build in dev mode as per team requirement
 RUN npm run build:dev
@@ -30,10 +31,11 @@ RUN apk add --no-cache tzdata && \
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-RUN npm ci
+
 #RUN npm i
 
 COPY . .
+RUN npm ci
 
 # Run tests (adjust the script if needed)
 CMD ["npm", "run", "test:coverage"]


### PR DESCRIPTION
This pull request introduces improvements to the Docker setup for the `onecgiar-pr-client` project, focusing on cleaner builds and better handling of dependencies and artifacts. The main changes include adding a `.dockerignore` file to exclude unnecessary files from Docker images and adjusting the `Dockerfile` to ensure dependencies are installed after copying the source code.

**Build and dependency management:**

* Added a `.dockerignore` file to exclude dependencies, build artifacts, logs, version control files, OS/editor files, environment variable files (except `.env.example`), and CI artifacts from Docker images, resulting in smaller and more secure builds.
* Moved the `npm ci` command to run after copying the entire source code in the `Dockerfile`, ensuring that all dependencies are installed with the latest code and reducing potential cache issues. [[1]](diffhunk://#diff-1de450f85dadad709fd1a742606a84460d76f0b4f3b886523e2ae5322f49bbddL13-R17) [[2]](diffhunk://#diff-1de450f85dadad709fd1a742606a84460d76f0b4f3b886523e2ae5322f49bbddL33-R38)