### PR TITLE
♻️ Refactor(result-ai-assistant) P2-1755: Update bucket name and key for form data submission

### DIFF
--- a/onecgiar-pr-client/src/app/pages/results/pages/result-creator/components/result-ai-assistant/result-ai-assistant.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-creator/components/result-ai-assistant/result-ai-assistant.component.spec.ts
@@ -122,7 +122,7 @@ describe('ResultAiAssistantComponent', () => {
       const formData = component['createUploadFormData']();
 
       expect(formData.get('file')).toEqual(mockFile);
-      expect(formData.get('bucketName')).toBe('microservice-mining');
+      expect(formData.get('bucketName')).toBe('ai-services-ibd');
       expect(formData.get('fileName')).toBe('test.pdf');
       expect(formData.get('weightLimit')).toBe('5242880'); // 5MB in bytes
       expect(formData.get('pageLimit')).toBe('10');
@@ -165,8 +165,8 @@ describe('ResultAiAssistantComponent', () => {
       const formData = component['createMiningFormData']('test-file.pdf');
 
       expect(formData.get('token')).toBe('test-token');
-      expect(formData.get('key')).toBe('test-file.pdf');
-      expect(formData.get('bucketName')).toBe('microservice-mining');
+      expect(formData.get('key')).toBe('prms/text-mining/files/test-file.pdf');
+      expect(formData.get('bucketName')).toBe('ai-services-ibd');
     });
 
     it('should create correct mining headers', () => {

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-creator/components/result-ai-assistant/result-ai-assistant.component.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-creator/components/result-ai-assistant/result-ai-assistant.component.ts
@@ -117,7 +117,8 @@ export class ResultAiAssistantComponent implements OnInit {
     const formData = new FormData();
 
     formData.append('file', selectedFile, selectedFile.name);
-    formData.append('bucketName', 'microservice-mining');
+    formData.append('bucketName', 'ai-services-ibd');
+    formData.append('key', `prms/text-mining/files/`);
     formData.append('fileName', selectedFile.name);
     formData.append('weightLimit', this.calculateWeightLimitBytes().toString());
     formData.append('pageLimit', this.createResultManagementService.pageLimit.toString());
@@ -163,8 +164,8 @@ export class ResultAiAssistantComponent implements OnInit {
   private createMiningFormData(filename: string): FormData {
     const formData = new FormData();
     formData.append('token', this.api.authSE?.localStorageToken);
-    formData.append('key', filename);
-    formData.append('bucketName', 'microservice-mining');
+    formData.append('bucketName', 'ai-services-ibd');
+    formData.append('key', `prms/text-mining/files/${filename}`);
     formData.append('environmentUrl', environment.apiBaseUrl);
     return formData;
   }


### PR DESCRIPTION
This pull request updates the file upload and mining logic in the `ResultAiAssistantComponent` to use a new S3 bucket and a more structured file key path. The changes ensure that files are stored in the `ai-services-ibd` bucket under a specific folder, improving organization and consistency. Unit tests have been updated to reflect these changes.

**File upload and mining logic updates:**

* Changed the S3 bucket name from `'microservice-mining'` to `'ai-services-ibd'` in both `createUploadFormData` and `createMiningFormData` methods in `result-ai-assistant.component.ts`. [[1]](diffhunk://#diff-d9a1d83f4d4fc0e72718b5807a23f4db82d26d008ce7d393b90f3453ed86c2b3L120-R121) [[2]](diffhunk://#diff-d9a1d83f4d4fc0e72718b5807a23f4db82d26d008ce7d393b90f3453ed86c2b3L166-R168)
* Updated the file key in `createMiningFormData` to use the path format `prms/text-mining/files/<filename>` instead of just the filename.
* Added a default key value of `prms/text-mining/files/` in `createUploadFormData` for consistency in file organization.

**Unit test updates:**

* Updated unit tests in `result-ai-assistant.component.spec.ts` to expect the new bucket name and key path for both upload and mining form data. [[1]](diffhunk://#diff-ca6bec735e3ec108682dd5ae49981232a923eb835a3791a8eb9df06e86426b0dL125-R125) [[2]](diffhunk://#diff-ca6bec735e3ec108682dd5ae49981232a923eb835a3791a8eb9df06e86426b0dL168-R169)