### PR TITLE
* Feat Introduce new Terminology and Enhancements

### DIFF
--- a/onecgiar-pr-client/src/app/internationalization/term.pipe.spec.ts
+++ b/onecgiar-pr-client/src/app/internationalization/term.pipe.spec.ts
@@ -1,0 +1,150 @@
+import { TestBed } from '@angular/core/testing';
+import { TermPipe } from './term.pipe';
+import { TerminologyService } from './terminology.service';
+import { TermKey } from './terminology.config';
+
+describe('TermPipe', () => {
+  let pipe: TermPipe;
+  let mockTerminologyService: jest.Mocked<TerminologyService>;
+
+  beforeEach(() => {
+    const terminologyServiceSpy = {
+      t: jest.fn()
+    };
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: TerminologyService, useValue: terminologyServiceSpy }]
+    });
+
+    // Create the pipe within the TestBed context
+    pipe = TestBed.runInInjectionContext(() => new TermPipe());
+    mockTerminologyService = TestBed.inject(TerminologyService) as jest.Mocked<TerminologyService>;
+  });
+
+  it('should create', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should call terminology service with correct parameters', () => {
+    const testKey: TermKey = 'term.entity.singular';
+    const testPortfolioAcronym = 'P25';
+    const expectedResult = 'Science Program/Accelerator';
+
+    mockTerminologyService.t.mockReturnValue(expectedResult);
+
+    const result = pipe.transform(testKey, testPortfolioAcronym);
+
+    expect(mockTerminologyService.t).toHaveBeenCalledWith(testKey, testPortfolioAcronym);
+    expect(result).toBe(expectedResult);
+  });
+
+  it('should handle null portfolio acronym', () => {
+    const testKey: TermKey = 'term.entity.singular';
+    const expectedResult = 'Initiative';
+
+    mockTerminologyService.t.mockReturnValue(expectedResult);
+
+    const result = pipe.transform(testKey, null);
+
+    expect(mockTerminologyService.t).toHaveBeenCalledWith(testKey, null);
+    expect(result).toBe(expectedResult);
+  });
+
+  it('should handle undefined portfolio acronym', () => {
+    const testKey: TermKey = 'term.entity.plural';
+    const expectedResult = 'Initiatives';
+
+    mockTerminologyService.t.mockReturnValue(expectedResult);
+
+    const result = pipe.transform(testKey, undefined);
+
+    expect(mockTerminologyService.t).toHaveBeenCalledWith(testKey, undefined);
+    expect(result).toBe(expectedResult);
+  });
+
+  it('should handle empty string portfolio acronym', () => {
+    const testKey: TermKey = 'term.entity.orPlatforms';
+    const expectedResult = 'Initiative or platform';
+
+    mockTerminologyService.t.mockReturnValue(expectedResult);
+
+    const result = pipe.transform(testKey, '');
+
+    expect(mockTerminologyService.t).toHaveBeenCalledWith(testKey, '');
+    expect(result).toBe(expectedResult);
+  });
+
+  it('should handle P25 portfolio acronym', () => {
+    const testKey: TermKey = 'term.entity.singular';
+    const expectedResult = 'Science Program/Accelerator';
+
+    mockTerminologyService.t.mockReturnValue(expectedResult);
+
+    const result = pipe.transform(testKey, 'P25');
+
+    expect(mockTerminologyService.t).toHaveBeenCalledWith(testKey, 'P25');
+    expect(result).toBe(expectedResult);
+  });
+
+  it('should handle non-P25 portfolio acronym', () => {
+    const testKey: TermKey = 'term.entity.singular';
+    const expectedResult = 'Initiative';
+
+    mockTerminologyService.t.mockReturnValue(expectedResult);
+
+    const result = pipe.transform(testKey, 'P10');
+
+    expect(mockTerminologyService.t).toHaveBeenCalledWith(testKey, 'P10');
+    expect(result).toBe(expectedResult);
+  });
+
+  it('should handle all TermKey types', () => {
+    const termKeys: TermKey[] = [
+      'term.entity.singular',
+      'term.entity.plural',
+      'term.entity.orPlatforms',
+      'term.entity.orPlatformsPlural',
+      'term.entity.orPlatformsWith()',
+      'term.entity.singularWith()',
+      'term.entity.orPlatformsOrSGP'
+    ];
+
+    termKeys.forEach((key, index) => {
+      const expectedResult = `Test Result ${index}`;
+      mockTerminologyService.t.mockReturnValue(expectedResult);
+
+      const result = pipe.transform(key, 'P25');
+
+      expect(mockTerminologyService.t).toHaveBeenCalledWith(key, 'P25');
+      expect(result).toBe(expectedResult);
+    });
+  });
+
+  it('should return the key when terminology service returns undefined', () => {
+    const testKey: TermKey = 'term.entity.singular';
+    const testPortfolioAcronym = 'P25';
+
+    mockTerminologyService.t.mockReturnValue(undefined as any);
+
+    const result = pipe.transform(testKey, testPortfolioAcronym);
+
+    expect(mockTerminologyService.t).toHaveBeenCalledWith(testKey, testPortfolioAcronym);
+    expect(result).toBeUndefined();
+  });
+
+  it('should be a non-pure pipe', () => {
+    // The pipe is marked as pure: false in the decorator
+    // This means it will be called on every change detection cycle
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should be standalone', () => {
+    // The pipe is marked as standalone: true in the decorator
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should have correct pipe name', () => {
+    // The pipe is named 'term' in the decorator
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/onecgiar-pr-client/src/app/internationalization/term.pipe.ts
+++ b/onecgiar-pr-client/src/app/internationalization/term.pipe.ts
@@ -2,14 +2,12 @@
 import { Pipe, PipeTransform, inject } from '@angular/core';
 import { TerminologyService } from './terminology.service';
 import { TermKey } from './terminology.config';
-import { DataControlService } from '../shared/services/data-control.service';
 
 @Pipe({ name: 'term', standalone: true, pure: false })
 export class TermPipe implements PipeTransform {
   private terms = inject(TerminologyService);
-  private dataControlSE = inject(DataControlService);
 
-  transform(key: TermKey, portfolioAcronym: string = this.dataControlSE.currentResult?.portfolio): string {
+  transform(key: TermKey, portfolioAcronym): string {
     return this.terms.t(key, portfolioAcronym);
   }
 }

--- a/onecgiar-pr-client/src/app/internationalization/terminology.service.spec.ts
+++ b/onecgiar-pr-client/src/app/internationalization/terminology.service.spec.ts
@@ -1,0 +1,212 @@
+import { TestBed } from '@angular/core/testing';
+import { TerminologyService } from './terminology.service';
+import { TermKey, LEGACY_TERMS, NEW_TERMS } from './terminology.config';
+
+describe('TerminologyService', () => {
+  let service: TerminologyService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(TerminologyService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('t method', () => {
+    it('should return legacy term when portfolioAcronym is null', () => {
+      const testKey: TermKey = 'term.entity.singular';
+      const result = service.t(testKey, null);
+
+      expect(result).toBe(LEGACY_TERMS[testKey]);
+    });
+
+    it('should return legacy term when portfolioAcronym is undefined', () => {
+      const testKey: TermKey = 'term.entity.plural';
+      const result = service.t(testKey, undefined);
+
+      expect(result).toBe(LEGACY_TERMS[testKey]);
+    });
+
+    it('should return legacy term when portfolioAcronym is empty string', () => {
+      const testKey: TermKey = 'term.entity.orPlatforms';
+      const result = service.t(testKey, '');
+
+      expect(result).toBe(LEGACY_TERMS[testKey]);
+    });
+
+    it('should return new term when portfolioAcronym is P25', () => {
+      const testKey: TermKey = 'term.entity.singular';
+      const result = service.t(testKey, 'P25');
+
+      expect(result).toBe(NEW_TERMS[testKey]);
+    });
+
+    it('should return legacy term when portfolioAcronym is not P25', () => {
+      const testKey: TermKey = 'term.entity.singular';
+      const result = service.t(testKey, 'P10');
+
+      expect(result).toBe(LEGACY_TERMS[testKey]);
+    });
+
+    it('should return legacy term when portfolioAcronym is any other value', () => {
+      const testKey: TermKey = 'term.entity.plural';
+      const result = service.t(testKey, 'SOME_OTHER_VALUE');
+
+      expect(result).toBe(LEGACY_TERMS[testKey]);
+    });
+
+    it('should handle all TermKey types with P25 portfolio', () => {
+      const termKeys: TermKey[] = [
+        'term.entity.singular',
+        'term.entity.plural',
+        'term.entity.orPlatforms',
+        'term.entity.orPlatformsPlural',
+        'term.entity.orPlatformsWith()',
+        'term.entity.singularWith()',
+        'term.entity.orPlatformsOrSGP'
+      ];
+
+      termKeys.forEach(key => {
+        const result = service.t(key, 'P25');
+        expect(result).toBe(NEW_TERMS[key]);
+      });
+    });
+
+    it('should handle all TermKey types with non-P25 portfolio', () => {
+      const termKeys: TermKey[] = [
+        'term.entity.singular',
+        'term.entity.plural',
+        'term.entity.orPlatforms',
+        'term.entity.orPlatformsPlural',
+        'term.entity.orPlatformsWith()',
+        'term.entity.singularWith()',
+        'term.entity.orPlatformsOrSGP'
+      ];
+
+      termKeys.forEach(key => {
+        const result = service.t(key, 'P10');
+        expect(result).toBe(LEGACY_TERMS[key]);
+      });
+    });
+
+    it('should return the key itself when term is not found in dictionary', () => {
+      // This test assumes there might be a key not in the dictionary
+      // Since all TermKey values are defined in the config, we'll test with a mock scenario
+      const mockKey = 'non.existent.key' as TermKey;
+      const result = service.t(mockKey, 'P25');
+
+      expect(result).toBe(mockKey);
+    });
+
+    it('should be case sensitive for portfolioAcronym', () => {
+      const testKey: TermKey = 'term.entity.singular';
+
+      const resultLowercase = service.t(testKey, 'p25');
+      const resultUppercase = service.t(testKey, 'P25');
+
+      expect(resultLowercase).toBe(LEGACY_TERMS[testKey]);
+      expect(resultUppercase).toBe(NEW_TERMS[testKey]);
+    });
+
+    it('should handle whitespace in portfolioAcronym', () => {
+      const testKey: TermKey = 'term.entity.singular';
+
+      const resultWithSpaces = service.t(testKey, ' P25 ');
+      const resultWithTabs = service.t(testKey, '\tP25\t');
+
+      expect(resultWithSpaces).toBe(LEGACY_TERMS[testKey]);
+      expect(resultWithTabs).toBe(LEGACY_TERMS[testKey]);
+    });
+  });
+
+  describe('getActiveDict method (private method testing through public interface)', () => {
+    it('should return LEGACY_TERMS for null portfolioAcronym', () => {
+      const testKey: TermKey = 'term.entity.singular';
+      const result = service.t(testKey, null);
+
+      expect(result).toBe('Initiative'); // From LEGACY_TERMS
+    });
+
+    it('should return NEW_TERMS for P25 portfolioAcronym', () => {
+      const testKey: TermKey = 'term.entity.singular';
+      const result = service.t(testKey, 'P25');
+
+      expect(result).toBe('Science Program/Accelerator'); // From NEW_TERMS
+    });
+
+    it('should return LEGACY_TERMS for any other portfolioAcronym', () => {
+      const testKey: TermKey = 'term.entity.singular';
+      const result = service.t(testKey, 'P10');
+
+      expect(result).toBe('Initiative'); // From LEGACY_TERMS
+    });
+  });
+
+  describe('service configuration', () => {
+    it('should be provided in root', () => {
+      // This test verifies the service is properly configured
+      expect(service).toBeInstanceOf(TerminologyService);
+    });
+
+    it('should be injectable', () => {
+      const injectedService = TestBed.inject(TerminologyService);
+      expect(injectedService).toBe(service);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle undefined key gracefully', () => {
+      const result = service.t(undefined as any, 'P25');
+      expect(result).toBeUndefined();
+    });
+
+    it('should handle empty string key', () => {
+      const result = service.t('' as any, 'P25');
+      expect(result).toBe('');
+    });
+
+    it('should handle very long portfolioAcronym', () => {
+      const longAcronym = 'A'.repeat(1000);
+      const testKey: TermKey = 'term.entity.singular';
+      const result = service.t(testKey, longAcronym);
+
+      expect(result).toBe(LEGACY_TERMS[testKey]);
+    });
+
+    it('should handle special characters in portfolioAcronym', () => {
+      const testKey: TermKey = 'term.entity.singular';
+      const specialChars = 'P25!@#$%^&*()';
+      const result = service.t(testKey, specialChars);
+
+      expect(result).toBe(LEGACY_TERMS[testKey]);
+    });
+  });
+
+  describe('performance and consistency', () => {
+    it('should return consistent results for same inputs', () => {
+      const testKey: TermKey = 'term.entity.singular';
+      const portfolioAcronym = 'P25';
+
+      const result1 = service.t(testKey, portfolioAcronym);
+      const result2 = service.t(testKey, portfolioAcronym);
+
+      expect(result1).toBe(result2);
+    });
+
+    it('should handle multiple calls efficiently', () => {
+      const testKey: TermKey = 'term.entity.singular';
+      const iterations = 100;
+
+      const start = performance.now();
+      for (let i = 0; i < iterations; i++) {
+        service.t(testKey, 'P25');
+      }
+      const end = performance.now();
+
+      // This test ensures the method doesn't have performance issues
+      expect(end - start).toBeLessThan(100); // Should complete in less than 100ms
+    });
+  });
+});

--- a/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-contributors/components/ipsr-contributors-toc/ipsr-contributors-toc.component.html
+++ b/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-contributors/components/ipsr-contributors-toc/ipsr-contributors-toc.component.html
@@ -1,20 +1,23 @@
-<app-pr-field-header label="Lead and Contributing Initiatives" [required]="false"></app-pr-field-header>
+<app-pr-field-header
+  [label]="'Lead and Contributing ' + ('term.entity.plural' | term: this.api.dataControlSE.currentResult?.portfolio)"
+  [required]="false"></app-pr-field-header>
 
 <div class="dropdown-50p">
   <app-pr-multi-select
     [options]="this.getcontributingInitiativesList"
-    label="Contributing CGIAR Initiatives"
+    [label]="'Contributing CGIAR ' + ('term.entity.plural' | term: this.api.dataControlSE.currentResult?.portfolio)"
     [disableOptions]="this.disabledOptions"
     optionLabel="full_name"
     optionValue="id"
     [required]="false"
     [(ngModel)]="this.contributorsBody.contributingInitiativeNew"
-    placeholder="Select Initiative(s)">
+    [placeholder]="'Select ' + ('term.entity.singularWith()' | term: this.api.dataControlSE.currentResult?.portfolio)">
   </app-pr-multi-select>
 </div>
 <br />
 
-<app-pr-field-header description="Initiative(s) selected:"></app-pr-field-header>
+<app-pr-field-header
+  [description]="('term.entity.singularWith()' | term: this.api.dataControlSE.currentResult?.portfolio) + ' selected:'"></app-pr-field-header>
 
 <div class="chips_container">
   <div class="pr_chip_selected" *ngFor="let item of this.contributorsBody?.contributing_initiatives.accepted_contributing_initiatives; let i = index">

--- a/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-contributors/components/ipsr-contributors-toc/ipsr-contributors-toc.component.html
+++ b/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-contributors/components/ipsr-contributors-toc/ipsr-contributors-toc.component.html
@@ -1,23 +1,23 @@
 <app-pr-field-header
-  [label]="'Lead and Contributing ' + ('term.entity.plural' | term: this.api.dataControlSE.currentResult?.portfolio)"
+  [label]="'Lead and Contributing ' + ('term.entity.plural' | term: this.ipsrDataControlSE.detailData?.portfolio)"
   [required]="false"></app-pr-field-header>
 
 <div class="dropdown-50p">
   <app-pr-multi-select
     [options]="this.getcontributingInitiativesList"
-    [label]="'Contributing CGIAR ' + ('term.entity.plural' | term: this.api.dataControlSE.currentResult?.portfolio)"
+    [label]="'Contributing CGIAR ' + ('term.entity.plural' | term: this.ipsrDataControlSE.detailData?.portfolio)"
     [disableOptions]="this.disabledOptions"
     optionLabel="full_name"
     optionValue="id"
     [required]="false"
     [(ngModel)]="this.contributorsBody.contributingInitiativeNew"
-    [placeholder]="'Select ' + ('term.entity.singularWith()' | term: this.api.dataControlSE.currentResult?.portfolio)">
+    [placeholder]="'Select ' + ('term.entity.singularWith()' | term: this.ipsrDataControlSE.detailData?.portfolio)">
   </app-pr-multi-select>
 </div>
 <br />
 
 <app-pr-field-header
-  [description]="('term.entity.singularWith()' | term: this.api.dataControlSE.currentResult?.portfolio) + ' selected:'"></app-pr-field-header>
+  [description]="('term.entity.singularWith()' | term: this.ipsrDataControlSE.detailData?.portfolio) + ' selected:'"></app-pr-field-header>
 
 <div class="chips_container">
   <div class="pr_chip_selected" *ngFor="let item of this.contributorsBody?.contributing_initiatives.accepted_contributing_initiatives; let i = index">

--- a/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-contributors/components/ipsr-contributors-toc/ipsr-contributors-toc.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-contributors/components/ipsr-contributors-toc/ipsr-contributors-toc.component.spec.ts
@@ -6,7 +6,6 @@ import { PrMultiSelectComponent } from '../../../../../../../../custom-fields/pr
 import { FormsModule } from '@angular/forms';
 import { of } from 'rxjs';
 import { ApiService } from '../../../../../../../../shared/services/api/api.service';
-import { RolesService } from '../../../../../../../../shared/services/global/roles.service';
 import { TermPipe } from '../../../../../../../../internationalization/term.pipe';
 
 describe('IpsrContributorsTocComponent', () => {

--- a/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-contributors/components/ipsr-contributors-toc/ipsr-contributors-toc.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-contributors/components/ipsr-contributors-toc/ipsr-contributors-toc.component.spec.ts
@@ -6,38 +6,42 @@ import { PrMultiSelectComponent } from '../../../../../../../../custom-fields/pr
 import { FormsModule } from '@angular/forms';
 import { of } from 'rxjs';
 import { ApiService } from '../../../../../../../../shared/services/api/api.service';
+import { RolesService } from '../../../../../../../../shared/services/global/roles.service';
+import { TermPipe } from '../../../../../../../../internationalization/term.pipe';
 
 describe('IpsrContributorsTocComponent', () => {
   let component: IpsrContributorsTocComponent;
   let fixture: ComponentFixture<IpsrContributorsTocComponent>;
   let mockApiService: any;
-  const mockResponse = [{ id: 1, name: 'Initiative 1' }]
+  const mockResponse = [{ id: 1, name: 'Initiative 1' }];
 
   beforeEach(async () => {
     mockApiService = {
       resultsSE: {
         GET_AllWithoutResults: () => of({ response: mockResponse }),
+        GETInnovationPackageDetail: () => of({ response: { portfolio: 'P25' } })
       },
+      dataControlSE: {
+        currentResult: { portfolio: 'P25' }
+      },
+      rolesSE: {
+        readOnly: false,
+        platformIsClosed: false,
+        validateInitiative: jest.fn().mockReturnValue(true),
+        isAdmin: false
+      }
     };
 
     await TestBed.configureTestingModule({
-      declarations: [
-        IpsrContributorsTocComponent,
-        PrFieldHeaderComponent,
-        PrMultiSelectComponent
-       ],
-      imports: [
-        HttpClientTestingModule,
-        FormsModule
-      ],
+      declarations: [IpsrContributorsTocComponent, PrFieldHeaderComponent, PrMultiSelectComponent],
+      imports: [HttpClientTestingModule, FormsModule, TermPipe],
       providers: [
         {
           provide: ApiService,
-          useValue: mockApiService,
-        },
+          useValue: mockApiService
+        }
       ]
-    })
-    .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(IpsrContributorsTocComponent);
     component = fixture.componentInstance;
@@ -61,7 +65,7 @@ describe('IpsrContributorsTocComponent', () => {
       component.GET_AllWithoutResults();
 
       expect(spy).toHaveBeenCalled();
-      expect(component.contributingInitiativesList).toEqual(mockResponse)
+      expect(component.contributingInitiativesList).toEqual(mockResponse);
     });
   });
 
@@ -94,5 +98,5 @@ describe('IpsrContributorsTocComponent', () => {
 
       expect(item.is_active).toBeFalsy();
     });
-  })
+  });
 });

--- a/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-contributors/components/ipsr-contributors-toc/ipsr-contributors-toc.component.ts
+++ b/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-contributors/components/ipsr-contributors-toc/ipsr-contributors-toc.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, Input } from '@angular/core';
 import { ContributorsBody } from '../../model/contributorsBody';
 import { ApiService } from '../../../../../../../../shared/services/api/api.service';
 import { RolesService } from '../../../../../../../../shared/services/global/roles.service';
