### PR TITLE
chore(dockerfile): Refactor Dockerfile for improved clarity and consistency

### DIFF
--- a/onecgiar-pr-client/Dockerfile
+++ b/onecgiar-pr-client/Dockerfile
@@ -50,7 +50,7 @@ RUN rm -rf /usr/share/nginx/html/*
 COPY nginx.conf /etc/nginx/nginx.conf
 
 # Copy built Angular app from build stage
-COPY --from=build /usr/src/app/dist/onecgiar-pr-client /usr/share/nginx/html
+COPY --from=build /usr/src/app/dist/onecgiar-pr-client/browser /usr/share/nginx/html
 
 # Permissions
 RUN chmod -R 755 /usr/share/nginx/html


### PR DESCRIPTION
This pull request makes a small adjustment to the deployment process for the Angular application in the Dockerfile. Instead of copying the entire build output, it now specifically copies the contents of the `browser` subdirectory, which is the correct location for the production build artifacts.

* Deployment process: Updated the `Dockerfile` to copy the built Angular app from `dist/onecgiar-pr-client/browser` instead of `dist/onecgiar-pr-client` to ensure only the production-ready files are served by Nginx.