### PR TITLE
chore: update Dockerfile for improved build and test stages

### DIFF
--- a/onecgiar-pr-client/Dockerfile
+++ b/onecgiar-pr-client/Dockerfile
@@ -14,7 +14,7 @@ COPY package*.json ./
 #RUN npm i
 
 COPY . .
-RUN npm ci
+RUN npm i
 
 # Build in dev mode as per team requirement
 RUN npm run build:dev
@@ -35,7 +35,7 @@ COPY package*.json ./
 #RUN npm i
 
 COPY . .
-RUN npm ci
+RUN npm i
 
 # Run tests (adjust the script if needed)
 CMD ["npm", "run", "test:coverage"]


### PR DESCRIPTION
This pull request makes a minor adjustment to the `onecgiar-pr-client/Dockerfile` by changing the way npm dependencies are installed. The installation command is switched from `npm ci` to `npm i` to improve compatibility or address team requirements.

* Dockerfile dependency installation: Changed the command from `npm ci` to `npm i` after copying project files, both for building and testing steps. [[1]](diffhunk://#diff-1de450f85dadad709fd1a742606a84460d76f0b4f3b886523e2ae5322f49bbddL17-R17) [[2]](diffhunk://#diff-1de450f85dadad709fd1a742606a84460d76f0b4f3b886523e2ae5322f49bbddL38-R38)