+import { IpsrDataControlService } from '../../../../../../services/ipsr-data-control.service';
 
 @Component({
   selector: 'app-ipsr-contributors-toc',
@@ -16,7 +17,8 @@ export class IpsrContributorsTocComponent implements OnInit {
 
   constructor(
     public api: ApiService,
-    public rolesSE: RolesService
+    public rolesSE: RolesService,
+    public ipsrDataControlSE: IpsrDataControlService
   ) {}
 
   ngOnInit(): void {

--- a/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-contributors/components/ipsr-contributors-toc/ipsr-contributors-toc.component.ts
+++ b/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-contributors/components/ipsr-contributors-toc/ipsr-contributors-toc.component.ts
@@ -4,25 +4,30 @@ import { ApiService } from '../../../../../../../../shared/services/api/api.serv
 import { RolesService } from '../../../../../../../../shared/services/global/roles.service';
 
 @Component({
-    selector: 'app-ipsr-contributors-toc',
-    templateUrl: './ipsr-contributors-toc.component.html',
-    styleUrls: ['./ipsr-contributors-toc.component.scss'],
-    standalone: false
+  selector: 'app-ipsr-contributors-toc',
+  templateUrl: './ipsr-contributors-toc.component.html',
+  styleUrls: ['./ipsr-contributors-toc.component.scss'],
+  standalone: false
 })
 export class IpsrContributorsTocComponent implements OnInit {
   @Input() contributorsBody = new ContributorsBody();
   @Input() disabledOptions = [];
   contributingInitiativesList = [];
 
-  constructor(public api: ApiService, public rolesSE: RolesService) {}
+  constructor(
+    public api: ApiService,
+    public rolesSE: RolesService
+  ) {}
 
   ngOnInit(): void {
     this.GET_AllWithoutResults();
   }
 
   GET_AllWithoutResults() {
-    this.api.resultsSE.GET_AllWithoutResults().subscribe(({ response }) => {
-      this.contributingInitiativesList = response;
+    this.api.resultsSE.GETInnovationPackageDetail().subscribe(({ response }) => {
+      this.api.resultsSE.GET_AllWithoutResults(response.portfolio).subscribe(({ response }) => {
+        this.contributingInitiativesList = response;
+      });
     });
   }
 

--- a/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-contributors/ipsr-contributors.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-contributors/ipsr-contributors.component.spec.ts
@@ -14,6 +14,7 @@ import { of } from 'rxjs';
 import { ApiService } from '../../../../../../shared/services/api/api.service';
 import { TocInitiativeOutComponent } from '../../../../../results/pages/result-detail/pages/rd-theory-of-change/components/shared/toc-initiative-out/toc-initiative-out.component';
 import { PrYesOrNotComponent } from '../../../../../../custom-fields/pr-yes-or-not/pr-yes-or-not.component';
+import { TermPipe } from '../../../../../../internationalization/term.pipe';
 
 describe('IpsrContributorsComponent', () => {
   let component: IpsrContributorsComponent;
@@ -80,7 +81,7 @@ describe('IpsrContributorsComponent', () => {
         TocInitiativeOutComponent,
         PrYesOrNotComponent
       ],
-      imports: [HttpClientTestingModule, FormsModule],
+      imports: [HttpClientTestingModule, FormsModule, TermPipe],
       providers: [
         {
           provide: ApiService,

--- a/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-contributors/ipsr-contributors.module.ts
+++ b/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-contributors/ipsr-contributors.module.ts
@@ -9,9 +9,16 @@ import { IpsrContributorsTocComponent } from './components/ipsr-contributors-toc
 import { IpsrNonPooledProjectsComponent } from './components/ipsr-non-pooled-projects/ipsr-non-pooled-projects.component';
 import { IpsrContributorsNonCgiarPartnersComponent } from './components/ipsr-contributors-non-cgiar-partners/ipsr-contributors-non-cgiar-partners.component';
 import { IpsrContributorsCentersComponent } from './components/ipsr-contributors-centers/ipsr-contributors-centers.component';
+import { TermPipe } from '../../../../../../internationalization/term.pipe';
 
 @NgModule({
-  declarations: [IpsrContributorsComponent, IpsrContributorsTocComponent, IpsrNonPooledProjectsComponent, IpsrContributorsNonCgiarPartnersComponent, IpsrContributorsCentersComponent],
-  imports: [CommonModule, IpsrContributorsRoutingModule, CustomFieldsModule, TocInitiativeOutModule]
+  declarations: [
+    IpsrContributorsComponent,
+    IpsrContributorsTocComponent,
+    IpsrNonPooledProjectsComponent,
+    IpsrContributorsNonCgiarPartnersComponent,
+    IpsrContributorsCentersComponent
+  ],
+  imports: [CommonModule, IpsrContributorsRoutingModule, CustomFieldsModule, TocInitiativeOutModule, TermPipe]
 })
 export class IpsrContributorsModule {}

--- a/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-innovation-use-pathway/pages/step-n1/components/step-n1-experts/step-n1-experts.component.scss
+++ b/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-innovation-use-pathway/pages/step-n1/components/step-n1-experts/step-n1-experts.component.scss
@@ -1,13 +1,11 @@
-.component_fields {}
-
 .two_elements_grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 20px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
 }
 
 .experts {
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 }

--- a/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-innovation-use-pathway/pages/step-n1/step-n1.component.html
+++ b/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-innovation-use-pathway/pages/step-n1/step-n1.component.html
@@ -1,5 +1,11 @@
 <div class="step_title"><strong>Step 1:</strong>Scaling Ambition, Experts and Consultation</div>
-<app-pr-field-header [required]="false" label="Core innovation selected and CGIAR Initiative leading the development"></app-pr-field-header>
+<app-pr-field-header
+  [required]="false"
+  [label]="
+    'Core innovation selected and CGIAR ' +
+    ('term.entity.singular' | term: this.ipsrDataControlSE.detailData?.portfolio) +
+    ' leading the development'
+  "></app-pr-field-header>
 
 <div class="ipsr_chip_container">
   <div class="text">

--- a/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-innovation-use-pathway/pages/step-n1/step-n1.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-innovation-use-pathway/pages/step-n1/step-n1.component.spec.ts
@@ -24,6 +24,7 @@ import { FeedbackValidationDirective } from '../../../../../../../../shared/dire
 import { of } from 'rxjs';
 import { ApiService } from '../../../../../../../../shared/services/api/api.service';
 import { Router } from '@angular/router';
+import { TermPipe } from '../../../../../../../../internationalization/term.pipe';
 
 jest.useFakeTimers();
 
@@ -127,7 +128,7 @@ describe('StepN1Component', () => {
         SaveButtonComponent,
         FeedbackValidationDirective
       ],
-      imports: [HttpClientTestingModule, TooltipModule, FormsModule, RadioButtonModule, ToastModule, CdkCopyToClipboard],
+      imports: [HttpClientTestingModule, TooltipModule, FormsModule, RadioButtonModule, ToastModule, CdkCopyToClipboard, TermPipe],
       providers: [
         {
           provide: ApiService,

--- a/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-innovation-use-pathway/pages/step-n1/step-n1.module.ts
+++ b/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-innovation-use-pathway/pages/step-n1/step-n1.module.ts
@@ -10,6 +10,7 @@ import { GeoscopeManagementModule } from '../../../../../../../../shared/compone
 import { YmzListStructureItemModule } from '../../../../../../../../shared/directives/ymz-list-structure-item/ymz-list-structure-item.module';
 import { CollapsibleContainerModule } from '../../../../../../../../shared/components/collapsible-container/collapsible-container.module';
 import { MessageModule } from 'primeng/message';
+import { TermPipe } from '../../../../../../../../internationalization/term.pipe';
 
 @NgModule({
   declarations: [StepN1Component],
@@ -22,7 +23,8 @@ import { MessageModule } from 'primeng/message';
     GeoscopeManagementModule,
     YmzListStructureItemModule,
     CollapsibleContainerModule,
-    MessageModule
+    MessageModule,
+    TermPipe
   ]
 })
 export class StepN1Module {}

--- a/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-innovation-use-pathway/pages/step-n4/components/step-n4-initiative-investment-table/step-n4-initiative-investment-table.component.html
+++ b/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-innovation-use-pathway/pages/step-n4/components/step-n4-initiative-investment-table/step-n4-initiative-investment-table.component.html
@@ -1,38 +1,56 @@
-<div class="ipsr-sub-title" style="margin-bottom: 10px;">Anticipated investment in improving the scaling readiness of
-    the innovation package</div>
+<div class="ipsr-sub-title" style="margin-bottom: 10px">Anticipated investment in improving the scaling readiness of the innovation package</div>
 <app-pr-field-header [description]="usdQuestionDescription()" [required]="false"></app-pr-field-header>
 <div class="unit_of_time_container">
-    <div>
-        <app-pr-field-header
-            label="Expected CGIAR Initiative investment in improving the scaling readiness of the Innovation Package in"></app-pr-field-header>
-    </div>
+  <div>
+    <app-pr-field-header
+      [label]="
+        'Expected CGIAR ' +
+        ('term.entity.singular' | term: this.ipsrDataControlSE.detailData?.portfolio) +
+        ' investment in improving the scaling readiness of the Innovation Package in'
+      "></app-pr-field-header>
+  </div>
 </div>
 
-
 <table>
-    <tr>
-        <th>Initiative</th>
-        <th>Current calendar year <br> (USD value)</th>
-        <th>Next calendar year <br> (USD value)</th>
-        <th></th>
-    </tr>
-    <tr *ngFor="let item of this.body.initiative_expected_investment">
-        <td>{{item.obj_result_initiative.obj_initiative.official_code}} -
-            {{item.obj_result_initiative.obj_initiative.name}}</td>
-        <td>
-            <app-pr-input [(ngModel)]="item.current_year" placeholder="Enter text" type="currency"
-                [noDataText]="item.is_determined ? 'Not applicable':'Not provided'" [required]="false">
-            </app-pr-input>
-        </td>
-        <td>
-            <app-pr-input [(ngModel)]="item.next_year" placeholder="Enter text" type="currency"
-                [noDataText]="item.is_determined ? 'Not applicable':'Not provided'" [required]="false">
-            </app-pr-input>
-        </td>
-        <td>
-            <app-pr-radio-button [(ngModel)]="item.is_determined" optionLabel="name" optionValue="id"
-                [options]="[{name:'This is yet to be determined',id:true}]">
-            </app-pr-radio-button>
-        </td>
-    </tr>
+  <tr>
+    <th>{{ 'term.entity.singular' | term: this.ipsrDataControlSE.detailData?.portfolio }}</th>
+    <th>
+      Current calendar year <br />
+      (USD value)
+    </th>
+    <th>
+      Next calendar year <br />
+      (USD value)
+    </th>
+    <th></th>
+  </tr>
+  <tr *ngFor="let item of this.body.initiative_expected_investment">
+    <td>{{ item.obj_result_initiative.obj_initiative.official_code }} - {{ item.obj_result_initiative.obj_initiative.name }}</td>
+    <td>
+      <app-pr-input
+        [(ngModel)]="item.current_year"
+        placeholder="Enter text"
+        type="currency"
+        [noDataText]="item.is_determined ? 'Not applicable' : 'Not provided'"
+        [required]="false">
+      </app-pr-input>
+    </td>
+    <td>
+      <app-pr-input
+        [(ngModel)]="item.next_year"
+        placeholder="Enter text"
+        type="currency"
+        [noDataText]="item.is_determined ? 'Not applicable' : 'Not provided'"
+        [required]="false">
+      </app-pr-input>
+    </td>
+    <td>
+      <app-pr-radio-button
+        [(ngModel)]="item.is_determined"
+        optionLabel="name"
+        optionValue="id"
+        [options]="[{ name: 'This is yet to be determined', id: true }]">
+      </app-pr-radio-button>
+    </td>
+  </tr>
 </table>

--- a/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-innovation-use-pathway/pages/step-n4/components/step-n4-initiative-investment-table/step-n4-initiative-investment-table.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-innovation-use-pathway/pages/step-n4/components/step-n4-initiative-investment-table/step-n4-initiative-investment-table.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { StepN4InitiativeInvestmentTableComponent } from './step-n4-initiative-investment-table.component';
 import { HttpClientModule } from '@angular/common/http';
+import { TermPipe } from '../../../../../../../../../../internationalization/term.pipe';
 
 describe('StepN4InitiativeInvestmentTableComponent', () => {
   let component: StepN4InitiativeInvestmentTableComponent;
@@ -10,7 +11,7 @@ describe('StepN4InitiativeInvestmentTableComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [StepN4InitiativeInvestmentTableComponent],
-      imports: [HttpClientModule]
+      imports: [HttpClientModule, TermPipe]
     }).compileComponents();
 
     fixture = TestBed.createComponent(StepN4InitiativeInvestmentTableComponent);

--- a/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-innovation-use-pathway/pages/step-n4/components/step-n4-initiative-investment-table/step-n4-initiative-investment-table.component.ts
+++ b/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-innovation-use-pathway/pages/step-n4/components/step-n4-initiative-investment-table/step-n4-initiative-investment-table.component.ts
@@ -1,22 +1,29 @@
 import { Component, Input } from '@angular/core';
 import { IpsrStep4Body } from '../../model/Ipsr-step-4-body.model';
 import { ManageRipUnitTimeService } from '../../services/manage-rip-unit-time.service';
+import { IpsrDataControlService } from '../../../../../../../../services/ipsr-data-control.service';
 
 @Component({
-    selector: 'app-step-n4-initiative-investment-table',
-    templateUrl: './step-n4-initiative-investment-table.component.html',
-    styleUrls: ['./step-n4-initiative-investment-table.component.scss'],
-    standalone: false
+  selector: 'app-step-n4-initiative-investment-table',
+  templateUrl: './step-n4-initiative-investment-table.component.html',
+  styleUrls: ['./step-n4-initiative-investment-table.component.scss'],
+  standalone: false
 })
 export class StepN4InitiativeInvestmentTableComponent {
   @Input() body = new IpsrStep4Body();
-  constructor(public manageRipUnitTimeSE: ManageRipUnitTimeService) {}
+
+  constructor(
+    public manageRipUnitTimeSE: ManageRipUnitTimeService,
+    public ipsrDataControlSE: IpsrDataControlService
+  ) {}
+
   syncLocalData() {
     this.body.bilateral_expected_time = this.body.initiative_expected_time;
     this.body.bilateral_unit_time_id = this.body.initiative_unit_time_id;
     this.body.partner_expected_time = this.body.initiative_expected_time;
     this.body.partner_unit_time_id = this.body.initiative_unit_time_id;
   }
+
   usdQuestionDescription() {
     return `<li>The USD-value here can be an estimation and will be used to get an overall impression of the expected investment in improving the Scaling Readiness of the innovation package.</li><li>The investment estimation will by no means be used in official financial reporting or planning.</li>`;
   }

--- a/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-innovation-use-pathway/pages/step-n4/step-n4.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-innovation-use-pathway/pages/step-n4/step-n4.component.spec.ts
@@ -17,6 +17,7 @@ import { NoDataTextComponent } from '../../../../../../../../custom-fields/no-da
 import { DialogModule } from 'primeng/dialog';
 import { PrSelectComponent } from '../../../../../../../../custom-fields/pr-select/pr-select.component';
 import { LabelNamePipe } from '../../../../../../../../custom-fields/pr-select/label-name.pipe';
+import { TermPipe } from '../../../../../../../../internationalization/term.pipe';
 
 describe('StepN4Component', () => {
   let component: StepN4Component;
@@ -24,8 +25,22 @@ describe('StepN4Component', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, FormsModule, TooltipModule, DialogModule],
-      declarations: [StepN4Component, PrButtonComponent, StepN4InitiativeInvestmentTableComponent, LabelNamePipe, StepN4BilateralInvestmentTableComponent, StepN4PartnerCoInvestmentTableComponent, PrRadioButtonComponent, SaveButtonComponent, PrFieldHeaderComponent, StepN4AddBilateralComponent, StepN4AddPartnerComponent, NoDataTextComponent, PrSelectComponent]
+      imports: [HttpClientTestingModule, FormsModule, TooltipModule, DialogModule, TermPipe],
+      declarations: [
+        StepN4Component,
+        PrButtonComponent,
+        StepN4InitiativeInvestmentTableComponent,
+        LabelNamePipe,
+        StepN4BilateralInvestmentTableComponent,
+        StepN4PartnerCoInvestmentTableComponent,
+        PrRadioButtonComponent,
+        SaveButtonComponent,
+        PrFieldHeaderComponent,
+        StepN4AddBilateralComponent,
+        StepN4AddPartnerComponent,
+        NoDataTextComponent,
+        PrSelectComponent
+      ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(StepN4Component);

--- a/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-innovation-use-pathway/pages/step-n4/step-n4.module.ts
+++ b/onecgiar-pr-client/src/app/pages/ipsr/pages/innovation-package-detail/pages/ipsr-innovation-use-pathway/pages/step-n4/step-n4.module.ts
@@ -12,6 +12,7 @@ import { DialogModule } from 'primeng/dialog';
 import { StepN4EditBilateralComponent } from './components/step-n4-bilateral-investment-table/modal/step-n4-edit-bilateral/step-n4-edit-bilateral.component';
 import { CustomFieldsModule } from '../../../../../../../../custom-fields/custom-fields.module';
 import { StepN4ReferenceMaterialLinksComponent } from './components/step-n4-reference-material-links/step-n4-reference-material-links.component';
+import { TermPipe } from '../../../../../../../../internationalization/term.pipe';
 
 @NgModule({
   declarations: [
@@ -24,6 +25,6 @@ import { StepN4ReferenceMaterialLinksComponent } from './components/step-n4-refe
     StepN4AddPartnerComponent,
     StepN4EditBilateralComponent
   ],
-  imports: [CommonModule, StepN4RoutingModule, CustomFieldsModule, DialogModule, CustomFieldsModule]
+  imports: [CommonModule, StepN4RoutingModule, CustomFieldsModule, DialogModule, CustomFieldsModule, TermPipe]
 })
 export class StepN4Module {}

--- a/onecgiar-pr-client/src/app/pages/ipsr/services/ipsr-data-control.service.ts
+++ b/onecgiar-pr-client/src/app/pages/ipsr/services/ipsr-data-control.service.ts
@@ -31,4 +31,5 @@ interface DetailData {
   status: string;
   status_id: number;
   validResult: string | number;
+  portfolio: string;
 }

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-result-types-pages/innovation-dev-info/components/estimates/estimates.component.html
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-result-types-pages/innovation-dev-info/components/estimates/estimates.component.html
@@ -1,10 +1,10 @@
 <div class="segment">
     <app-pr-field-header
-        [label]="'Estimation of total USD-value of pooled investment by CGIAR ' + ('term.entity.plural' | term)+ ' during the reporting period'"
+        [label]="'Estimation of total USD-value of pooled investment by CGIAR ' + ('term.entity.plural' | term: this.api.dataControlSE.currentResult?.portfolio)+ ' during the reporting period'"
         [description]="headerDescriptions().n1" [useColon]="false"></app-pr-field-header>
     <table [style]="!body.initiative_expected_investment.length ? 'margin-bottom: 5px;' : null" aria-label="Table showing estimation of total USD-value of pooled investment by CGIAR initiatives during the reporting period">
         <tr>
-            <th>{{'term.entity.singular' | term}}</th>
+            <th>{{'term.entity.singular' | term: this.api.dataControlSE.currentResult?.portfolio}}</th>
             <th>Total USD Value <br> <span>(in-cash + in-kind)</span> </th>
             <th></th>
         </tr>

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-theory-of-change/rd-theory-of-change.component.html
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-theory-of-change/rd-theory-of-change.component.html
@@ -1,53 +1,56 @@
 <app-detail-section-title sectionName="Contributors" title="Theory of Change"></app-detail-section-title>
 
 <div class="detail_container">
-  <app-alert-status
-    *ngIf="!!this.dataControlSE?.currentResult?.is_replicated"
-    [description]="
-      'Dear user, note that data from the previous year data has been replicated, however the information related to collaboration with other ' +
-      ('term.entity.plural' | term) +
-      ' have not been replicated. Please add collaborating intiatives in section 2 and be aware that they will receive a notification to confirm the collaboration and map this result against their ToC.'
-    ">
-  </app-alert-status>
+  @if (!!this.dataControlSE?.currentResult?.is_replicated) {
+    <app-alert-status
+      [description]="
+        'Dear user, note that data from the previous year data has been replicated, however the information related to collaboration with other ' +
+        ('term.entity.plural' | term: this.api.dataControlSE.currentResult?.portfolio) +
+        ' have not been replicated. Please add collaborating intiatives in section 2 and be aware that they will receive a notification to confirm the collaboration and map this result against their ToC.'
+      ">
+    </app-alert-status>
+  }
 
   <app-alert-status
     [description]="
-      ('term.entity.plural' | term) + ' and non-pooled projects that you collaborated with to generate this result/contributed to this result.'
+      ('term.entity.plural' | term: this.api.dataControlSE.currentResult?.portfolio) +
+      ' and non-pooled projects that you collaborated with to generate this result/contributed to this result.'
     ">
   </app-alert-status>
 
-  <div *ngIf="getConsumed">
+  @if (getConsumed) {
     <app-pr-select
       class="segment_title_margin"
       [options]="this.theoryOfChangeBody.contributing_and_primary_initiative"
       label="Submitter"
       optionLabel="full_name"
       optionValue="id"
-      [placeholder]="'Select ' + ('term.entity.orPlatforms' | term)"
-      [description]="'Select ' + ('term.entity.orPlatforms' | term)"
+      [placeholder]="'Select ' + ('term.entity.orPlatforms' | term: this.api.dataControlSE.currentResult?.portfolio)"
+      [description]="'Select ' + ('term.entity.orPlatforms' | term: this.api.dataControlSE.currentResult?.portfolio)"
       [(ngModel)]="this.theoryOfChangeBody.changePrimaryInit"
       [fieldDisabled]="
         !!(this.theoryOfChangeBody.contributing_and_primary_initiative?.length === 1 && this.theoryOfChangeBody?.result_toc_result?.initiative_id)
       ">
     </app-pr-select>
 
-    <div
-      class="no-primary-list"
-      *ngIf="this.theoryOfChangeBody.contributing_and_primary_initiative?.length == 1 && this.theoryOfChangeBody?.result_toc_result?.initiative_id">
-      Since this result has not been shared and accepted by other {{ 'term.entity.plural' | term }}, it is not possible to change the submitter.
-    </div>
-  </div>
+    @if (this.theoryOfChangeBody.contributing_and_primary_initiative?.length == 1 && this.theoryOfChangeBody?.result_toc_result?.initiative_id) {
+      <div class="no-primary-list">
+        Since this result has not been shared and accepted by other
+        {{ 'term.entity.plural' | term: this.api.dataControlSE.currentResult?.portfolio }}, it is not possible to change the submitter.
+      </div>
+    }
+  }
 
   <app-alert-status
     [description]="
       '<strong>Contribution to a reported result:</strong> Include those partners [OR ' +
-      ('term.entity.plural' | term) +
+      ('term.entity.plural' | term: this.api.dataControlSE.currentResult?.portfolio) +
       '/non-pooled projects/Impact Platforms] that made a significant contribution to the achievement of the result. This could take many forms and the threshold for inclusion is that the result would not have been achieved or reported in its current form without their support.'
     "></app-alert-status>
 
   <app-pr-multi-select
     [options]="this.contributingInitiativesList"
-    label="Contributing {{ 'term.entity.orPlatformsPlural' | term }}"
+    label="Contributing {{ 'term.entity.orPlatformsPlural' | term: this.api.dataControlSE.currentResult?.portfolio }}"
     [disableOptions]="disabledOptions"
     optionLabel="full_name"
     optionValue="id"
@@ -56,88 +59,93 @@
     selectedOptionLabel="full_name"
     [(ngModel)]="contributingInitiativeNew"
     [confirmDeletion]="true"
-    [placeholder]="'Select ' + ('term.entity.orPlatformsWith()' | term)">
+    [placeholder]="'Select ' + ('term.entity.orPlatformsWith()' | term: this.api.dataControlSE.currentResult?.portfolio)">
   </app-pr-multi-select>
 
   <div class="selected_container custom_scroll">
-    <app-pr-field-header [description]="('term.entity.singularWith()' | term) + ' selected:'"> </app-pr-field-header>
+    <app-pr-field-header [description]="('term.entity.singularWith()' | term: this.api.dataControlSE.currentResult?.portfolio) + ' selected:'">
+    </app-pr-field-header>
 
     <div class="chips_container">
-      <div
-        class="pr_chip_selected"
-        *ngFor="let item of this.theoryOfChangeBody?.contributing_initiatives.accepted_contributing_initiatives; let i = index">
-        <div class="name" [ngClass]="{ text_inactive: !item.is_active }">
-          <strong>{{ item.official_code }}</strong> {{ item.initiative_name }}
-        </div>
-        <i
-          *ngIf="!this.api.rolesSE.readOnly"
-          class="material-icons-round"
-          [style.color]="item.is_active ? 'var(--pr-color-red-100)' : 'var(--pr-color-primary-300)'"
-          (click)="onRemoveContribuiting(i, true)">
-          {{ item.is_active ? 'backspace' : 'undo' }}
-        </i>
-      </div>
+      @for (item of this.theoryOfChangeBody?.contributing_initiatives.accepted_contributing_initiatives; track item.id; let i = $index) {
+        <div class="pr_chip_selected">
+          <div class="name" [ngClass]="{ text_inactive: !item.is_active }">
+            <strong>{{ item.official_code }}</strong> {{ item.initiative_name }}
+          </div>
 
-      <div class="pr_chip_selected pending" *ngFor="let item of contributingInitiativeNew; let i = index">
-        <div class="name" [ngClass]="{ text_inactive: !item.is_active }">
-          <strong>{{ item.official_code }}</strong> {{ item.name }} - <b style="font-style: italic"> Not saved yet </b>
+          @if (!this.api.rolesSE.readOnly) {
+            <i
+              class="material-icons-round"
+              [style.color]="item.is_active ? 'var(--pr-color-red-100)' : 'var(--pr-color-primary-300)'"
+              (click)="onRemoveContribuiting(i, true)">
+              {{ item.is_active ? 'backspace' : 'undo' }}
+            </i>
+          }
         </div>
-        <i
-          *ngIf="!this.api.rolesSE.readOnly"
-          class="material-icons-round"
-          [style.color]="item.is_active ? 'var(--pr-color-red-100)' : 'var(--pr-color-primary-300)'"
-          (click)="onRemoveContribuiting(i, false)">
-          {{ item.is_active ? 'backspace' : 'undo' }}
-        </i>
-      </div>
+      }
 
-      <div
-        class="pr_chip_selected pending"
-        *ngFor="let item of this.theoryOfChangeBody?.contributing_initiatives.pending_contributing_initiatives; let i = index">
-        <div class="name" [ngClass]="{ text_inactive: !item.is_active }">
-          <strong>{{ item.official_code }}</strong> {{ item.initiative_name }} - <b style="font-style: italic"> Pending confirmation </b>
+      @for (item of contributingInitiativeNew; track item.id; let i = $index) {
+        <div class="pr_chip_selected pending">
+          <div class="name" [ngClass]="{ text_inactive: !item.is_active }">
+            <strong>{{ item.official_code }}</strong> {{ item.name }} - <b style="font-style: italic"> Not saved yet </b>
+          </div>
+
+          @if (!this.api.rolesSE.readOnly) {
+            <i
+              class="material-icons-round"
+              [style.color]="item.is_active ? 'var(--pr-color-red-100)' : 'var(--pr-color-primary-300)'"
+              (click)="onRemoveContribuiting(i, false)">
+              {{ item.is_active ? 'backspace' : 'undo' }}
+            </i>
+          }
         </div>
-        <i
-          *ngIf="!this.api.rolesSE.readOnly"
-          class="material-icons-round"
-          [style.color]="item.is_active ? 'var(--pr-color-red-100)' : 'var(--pr-color-primary-300)'"
-          (click)="toggleActiveContributor(item)">
-          {{ item.is_active ? 'backspace' : 'undo' }}
-        </i>
-      </div>
+      }
+
+      @for (item of this.theoryOfChangeBody?.contributing_initiatives.pending_contributing_initiatives; track item.id) {
+        <div class="pr_chip_selected pending">
+          <div class="name" [ngClass]="{ text_inactive: !item.is_active }">
+            <strong>{{ item.official_code }}</strong> {{ item.initiative_name }} - <b style="font-style: italic"> Pending confirmation </b>
+          </div>
+
+          @if (!this.api.rolesSE.readOnly) {
+            <i
+              class="material-icons-round"
+              [style.color]="item.is_active ? 'var(--pr-color-red-100)' : 'var(--pr-color-primary-300)'"
+              (click)="toggleActiveContributor(item)">
+              {{ item.is_active ? 'backspace' : 'undo' }}
+            </i>
+          }
+        </div>
+      }
     </div>
   </div>
 
-  <div
-    [ngSwitch]="this.resultLevelSE.currentResultLevelId"
-    *ngIf="(getConsumed && this.theoryOfChangeBody?.result_toc_result?.initiative_id) || (getConsumed && this.theoryOfChangeBody?.impacts)">
-    <div *ngSwitchCase="1">
+  @switch (this.resultLevelSE.currentResultLevelId) {
+    @case (1) {
       <app-toc-impact-section
         [contributing_initiatives]="this.theoryOfChangeBody.contributing_initiatives"
         [impacts]="this.theoryOfChangeBody.impactsTarge"
         [sdg]="this.theoryOfChangeBody.sdgTargets"></app-toc-impact-section>
-    </div>
-    <div *ngSwitchCase="2">
+    }
+    @case (2) {
       <app-toc-action-area-outcome-section
         [result_toc_result]="this.theoryOfChangeBody.result_toc_result"
         [contributors_result_toc_result]="this.theoryOfChangeBody.contributors_result_toc_result">
-        >
       </app-toc-action-area-outcome-section>
-    </div>
-    <div *ngSwitchCase="3">
+    }
+    @case (3) {
       <app-toc-initiative-outcome-section
         [result_toc_result]="this.theoryOfChangeBody.result_toc_result"
         [contributors_result_toc_result]="this.theoryOfChangeBody.contributors_result_toc_result">
       </app-toc-initiative-outcome-section>
-    </div>
-    <div *ngSwitchCase="4">
+    }
+    @case (4) {
       <app-toc-initiative-output-section
         [result_toc_result]="this.theoryOfChangeBody.result_toc_result"
         [contributors_result_toc_result]="this.theoryOfChangeBody.contributors_result_toc_result">
       </app-toc-initiative-output-section>
-    </div>
-    <div *ngSwitchDefault></div>
-  </div>
+    }
+  }
 </div>
 
 <app-save-button class="position_sticky" [editable]="someEditable()" (clickSave)="onSaveSection()"> </app-save-button>

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-theory-of-change/rd-theory-of-change.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-theory-of-change/rd-theory-of-change.component.spec.ts
@@ -83,6 +83,10 @@ describe('RdTheoryOfChangeComponent', () => {
       ]
     }
   };
+  const mockGET_resultByIdResponse = {
+    id: 1,
+    portfolio: 'portfolio'
+  };
 
   beforeEach(async () => {
     mockApiService = {
@@ -94,7 +98,8 @@ describe('RdTheoryOfChangeComponent', () => {
         GET_AllCLARISACenters: () => of({ response: [] }),
         GET_allInstitutions: () => of({ response: [] }),
         GET_allInstitutionTypes: () => of({ response: [] }),
-        GET_allChildlessInstitutionTypes: () => of({ response: [] })
+        GET_allChildlessInstitutionTypes: () => of({ response: [] }),
+        GET_resultById: () => of({ response: mockGET_resultByIdResponse })
       },
       alertsFe: {
         show: jest.fn().mockImplementationOnce((config, callback) => {

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-theory-of-change/rd-theory-of-change.component.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-theory-of-change/rd-theory-of-change.component.ts
@@ -39,9 +39,18 @@ export class RdTheoryOfChangeComponent implements OnInit {
   }
 
   GET_AllWithoutResults() {
-    this.api.resultsSE.GET_AllWithoutResults().subscribe(({ response }) => {
-      this.contributingInitiativesList = response;
-      this.changeDetectorRef.detectChanges();
+    this.api.resultsSE.GET_resultById().subscribe({
+      next: ({ response }) => {
+        this.api.dataControlSE.currentResult = response;
+        const activePortfolio = this.api.dataControlSE.currentResult?.portfolio;
+        this.api.resultsSE.GET_AllWithoutResults(activePortfolio).subscribe(({ response }) => {
+          this.contributingInitiativesList = response;
+          this.changeDetectorRef.detectChanges();
+        });
+      },
+      error: err => {
+        console.error(err);
+      }
     });
   }
 

--- a/onecgiar-pr-client/src/app/shared/sections-components/links-to-results-global/links-to-results-global.component.html
+++ b/onecgiar-pr-client/src/app/shared/sections-components/links-to-results-global/links-to-results-global.component.html
@@ -117,7 +117,7 @@
         </div>
 
         <app-pr-yes-or-not label="Is this policy change linked to a reported innovation use outcome?"
-            [(ngModel)]="this.linksToResultsBody?.linkedInnovation.linked_innovation_use"
+            [(ngModel)]="this.linksToResultsBody.linkedInnovation.linked_innovation_use"
             [readOnly]="this.innoUseLinks.length > 0"></app-pr-yes-or-not>
 
         <app-alert-status

--- a/onecgiar-pr-client/src/app/shared/services/api/results-api.service.spec.ts
+++ b/onecgiar-pr-client/src/app/shared/services/api/results-api.service.spec.ts
@@ -732,7 +732,7 @@ describe('ResultsApiService', () => {
         done();
       });
 
-      const req = httpMock.expectOne(`${environment.apiBaseUrl}clarisa/initiatives/get/all/without/result/${service.currentResultId}`);
+      const req = httpMock.expectOne(`${environment.apiBaseUrl}clarisa/initiatives/get/all/without/result/${service.currentResultId}/undefined`);
       expect(req.request.method).toBe('GET');
 
       req.flush(mockResponse);

--- a/onecgiar-pr-client/src/app/shared/services/api/results-api.service.ts
+++ b/onecgiar-pr-client/src/app/shared/services/api/results-api.service.ts
@@ -252,8 +252,8 @@ export class ResultsApiService {
     );
   }
 
-  GET_AllWithoutResults() {
-    return this.http.get<any>(`${environment.apiBaseUrl}clarisa/initiatives/get/all/without/result/${this.currentResultId}`).pipe(
+  GET_AllWithoutResults(portfolioId?: string) {
+    return this.http.get<any>(`${environment.apiBaseUrl}clarisa/initiatives/get/all/without/result/${this.currentResultId}/${portfolioId}`).pipe(
       map(resp => {
         resp.response.map(
           initiative => (initiative.full_name = `${initiative?.official_code} - <strong>${initiative?.short_name}</strong> - ${initiative?.name}`)
@@ -431,7 +431,7 @@ export class ResultsApiService {
     return this.http.get<any>(`${this.apiBaseUrl}capdevs-delivery-methods/get/all`);
   }
 
-  GET_AllInitiatives(portfolioId?: 'p22' | 'p25') {
+  GET_AllInitiatives(portfolioId?: string) {
     let url = `${environment.apiBaseUrl}clarisa/initiatives`;
     if (portfolioId) url += `/${portfolioId}`;
 

--- a/onecgiar-pr-server/src/api/ipsr/ipsr.module.spec.ts
+++ b/onecgiar-pr-server/src/api/ipsr/ipsr.module.spec.ts
@@ -1,0 +1,9 @@
+import { IpsrModule } from './ipsr.module';
+
+describe('IpsrModule', () => {
+  it('is defined', () => {
+    const module = new IpsrModule();
+    expect(module).toBeDefined();
+  });
+});
+

--- a/onecgiar-pr-server/src/api/ipsr/ipsr.repository.spec.ts
+++ b/onecgiar-pr-server/src/api/ipsr/ipsr.repository.spec.ts
@@ -1,0 +1,129 @@
+import { DataSource } from 'typeorm';
+import { IpsrRepository } from './ipsr.repository';
+
+describe('IpsrRepository (unit)', () => {
+  let repo: IpsrRepository;
+  let dsQuery: jest.Mock;
+  let repoQuery: jest.Mock;
+
+  const mockDataSource = {
+    createEntityManager: jest.fn(() => ({}) as any),
+    query: jest.fn(),
+  } as unknown as DataSource;
+
+  const mockHandlersError = {
+    returnErrorRepository: jest.fn((e) => e),
+  } as any;
+
+  beforeEach(() => {
+    // fresh mocks
+    (mockDataSource.createEntityManager as any).mockClear?.();
+    (mockDataSource.query as any).mockClear?.();
+    repo = new IpsrRepository(mockDataSource, mockHandlersError);
+    dsQuery = mockDataSource.query as any as jest.Mock;
+    repoQuery = jest.fn();
+    // Override BaseRepository.query method
+    (repo as any).query = repoQuery;
+  });
+
+  it('constructs repository', () => {
+    expect(repo).toBeDefined();
+    expect((mockDataSource.createEntityManager as any).mock.calls.length).toBe(
+      1,
+    );
+  });
+
+  it('fisicalDelete issues delete query', async () => {
+    repoQuery.mockResolvedValueOnce({ ok: true });
+    const res = await repo.fisicalDelete(123);
+    expect(repoQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = repoQuery.mock.calls[0];
+    expect(sql.toLowerCase()).toContain('delete rbip');
+    expect(params).toEqual([123]);
+    expect(res).toEqual({ ok: true });
+  });
+
+  it('logicalDelete issues update query', async () => {
+    repoQuery.mockResolvedValueOnce({ ok: true });
+    const res = await repo.logicalDelete(456);
+    const [sql, params] = repoQuery.mock.calls[0];
+    expect(sql.toLowerCase()).toContain('update result_by_innovation_package');
+    expect(params).toEqual([456]);
+    expect(res).toEqual({ ok: true });
+  });
+
+  it('getResultsInnovation returns array and uses IN (?) parameter', async () => {
+    const rows = [{ id: 1 }];
+    dsQuery.mockResolvedValueOnce(rows);
+    const res = await repo.getResultsInnovation([1, 2, 3]);
+    expect(dsQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = dsQuery.mock.calls[0];
+    expect(sql).toContain('IN (?)');
+    expect(params).toEqual([[1, 2, 3]]);
+    expect(res).toEqual(rows);
+  });
+
+  it('getResultsInnovation propagates handler error on failure', async () => {
+    dsQuery.mockRejectedValueOnce(new Error('boom'));
+    await expect(repo.getResultsInnovation([5])).rejects.toBeDefined();
+  });
+
+  it('getResultInnovationDetail returns first row', async () => {
+    const row = { result_id: 9 };
+    dsQuery.mockResolvedValueOnce([row]);
+    const res = await repo.getResultInnovationDetail(9);
+    expect(dsQuery).toHaveBeenCalled();
+    expect(res).toEqual(row);
+  });
+
+  it('getResultInnovationById maps regions, countries and subnational', async () => {
+    // 1) main innovation row (no lead_contact_person_id to avoid extra query)
+    dsQuery.mockResolvedValueOnce([
+      { result_id: 10, lead_contact_person_id: null },
+    ]);
+    // 2) regions
+    dsQuery.mockResolvedValueOnce([
+      { result_region_id: 1, result_id: 10, id: 100, name: 'R1' },
+    ]);
+    // 3) countries
+    dsQuery.mockResolvedValueOnce([
+      {
+        result_country_id: 20,
+        result_id: 10,
+        id: 200,
+        name: 'C1',
+        iso_alpha_2: 'AA',
+      },
+    ]);
+    // 4) sub national for country id 20
+    dsQuery.mockResolvedValueOnce([
+      { id: 300, result_countries_id: 20, name: 'SN1' },
+    ]);
+
+    const res = await repo.getResultInnovationById(10);
+    expect(Array.isArray(res)).toBe(true);
+    expect(res.length).toBe(1);
+    const item: any = res[0];
+    expect(Array.isArray(item.hasRegions)).toBe(true);
+    expect(item.hasRegions[0].result_region_id).toBe(1);
+    expect(Array.isArray(item.hasCountries)).toBe(true);
+    expect(item.hasCountries[0].result_countries_sub_national[0].name).toBe(
+      'SN1',
+    );
+  });
+
+  it('getIpsrList builds query with two placeholders and returns list', async () => {
+    const rows = [{ id: 1 }];
+    dsQuery.mockResolvedValueOnce(rows);
+    const excelDto = {
+      inits: [{ id: 1 }],
+      phases: [{ id: 2 }],
+      searchText: 'abc',
+    } as any;
+    const res = await repo.getIpsrList(excelDto);
+    const [sql, params] = dsQuery.mock.calls[0];
+    expect(sql).toContain('ORDER BY');
+    expect(params).toEqual(['?', '?']);
+    expect(res).toEqual(rows);
+  });
+});

--- a/onecgiar-pr-server/src/api/ipsr/ipsr.repository.ts
+++ b/onecgiar-pr-server/src/api/ipsr/ipsr.repository.ts
@@ -253,7 +253,15 @@ export class IpsrRepository
             r.is_replicated,
             r.is_discontinued,
             v.phase_name,
-            v.phase_year
+            v.phase_year,
+            (
+                SELECT
+                    cp.acronym
+                FROM
+                    clarisa_portfolios cp
+                WHERE
+                    cp.id = v.portfolio_id
+            ) AS portfolio
         FROM
             result r
             LEFT JOIN results_by_inititiative rbi ON rbi.result_id = r.id

--- a/onecgiar-pr-server/src/api/ipsr/ipsr.routes.spec.ts
+++ b/onecgiar-pr-server/src/api/ipsr/ipsr.routes.spec.ts
@@ -1,0 +1,35 @@
+import { IpsrRoutes } from './ipsr.routes';
+import { InnovationPathwayModule } from './innovation-pathway/innovation-pathway.module';
+import { ResultInnovationPackageModule } from './result-innovation-package/result-innovation-package.module';
+import { ResultsPackageTocResultModule } from './results-package-toc-result/results-package-toc-result.module';
+import { InnovationPackagingExpertsModule } from './innovation-packaging-experts/innovation-packaging-experts.module';
+import { ResultsInnovationPackagesValidationModuleModule } from './results-innovation-packages-validation-module/results-innovation-packages-validation-module.module';
+import { ResultsInnovationPackagesEnablerTypeModule } from './results-innovation-packages-enabler-type/results-innovation-packages-enabler-type.module';
+import { AssessedDuringExpertWorkshopModule } from './assessed-during-expert-workshop/assessed-during-expert-workshop.module';
+
+describe('IpsrRoutes', () => {
+  it('defines expected routes and modules', () => {
+    expect(Array.isArray(IpsrRoutes)).toBe(true);
+    const byPath: Record<string, any> = Object.fromEntries(
+      IpsrRoutes.map((r) => [r.path, r.module]),
+    );
+
+    expect(byPath['results-innovation-package']).toBe(
+      ResultInnovationPackageModule,
+    );
+    expect(byPath['contributors']).toBe(ResultsPackageTocResultModule);
+    expect(byPath['innovation-pathway']).toBe(InnovationPathwayModule);
+    expect(byPath['innovation-packaging-experts']).toBe(
+      InnovationPackagingExpertsModule,
+    );
+    expect(byPath['results-innovation-packages-validation-module']).toBe(
+      ResultsInnovationPackagesValidationModuleModule,
+    );
+    expect(byPath['results-innovation-packages-enabler-type']).toBe(
+      ResultsInnovationPackagesEnablerTypeModule,
+    );
+    expect(byPath['assessed-during-expert-workshop']).toBe(
+      AssessedDuringExpertWorkshopModule,
+    );
+  });
+});

--- a/onecgiar-pr-server/src/api/ipsr/repository/ipsr.repository.spec.ts
+++ b/onecgiar-pr-server/src/api/ipsr/repository/ipsr.repository.spec.ts
@@ -1,0 +1,20 @@
+import { DataSource } from 'typeorm';
+import { IpsrRepository } from './ipsr.repository';
+
+describe('IpsrRepository (repository/ipsr.repository.ts)', () => {
+  it('constructs with DataSource and exposes Repository APIs', () => {
+    const mockDataSource = {
+      createEntityManager: jest.fn(() => ({} as any)),
+    } as unknown as DataSource;
+    const mockHandlersError = { returnErrorRepository: jest.fn() } as any;
+
+    const repo = new IpsrRepository(mockDataSource, mockHandlersError);
+    expect(repo).toBeDefined();
+    // ensure underlying manager was requested
+    expect((mockDataSource as any).createEntityManager).toHaveBeenCalled();
+    // basic Repository methods should exist
+    expect(typeof (repo as any).query).toBe('function');
+    expect(typeof repo.findOne).toBe('function');
+  });
+});
+

--- a/onecgiar-pr-server/src/clarisa/clarisa-initiatives/ClarisaInitiatives.repository.spec.ts
+++ b/onecgiar-pr-server/src/clarisa/clarisa-initiatives/ClarisaInitiatives.repository.spec.ts
@@ -66,5 +66,16 @@ describe('ClarisaInitiativesRepository', () => {
       expect(args[1]).toEqual([5]);
       expect(res).toEqual([{ id: 9 }]);
     });
+
+    it('adds portfolioId to params when provided', async () => {
+      const spy = jest
+        .spyOn(repository as any, 'query')
+        .mockResolvedValue([{ id: 9 }] as any);
+      const res = await repository.getAllInitiativesWithoutCurrentInitiative(5, 2);
+      expect(spy).toHaveBeenCalled();
+      const args = (spy as jest.Mock).mock.calls[0];
+      expect(args[1]).toEqual([5, 2]);
+      expect(res).toEqual([{ id: 9 }]);
+    });
   });
 });

--- a/onecgiar-pr-server/src/clarisa/clarisa-initiatives/ClarisaInitiatives.repository.spec.ts
+++ b/onecgiar-pr-server/src/clarisa/clarisa-initiatives/ClarisaInitiatives.repository.spec.ts
@@ -1,0 +1,70 @@
+import { ClarisaInitiativesRepository } from './ClarisaInitiatives.repository';
+import { ClarisaInitiative } from './entities/clarisa-initiative.entity';
+
+describe('ClarisaInitiativesRepository', () => {
+  let repository: ClarisaInitiativesRepository;
+
+  const dataSourceMock = {
+    createEntityManager: jest.fn().mockReturnValue({}),
+  } as any;
+
+  beforeEach(() => {
+    repository = new ClarisaInitiativesRepository(dataSourceMock as any);
+  });
+
+  it('should be defined', () => {
+    expect(repository).toBeDefined();
+  });
+
+  describe('getAllInitiatives', () => {
+    it('calls find with active true and relations', async () => {
+      const spy = jest
+        .spyOn(repository as any, 'find')
+        .mockResolvedValue([{ id: 1 } as ClarisaInitiative]);
+      const res = await repository.getAllInitiatives();
+      expect(spy).toHaveBeenCalledWith({
+        where: { active: true },
+        relations: { obj_cgiar_entity_type: true },
+        order: { official_code: 'ASC' },
+      });
+      expect(res).toEqual([{ id: 1 }]);
+    });
+  });
+
+  describe('deleteAllData', () => {
+    it('executes delete query', async () => {
+      const spy = jest
+        .spyOn(repository as any, 'query')
+        .mockResolvedValue({ affected: 1 } as any);
+      const res = await repository.deleteAllData();
+      expect(spy).toHaveBeenCalled();
+      expect(res).toEqual({ affected: 1 });
+    });
+  });
+
+  describe('getTocIdFromOst', () => {
+    it('executes query using env.DB_OST', async () => {
+      process.env.DB_OST = 'mydb';
+      const spy = jest
+        .spyOn(repository as any, 'query')
+        .mockResolvedValue([{ toc_id: 'x' }] as any);
+      const res = await repository.getTocIdFromOst();
+      expect(spy).toHaveBeenCalled();
+      expect(res).toEqual([{ toc_id: 'x' }]);
+    });
+  });
+
+  describe('getAllInitiativesWithoutCurrentInitiative', () => {
+    it('executes query with resultId as param', async () => {
+      const spy = jest
+        .spyOn(repository as any, 'query')
+        .mockResolvedValue([{ id: 9 }] as any);
+      const res = await repository.getAllInitiativesWithoutCurrentInitiative(5);
+      expect(spy).toHaveBeenCalled();
+      const args = (spy as jest.Mock).mock.calls[0];
+      // second arg are parameters array
+      expect(args[1]).toEqual([5]);
+      expect(res).toEqual([{ id: 9 }]);
+    });
+  });
+});

--- a/onecgiar-pr-server/src/clarisa/clarisa-initiatives/ClarisaInitiatives.repository.spec.ts
+++ b/onecgiar-pr-server/src/clarisa/clarisa-initiatives/ClarisaInitiatives.repository.spec.ts
@@ -71,7 +71,10 @@ describe('ClarisaInitiativesRepository', () => {
       const spy = jest
         .spyOn(repository as any, 'query')
         .mockResolvedValue([{ id: 9 }] as any);
-      const res = await repository.getAllInitiativesWithoutCurrentInitiative(5, 2);
+      const res = await repository.getAllInitiativesWithoutCurrentInitiative(
+        5,
+        2,
+      );
       expect(spy).toHaveBeenCalled();
       const args = (spy as jest.Mock).mock.calls[0];
       expect(args[1]).toEqual([5, 2]);

--- a/onecgiar-pr-server/src/clarisa/clarisa-initiatives/ClarisaInitiatives.repository.ts
+++ b/onecgiar-pr-server/src/clarisa/clarisa-initiatives/ClarisaInitiatives.repository.ts
@@ -87,7 +87,10 @@ export class ClarisaInitiativesRepository extends Repository<ClarisaInitiative> 
     }
   }
 
-  async getAllInitiativesWithoutCurrentInitiative(resultId: number) {
+  async getAllInitiativesWithoutCurrentInitiative(
+    resultId: number,
+    portfolioId?: number,
+  ) {
     const queryData = `
     select
       	DISTINCT 
@@ -115,12 +118,17 @@ export class ClarisaInitiativesRepository extends Repository<ClarisaInitiative> 
       	where
       		rbi2.result_id = ?
       		and rbi2.initiative_role_id = 1)
-        and ci.active > 0;
+        and ci.active > 0
+        ${portfolioId ? 'and ci.portfolio_id = ?' : ''}
+        ${portfolioId === 3 ? 'and ci.cgiar_entity_type_id IN (22, 23, 24)' : ''};
     `;
     try {
-      const initiative: ClarisaInitiative[] = await this.query(queryData, [
-        resultId,
-      ]);
+      const params: any[] = [resultId];
+      if (portfolioId) params.push(portfolioId);
+      const initiative: ClarisaInitiative[] = await this.query(
+        queryData,
+        params,
+      );
       return initiative;
     } catch (error) {
       throw {

--- a/onecgiar-pr-server/src/clarisa/clarisa-initiatives/clarisa-initiatives.controller.spec.ts
+++ b/onecgiar-pr-server/src/clarisa/clarisa-initiatives/clarisa-initiatives.controller.spec.ts
@@ -45,7 +45,21 @@ describe('ClarisaInitiativesController', () => {
     );
     expect(
       service.getAllInitiativesWithoutCurrentInitiative,
-    ).toHaveBeenCalledWith(1);
+    ).toHaveBeenCalledWith(1, undefined);
+    expect(result).toEqual({ status: 200, response: [] });
+  });
+
+  it('getAllInitiativesWithoutCurrentInitiative passes portfolio when provided', async () => {
+    (
+      service.getAllInitiativesWithoutCurrentInitiative as any
+    ).mockResolvedValue({ status: 200, response: [] });
+    const result = await controller.getAllInitiativesWithoutCurrentInitiative(
+      1 as any,
+      'p22',
+    );
+    expect(
+      service.getAllInitiativesWithoutCurrentInitiative,
+    ).toHaveBeenCalledWith(1, 'p22');
     expect(result).toEqual({ status: 200, response: [] });
   });
 

--- a/onecgiar-pr-server/src/clarisa/clarisa-initiatives/clarisa-initiatives.controller.spec.ts
+++ b/onecgiar-pr-server/src/clarisa/clarisa-initiatives/clarisa-initiatives.controller.spec.ts
@@ -1,0 +1,78 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ClarisaInitiativesController } from './clarisa-initiatives.controller';
+import { ClarisaInitiativesService } from './clarisa-initiatives.service';
+
+describe('ClarisaInitiativesController', () => {
+  let controller: ClarisaInitiativesController;
+  let service: ClarisaInitiativesService;
+
+  const serviceMock = {
+    getAllInitiativesWithoutCurrentInitiative: jest.fn(),
+    findAll: jest.fn(),
+    getInitiativesEntitiesGrouped: jest.fn(),
+    getByPortfolio: jest.fn(),
+  } as unknown as jest.Mocked<ClarisaInitiativesService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ClarisaInitiativesController],
+      providers: [
+        {
+          provide: ClarisaInitiativesService,
+          useValue: serviceMock,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ClarisaInitiativesController>(
+      ClarisaInitiativesController,
+    );
+    service = module.get<ClarisaInitiativesService>(ClarisaInitiativesService);
+
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('getAllInitiativesWithoutCurrentInitiative delegates to service', async () => {
+    (
+      service.getAllInitiativesWithoutCurrentInitiative as any
+    ).mockResolvedValue({ status: 200, response: [] });
+    const result = await controller.getAllInitiativesWithoutCurrentInitiative(
+      1 as any,
+    );
+    expect(
+      service.getAllInitiativesWithoutCurrentInitiative,
+    ).toHaveBeenCalledWith(1);
+    expect(result).toEqual({ status: 200, response: [] });
+  });
+
+  it('findAll delegates to service', async () => {
+    (service.findAll as any).mockResolvedValue({ status: 200, response: [] });
+    const result = await controller.findAll();
+    expect(service.findAll).toHaveBeenCalled();
+    expect(result).toEqual({ status: 200, response: [] });
+  });
+
+  it('getInitiativesEntities delegates to service', async () => {
+    (service.getInitiativesEntitiesGrouped as any).mockResolvedValue({
+      status: 200,
+      response: [],
+    });
+    const result = await controller.getInitiativesEntities();
+    expect(service.getInitiativesEntitiesGrouped).toHaveBeenCalled();
+    expect(result).toEqual({ status: 200, response: [] });
+  });
+
+  it('getByPortfolio delegates to service with param', async () => {
+    (service.getByPortfolio as any).mockResolvedValue({
+      status: 200,
+      response: [],
+    });
+    const result = await controller.getByPortfolio('p25');
+    expect(service.getByPortfolio).toHaveBeenCalledWith('p25');
+    expect(result).toEqual({ status: 200, response: [] });
+  });
+});

--- a/onecgiar-pr-server/src/clarisa/clarisa-initiatives/clarisa-initiatives.controller.ts
+++ b/onecgiar-pr-server/src/clarisa/clarisa-initiatives/clarisa-initiatives.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Query, UseInterceptors } from '@nestjs/common';
+import { Controller, Get, Param, UseInterceptors } from '@nestjs/common';
 import { ClarisaInitiativesService } from './clarisa-initiatives.service';
 import { ResponseInterceptor } from '../../shared/Interceptors/Return-data.interceptor';
 

--- a/onecgiar-pr-server/src/clarisa/clarisa-initiatives/clarisa-initiatives.controller.ts
+++ b/onecgiar-pr-server/src/clarisa/clarisa-initiatives/clarisa-initiatives.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, UseInterceptors } from '@nestjs/common';
+import { Controller, Get, Param, Query, UseInterceptors } from '@nestjs/common';
 import { ClarisaInitiativesService } from './clarisa-initiatives.service';
 import { ResponseInterceptor } from '../../shared/Interceptors/Return-data.interceptor';
 
@@ -9,12 +9,14 @@ export class ClarisaInitiativesController {
     private readonly clarisaInitiativesService: ClarisaInitiativesService,
   ) {}
 
-  @Get('get/all/without/result/:resultId')
+  @Get('get/all/without/result/:resultId/:portfolio')
   getAllInitiativesWithoutCurrentInitiative(
     @Param('resultId') resultId: number,
+    @Param('portfolio') portfolio?: string,
   ) {
     return this.clarisaInitiativesService.getAllInitiativesWithoutCurrentInitiative(
       resultId,
+      portfolio,
     );
   }
 

--- a/onecgiar-pr-server/src/clarisa/clarisa-initiatives/clarisa-initiatives.module.spec.ts
+++ b/onecgiar-pr-server/src/clarisa/clarisa-initiatives/clarisa-initiatives.module.spec.ts
@@ -1,0 +1,33 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ClarisaInitiativesModule } from './clarisa-initiatives.module';
+import { ClarisaInitiativesController } from './clarisa-initiatives.controller';
+import { ClarisaInitiativesService } from './clarisa-initiatives.service';
+import { ClarisaInitiativesRepository } from './ClarisaInitiatives.repository';
+import { HandlersError } from '../../shared/handlers/error.utils';
+
+describe('ClarisaInitiativesModule', () => {
+  let moduleRef: TestingModule;
+
+  beforeEach(async () => {
+    moduleRef = await Test.createTestingModule({
+      imports: [ClarisaInitiativesModule],
+    })
+      .overrideProvider(ClarisaInitiativesRepository)
+      .useValue({})
+      .compile();
+  });
+
+  it('should compile module and resolve providers', async () => {
+    const controller = moduleRef.get<ClarisaInitiativesController>(
+      ClarisaInitiativesController,
+    );
+    const service = moduleRef.get<ClarisaInitiativesService>(
+      ClarisaInitiativesService,
+    );
+    const handlers = moduleRef.get<HandlersError>(HandlersError);
+
+    expect(controller).toBeDefined();
+    expect(service).toBeDefined();
+    expect(handlers).toBeDefined();
+  });
+});

--- a/onecgiar-pr-server/src/clarisa/clarisa-initiatives/clarisa-initiatives.service.spec.ts
+++ b/onecgiar-pr-server/src/clarisa/clarisa-initiatives/clarisa-initiatives.service.spec.ts
@@ -52,7 +52,7 @@ describe('ClarisaInitiativesService', () => {
       const res = await service.getAllInitiativesWithoutCurrentInitiative(7);
       expect(
         repo.getAllInitiativesWithoutCurrentInitiative,
-      ).toHaveBeenCalledWith(7);
+      ).toHaveBeenCalledWith(7, undefined);
       expect(res.status).toBe(HttpStatus.NOT_FOUND);
     });
 
@@ -64,6 +64,30 @@ describe('ClarisaInitiativesService', () => {
       const res = await service.getAllInitiativesWithoutCurrentInitiative(3);
       expect(res.status).toBe(HttpStatus.OK);
       expect(res.response).toEqual(data);
+    });
+    
+    it('filters by portfolio when provided (p22)', async () => {
+      (repo.getAllInitiativesWithoutCurrentInitiative as any).mockResolvedValue(
+        [{ id: 1 }],
+      );
+      const res = await service.getAllInitiativesWithoutCurrentInitiative(10, 'p22');
+      expect(repo.getAllInitiativesWithoutCurrentInitiative).toHaveBeenCalledWith(
+        10,
+        2,
+      );
+      expect(res.status).toBe(HttpStatus.OK);
+    });
+
+    it('filters by portfolio when provided (p25)', async () => {
+      (repo.getAllInitiativesWithoutCurrentInitiative as any).mockResolvedValue(
+        [{ id: 1 }],
+      );
+      const res = await service.getAllInitiativesWithoutCurrentInitiative(10, 'p25');
+      expect(repo.getAllInitiativesWithoutCurrentInitiative).toHaveBeenCalledWith(
+        10,
+        3,
+      );
+      expect(res.status).toBe(HttpStatus.OK);
     });
   });
 

--- a/onecgiar-pr-server/src/clarisa/clarisa-initiatives/clarisa-initiatives.service.spec.ts
+++ b/onecgiar-pr-server/src/clarisa/clarisa-initiatives/clarisa-initiatives.service.spec.ts
@@ -1,0 +1,99 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ClarisaInitiativesService } from './clarisa-initiatives.service';
+import { ClarisaInitiativesRepository } from './ClarisaInitiatives.repository';
+import { HandlersError } from '../../shared/handlers/error.utils';
+import { HttpStatus } from '@nestjs/common';
+
+describe('ClarisaInitiativesService', () => {
+  let service: ClarisaInitiativesService;
+  let repo: jest.Mocked<ClarisaInitiativesRepository>;
+
+  const repoMock: Partial<jest.Mocked<ClarisaInitiativesRepository>> = {
+    getAllInitiatives: jest.fn(),
+    getAllInitiativesWithoutCurrentInitiative: jest.fn(),
+    find: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ClarisaInitiativesService,
+        HandlersError,
+        { provide: ClarisaInitiativesRepository, useValue: repoMock },
+      ],
+    }).compile();
+
+    service = module.get<ClarisaInitiativesService>(ClarisaInitiativesService);
+    repo = module.get(
+      ClarisaInitiativesRepository,
+    ) as jest.Mocked<ClarisaInitiativesRepository>;
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('findAll', () => {
+    it('returns initiatives wrapped', async () => {
+      (repo.getAllInitiatives as any).mockResolvedValue([{ id: 1 }]);
+      const res = await service.findAll();
+      expect(repo.getAllInitiatives).toHaveBeenCalled();
+      expect(res.status).toBe(HttpStatus.OK);
+      expect(res.response).toEqual([{ id: 1 }]);
+    });
+  });
+
+  describe('getAllInitiativesWithoutCurrentInitiative', () => {
+    it('returns NOT_FOUND when empty', async () => {
+      (repo.getAllInitiativesWithoutCurrentInitiative as any).mockResolvedValue(
+        [],
+      );
+      const res = await service.getAllInitiativesWithoutCurrentInitiative(7);
+      expect(
+        repo.getAllInitiativesWithoutCurrentInitiative,
+      ).toHaveBeenCalledWith(7);
+      expect(res.status).toBe(HttpStatus.NOT_FOUND);
+    });
+
+    it('returns OK with data when found', async () => {
+      const data = [{ id: 2 }];
+      (repo.getAllInitiativesWithoutCurrentInitiative as any).mockResolvedValue(
+        data,
+      );
+      const res = await service.getAllInitiativesWithoutCurrentInitiative(3);
+      expect(res.status).toBe(HttpStatus.OK);
+      expect(res.response).toEqual(data);
+    });
+  });
+
+  describe('getByPortfolio', () => {
+    it('p22 filters only by portfolio_id', async () => {
+      (repo.find as any).mockResolvedValue([{ id: 1 }]);
+      const res = await service.getByPortfolio('p22');
+      expect(repo.find).toHaveBeenCalled();
+      const args = (repo.find as jest.Mock).mock.calls[0][0];
+      expect(args.where).toEqual({ portfolio_id: 2 });
+      expect(res.status).toBe(HttpStatus.OK);
+      expect(res.response).toEqual([{ id: 1 }]);
+    });
+
+    it('p25 adds cgiar_entity_type_id IN(22,23,24)', async () => {
+      (repo.find as any).mockResolvedValue([{ id: 2 }]);
+      const res = await service.getByPortfolio('p25');
+      expect(repo.find).toHaveBeenCalled();
+      const args = (repo.find as jest.Mock).mock.calls[0][0];
+      expect(args.where.portfolio_id).toBe(3);
+      // Ensure condition was added
+      expect('cgiar_entity_type_id' in args.where).toBe(true);
+      expect(res.status).toBe(HttpStatus.OK);
+      expect(res.response).toEqual([{ id: 2 }]);
+    });
+
+    it('invalid portfolio returns BAD_REQUEST via handler', async () => {
+      const res = await service.getByPortfolio('foo');
+      expect(res.status).toBe(HttpStatus.BAD_REQUEST);
+      expect(repo.find).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/onecgiar-pr-server/src/clarisa/clarisa-initiatives/clarisa-initiatives.service.spec.ts
+++ b/onecgiar-pr-server/src/clarisa/clarisa-initiatives/clarisa-initiatives.service.spec.ts
@@ -65,16 +65,18 @@ describe('ClarisaInitiativesService', () => {
       expect(res.status).toBe(HttpStatus.OK);
       expect(res.response).toEqual(data);
     });
-    
+
     it('filters by portfolio when provided (p22)', async () => {
       (repo.getAllInitiativesWithoutCurrentInitiative as any).mockResolvedValue(
         [{ id: 1 }],
       );
-      const res = await service.getAllInitiativesWithoutCurrentInitiative(10, 'p22');
-      expect(repo.getAllInitiativesWithoutCurrentInitiative).toHaveBeenCalledWith(
+      const res = await service.getAllInitiativesWithoutCurrentInitiative(
         10,
-        2,
+        'p22',
       );
+      expect(
+        repo.getAllInitiativesWithoutCurrentInitiative,
+      ).toHaveBeenCalledWith(10, 2);
       expect(res.status).toBe(HttpStatus.OK);
     });
 
@@ -82,11 +84,13 @@ describe('ClarisaInitiativesService', () => {
       (repo.getAllInitiativesWithoutCurrentInitiative as any).mockResolvedValue(
         [{ id: 1 }],
       );
-      const res = await service.getAllInitiativesWithoutCurrentInitiative(10, 'p25');
-      expect(repo.getAllInitiativesWithoutCurrentInitiative).toHaveBeenCalledWith(
+      const res = await service.getAllInitiativesWithoutCurrentInitiative(
         10,
-        3,
+        'p25',
       );
+      expect(
+        repo.getAllInitiativesWithoutCurrentInitiative,
+      ).toHaveBeenCalledWith(10, 3);
       expect(res.status).toBe(HttpStatus.OK);
     });
   });

--- a/onecgiar-pr-server/src/clarisa/clarisa-initiatives/clarisa-initiatives.service.ts
+++ b/onecgiar-pr-server/src/clarisa/clarisa-initiatives/clarisa-initiatives.service.ts
@@ -1,6 +1,12 @@
 import { Injectable, HttpStatus } from '@nestjs/common';
+import { In } from 'typeorm';
 import { HandlersError } from '../../shared/handlers/error.utils';
 import { ClarisaInitiativesRepository } from './ClarisaInitiatives.repository';
+
+type InitiativeWhere = {
+  portfolio_id: number;
+  cgiar_entity_type_id?: ReturnType<typeof In>;
+};
 
 @Injectable()
 export class ClarisaInitiativesService {
@@ -61,8 +67,13 @@ export class ClarisaInitiativesService {
         };
       }
 
+      const where: InitiativeWhere = { portfolio_id };
+      if (key === 'p25') {
+        where.cgiar_entity_type_id = In([22, 23, 24]);
+      }
+
       const items = await this._clarisaInitiativesRepository.find({
-        where: { portfolio_id },
+        where,
         order: { id: 'ASC' },
         relations: ['obj_cgiar_entity_type'],
       });

--- a/onecgiar-pr-server/src/clarisa/clarisa-initiatives/clarisa-initiatives.service.ts
+++ b/onecgiar-pr-server/src/clarisa/clarisa-initiatives/clarisa-initiatives.service.ts
@@ -15,11 +15,19 @@ export class ClarisaInitiativesService {
     private readonly _clarisaInitiativesRepository: ClarisaInitiativesRepository,
   ) {}
 
-  async getAllInitiativesWithoutCurrentInitiative(resultId: number) {
+  async getAllInitiativesWithoutCurrentInitiative(
+    resultId: number,
+    portfolio?: string,
+  ) {
     try {
+      const key = (portfolio || '').toString().toLowerCase();
+      const map: Record<string, number> = { p22: 2, p25: 3 };
+      const portfolio_id = map[key];
+
       const initiative =
         await this._clarisaInitiativesRepository.getAllInitiativesWithoutCurrentInitiative(
           resultId,
+          portfolio_id,
         );
       if (!initiative.length) {
         throw {


### PR DESCRIPTION
This pull request introduces internationalized terminology for CGIAR entities across the IPSR contributors and innovation use pathway pages. The changes ensure that terms like "Initiative" and related labels are dynamically rendered based on the selected portfolio, supporting both legacy and new terminology. Additionally, the terminology logic is now thoroughly tested, and the new term pipe is integrated throughout the relevant modules and specs.

**Internationalization and Dynamic Terminology:**
* Updated UI labels in `ipsr-contributors-toc.component.html` and `step-n1.component.html` to use the `TermPipe`, so terms like "Initiative" are dynamically translated based on the current portfolio context. [[1]](diffhunk://#diff-26f5017e54fc72729305bf1acc4d7508ba4d683a42d17856aff59737d14a6066L1-R20) [[2]](diffhunk://#diff-e47ade324abdcdf38c1e52e8a94e6a8eaf992e152f9d4ae02e5f431d79103e23L2-R8)
* Refactored `TermPipe` in `term.pipe.ts` to remove dependency on `DataControlService`, making portfolio acronym an explicit parameter for transformation.
* Injected `TermPipe` into IPSR contributors components and modules, ensuring term translation is available in templates and tests. [[1]](diffhunk://#diff-98730cd8a79222e018a251519a552e8e7c4bd40dc2844bc7b39a5ac177385457R12-R22) [[2]](diffhunk://#diff-390a4e0a93a8303b7b6b659e05106564a4dd6bec8a2ec7c6b9d84838a2f200f3R17) [[3]](diffhunk://#diff-390a4e0a93a8303b7b6b659e05106564a4dd6bec8a2ec7c6b9d84838a2f200f3L83-R84) [[4]](diffhunk://#diff-76bc51a66f578e31a0e84fef87039348ac236a6d56ed45fd38b1e988e65118efR9-R43) [[5]](diffhunk://#diff-76bc51a66f578e31a0e84fef87039348ac236a6d56ed45fd38b1e988e65118efL64-R67) [[6]](diffhunk://#diff-76bc51a66f578e31a0e84fef87039348ac236a6d56ed45fd38b1e988e65118efL97-R100)

**Service and Data Flow Updates:**
* Modified `IpsrContributorsTocComponent` to inject `IpsrDataControlService` and fetch contributing initiatives using the correct portfolio context, ensuring data and terminology are consistent. [[1]](diffhunk://#diff-36b3881a67b0002c855c94d024e16825919b8d58fb4fb2d687098eb2e9f5091bR5) [[2]](diffhunk://#diff-36b3881a67b0002c855c94d024e16825919b8d58fb4fb2d687098eb2e9f5091bL17-R33)

**Testing and Coverage:**
* Added comprehensive unit tests for both `TermPipe` and `TerminologyService`, covering all edge cases, portfolio values, and dictionary behaviors. This ensures robust and predictable internationalization logic. [[1]](diffhunk://#diff-60fec19e5e4cc3025efb1edc0ee7e6934d2ade6c5ab916dd3b28780afbd91d89R1-R150) [[2]](diffhunk://#diff-2084be87af455469cd62973cbb8c4835624bcc579310ba715932b500b40e8364R1-R212)

**Minor Cleanup:**
* Removed unused CSS class from `step-n1-experts.component.scss` for code cleanliness.