### PR TITLE
* Feat primary initiative budgets and P25 phase change (V2 / same portfolio)

### DIFF
--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -1,7 +1,1 @@
-{
-  "plugins": {
-    "atlassian": {
-      "enabled": true
-    }
-  }
-}
+{}

--- a/onecgiar-pr-server/src/api/results/result_budget/repositories/result_initiative_budget.repository.ts
+++ b/onecgiar-pr-server/src/api/results/result_budget/repositories/result_initiative_budget.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { DataSource } from 'typeorm';
+import { DataSource, EntityManager } from 'typeorm';
 import { HandlersError } from '../../../../shared/handlers/error.utils';
 import { ResultInitiativeBudget } from '../entities/result_initiative_budget.entity';
 import {
@@ -9,6 +9,7 @@ import {
 import { predeterminedDateValidation } from '../../../../shared/utils/versioning.utils';
 import { LogicalDelete } from '../../../../shared/globalInterfaces/delete.interface';
 import { BaseRepository } from '../../../../shared/extendsGlobalDTO/base-repository';
+import { TokenDto } from '../../../../shared/globalInterfaces/token.dto';
 
 @Injectable()
 export class ResultInitiativeBudgetRepository
@@ -96,6 +97,44 @@ export class ResultInitiativeBudgetRepository
            `,
     };
   }
+  /**
+   * Ensures each active primary initiative row on the result has at least one active budget row.
+   * Used after cross-portfolio V2 (P22→P25) and as a safety net when replicate inserts none.
+   */
+  async ensureMissingBudgetsForPrimaryInitiatives(
+    manager: EntityManager,
+    newResultId: number,
+    user: TokenDto,
+    predeterminedDate?: Date,
+  ): Promise<void> {
+    const createdDate = predeterminedDateValidation(predeterminedDate);
+    const sql = `
+      INSERT INTO result_initiative_budget (
+        created_date
+        ,created_by
+        ,is_active
+        ,last_updated_by
+        ,result_initiative_id
+      )
+      SELECT
+        ${createdDate}
+        ,${user.id}
+        ,1
+        ,${user.id}
+        ,rbi.id
+      FROM results_by_inititiative rbi
+      WHERE rbi.result_id = ${newResultId}
+        AND rbi.is_active > 0
+        AND rbi.initiative_role_id = 1
+        AND NOT EXISTS (
+          SELECT 1 FROM result_initiative_budget rib
+          WHERE rib.result_initiative_id = rbi.id
+            AND rib.is_active > 0
+        )
+    `;
+    await manager.query(sql);
+  }
+
   constructor(
     private dataSource: DataSource,
     private readonly _handlersError: HandlersError,

--- a/onecgiar-pr-server/src/api/results/results_by_inititiatives/resultByInitiatives.repository.ts
+++ b/onecgiar-pr-server/src/api/results/results_by_inititiatives/resultByInitiatives.repository.ts
@@ -19,6 +19,17 @@ export class ResultByInitiativesRepository
   createQueries(
     config: ReplicableConfigInterface<ResultsByInititiative>,
   ): ConfigCustomQueryInterface {
+    const v2CrossPortfolio =
+      config?.entity_id != null && config?.same_portfolio_phase_change !== true;
+    const v2SamePortfolio =
+      config?.entity_id != null && config?.same_portfolio_phase_change === true;
+    const initiativeIdSql = v2CrossPortfolio
+      ? `${config.entity_id}`
+      : 'rbi.inititiative_id';
+    const initiativeRoleFilter = v2SamePortfolio
+      ? ''
+      : 'and rbi.initiative_role_id = 1';
+
     return {
       findQuery: `
       select 
@@ -26,7 +37,7 @@ export class ResultByInitiativesRepository
         rbi.is_active,
         null as last_updated_date,
         ${config.new_result_id} as result_id,
-        ${config?.entity_id ?? 'rbi.inititiative_id'},
+        ${initiativeIdSql},
         rbi.initiative_role_id,
         ${config.user.id} as created_by,
         null as last_updated_by,
@@ -34,6 +45,7 @@ export class ResultByInitiativesRepository
       from results_by_inititiative rbi
       where rbi.result_id = ${config.old_result_id}
         and rbi.is_active > 0
+        ${initiativeRoleFilter}
     `,
       insertQuery: `
       insert into results_by_inititiative (
@@ -50,7 +62,7 @@ export class ResultByInitiativesRepository
         rbi.is_active,
         null as last_updated_date,
         ${config.new_result_id} as result_id,
-        ${config?.entity_id ?? 'rbi.inititiative_id'},
+        ${initiativeIdSql},
         rbi.initiative_role_id,
         ${config.user.id} as created_by,
         null as last_updated_by,
@@ -58,7 +70,7 @@ export class ResultByInitiativesRepository
       from results_by_inititiative rbi
       where rbi.result_id = ${config.old_result_id}
         and rbi.is_active > 0
-        and rbi.initiative_role_id = 1
+        ${initiativeRoleFilter}
     `,
       returnQuery: `select * from results_by_inititiative rbi where rbi.result_id = ${config.new_result_id} `,
     };

--- a/onecgiar-pr-server/src/api/versioning/versioning.service.spec.ts
+++ b/onecgiar-pr-server/src/api/versioning/versioning.service.spec.ts
@@ -78,6 +78,7 @@ import { ClarisaInitiativesRepository } from '../../clarisa/clarisa-initiatives/
 
 describe('VersioningService', () => {
   let service: VersioningService;
+  let testingModule: TestingModule;
   let resultRepository;
   let versionRepository;
 
@@ -88,7 +89,7 @@ describe('VersioningService', () => {
   muckResult.version_id = 2;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    testingModule = await Test.createTestingModule({
       providers: [
         VersioningService,
         VersionRepository,
@@ -100,7 +101,15 @@ describe('VersioningService', () => {
         NonPooledProjectRepository,
         ResultsCenterRepository,
         ResultsTocResultRepository,
-        ResultByInitiativesRepository,
+        {
+          provide: ResultByInitiativesRepository,
+          useValue: {
+            getOwnerInitiativeByResult: jest.fn().mockResolvedValue({
+              inititiative_id: 100,
+            }),
+            replicate: jest.fn().mockResolvedValue([]),
+          },
+        },
         ResultByIntitutionsRepository,
         ResultByInstitutionsByDeliveriesTypeRepository,
         ResultByIntitutionsTypeRepository,
@@ -127,7 +136,15 @@ describe('VersioningService', () => {
         ResultStatusRepository,
         ResultsActionAreaOutcomeRepository,
         ResultsTocTargetIndicatorRepository,
-        ResultInitiativeBudgetRepository,
+        {
+          provide: ResultInitiativeBudgetRepository,
+          useValue: {
+            replicate: jest.fn().mockResolvedValue([]),
+            ensureMissingBudgetsForPrimaryInitiatives: jest
+              .fn()
+              .mockResolvedValue(undefined),
+          },
+        },
         EvidenceSharepointRepository,
         EvidencesService,
         ShareResultRequestRepository,
@@ -150,7 +167,12 @@ describe('VersioningService', () => {
         ResultsByIpInnovationUseMeasureRepository,
         ResultsIpInstitutionTypeRepository,
         MQAPService,
-        ClarisaInitiativesRepository,
+        {
+          provide: ClarisaInitiativesRepository,
+          useValue: {
+            findOne: jest.fn().mockResolvedValue({ portfolio_id: 1 }),
+          },
+        },
         {
           provide: GlobalParameterCacheService,
           useValue: {
@@ -207,6 +229,7 @@ describe('VersioningService', () => {
             createEntityManager: jest.fn().mockReturnThis(),
             transaction: jest.fn().mockImplementation((cb) =>
               cb({
+                query: jest.fn().mockResolvedValue([]),
                 update: jest.fn().mockResolvedValue({}),
                 getRepository: jest.fn().mockReturnValue({
                   findOne: jest.fn().mockResolvedValue({}),
@@ -241,10 +264,10 @@ describe('VersioningService', () => {
       imports: [HttpModule, MQAPModule],
     }).compile();
 
-    service = module.get<VersioningService>(VersioningService);
+    service = testingModule.get<VersioningService>(VersioningService);
 
-    resultRepository = module.get<ResultRepository>(ResultRepository);
-    versionRepository = module.get<VersionRepository>(VersionRepository);
+    resultRepository = testingModule.get<ResultRepository>(ResultRepository);
+    versionRepository = testingModule.get<VersionRepository>(VersionRepository);
   });
 
   it('should throw an error if the result is not found', async () => {
@@ -267,6 +290,34 @@ describe('VersioningService', () => {
       ReturnResponseUtil.format({
         message: `Result ID: 2 is a Knowledge Product, this type of result is not possible to phase shift it contact support`,
         response: 2,
+        statusCode: HttpStatus.CONFLICT,
+      }),
+    );
+  });
+
+  it('should require V2 when primary submitter is already P25 (portfolio 3)', async () => {
+    const rbi = testingModule.get<ResultByInitiativesRepository>(
+      ResultByInitiativesRepository,
+    );
+    const clarisa = testingModule.get<ClarisaInitiativesRepository>(
+      ClarisaInitiativesRepository,
+    );
+    (rbi.getOwnerInitiativeByResult as jest.Mock).mockResolvedValueOnce({
+      inititiative_id: 200,
+    });
+    (clarisa.findOne as jest.Mock).mockResolvedValueOnce({
+      portfolio_id: 3,
+    });
+    resultRepository.findOne.mockResolvedValueOnce({
+      id: 3,
+      result_code: 3,
+      result_type_id: 5,
+      version_id: 2,
+    } as any);
+    await expect(service.versionProcess(3, {} as any)).rejects.toEqual(
+      ReturnResponseUtil.format({
+        message: `Results whose primary submitter is already a P25 CGIAR Program must use phase change with entityId (V2).`,
+        response: 3,
         statusCode: HttpStatus.CONFLICT,
       }),
     );

--- a/onecgiar-pr-server/src/api/versioning/versioning.service.ts
+++ b/onecgiar-pr-server/src/api/versioning/versioning.service.ts
@@ -148,7 +148,7 @@ export class VersioningService {
   }
 
   async setQaStatus(data: UpdateQaResults) {
-    if (!data?.results_id || !data?.results_id?.length) {
+    if (!data?.results_id?.length) {
       throw ReturnResponseUtil.format({
         message: `The results_id field is required`,
         response: null,
@@ -199,8 +199,17 @@ export class VersioningService {
           is_active: true,
         },
       });
-      return res ? false : true;
-    } catch (_error) {
+      return !res;
+    } catch (error: unknown) {
+      let detail = 'Unexpected error';
+      if (error instanceof Error) {
+        detail = error.message;
+      } else if (typeof error === 'string') {
+        detail = error;
+      }
+      this._logger.warn(
+        `$_genericValidation failed (result_code=${result_code}, phase_id=${phase_id}): ${detail}`,
+      );
       return false;
     }
   }
@@ -268,7 +277,7 @@ export class VersioningService {
         );
       }
 
-      switch (parseInt(`${result.result_type_id}`)) {
+      switch (Number.parseInt(`${result.result_type_id}`, 10)) {
         case 1:
           await this._resultsPolicyChangesRepository.replicate(manager, config);
           break;
@@ -355,8 +364,6 @@ export class VersioningService {
 
       return dataResult;
     });
-
-    //await this._resultsImpactAreaIndicatorRepository.replicable(config);
 
     this._logger.log(
       `REPORTING: The change of phase of result ${result.id} is completed correctly.`,
@@ -539,7 +546,6 @@ export class VersioningService {
           entity_id,
           same_portfolio_phase_change,
         );
-        break;
       case 2:
         return await this.$_phaseChangeIPSR(
           result,
@@ -548,7 +554,6 @@ export class VersioningService {
           entity_id,
           same_portfolio_phase_change,
         );
-        break;
       default:
         break;
     }
@@ -657,7 +662,7 @@ export class VersioningService {
       where: { id: entity_id, active: true },
     });
 
-    if (!entity || entity.portfolio_id !== PORTFOLIO_CGIAR_PROGRAMS_P25_ID) {
+    if (entity?.portfolio_id !== PORTFOLIO_CGIAR_PROGRAMS_P25_ID) {
       throw ReturnResponseUtil.format({
         message: `Replication is only allowed for entities with portfolio_id = ${PORTFOLIO_CGIAR_PROGRAMS_P25_ID}`,
         response: entity_id,
@@ -848,7 +853,7 @@ export class VersioningService {
       await this._versionRepository.$_getAllInovationDevToReplicate(phase);
 
     for (const r of results) {
-      if (this.$_genericValidation(r.result_code, phase.id)) {
+      if (await this.$_genericValidation(r.result_code, phase.id)) {
         await this.$_phaseChangeReporting(r, phase, user);
       }
     }

--- a/onecgiar-pr-server/src/api/versioning/versioning.service.ts
+++ b/onecgiar-pr-server/src/api/versioning/versioning.service.ts
@@ -64,6 +64,9 @@ import { ResultCountrySubnationalRepository } from '../results/result-countries-
 import { ResultAnswerRepository } from '../results/result-questions/repository/result-answers.repository';
 import { ClarisaInitiativesRepository } from '../../clarisa/clarisa-initiatives/ClarisaInitiatives.repository';
 
+/** Clarisa `clarisa_initiatives.portfolio_id` for CGIAR Programs (P25). */
+const PORTFOLIO_CGIAR_PROGRAMS_P25_ID = 3;
+
 @Injectable()
 export class VersioningService {
   private readonly _logger: Logger = new Logger(VersioningService.name);
@@ -207,6 +210,7 @@ export class VersioningService {
     phase: Version,
     user: TokenDto,
     entity_id?: number,
+    same_portfolio_phase_change?: boolean,
   ) {
     this._logger.log(
       `REPORTING: Phase change in the ${result.id} result to the phase [${phase.id}]:${phase.phase_name} .`,
@@ -242,16 +246,20 @@ export class VersioningService {
       );
       dataResult.result_code = result.result_code;
 
+      const isV2CrossPortfolio =
+        entity_id != null && same_portfolio_phase_change !== true;
+
       const config = {
         old_result_id: result.id,
         new_result_id: dataResult.id,
         phase: phase.id,
         user: user,
         entity_id: entity_id,
+        same_portfolio_phase_change: same_portfolio_phase_change,
       };
       await this._resultByInitiativesRepository.replicate(manager, config);
 
-      if (!entity_id) {
+      if (!isV2CrossPortfolio) {
         await this._shareResultRequestRepository.replicate(manager, config);
         await this._resultInitiativeBudgetRepository.replicate(manager, config);
         await this._resultNonPooledProjectBudgetRepository.replicate(
@@ -325,7 +333,7 @@ export class VersioningService {
       );
       await this._resultByIntitutionsTypeRepository.replicate(manager, config);
 
-      if (!entity_id) {
+      if (!isV2CrossPortfolio) {
         await this._resultInstitutionsBudgetRepository.replicate(
           manager,
           config,
@@ -338,6 +346,12 @@ export class VersioningService {
       await this._evidencesRepository.replicate(manager, config);
       await this._evidenceSharepointRepository.replicate(manager, config);
       await this._evidencesService.replicateSPFiles(config);
+
+      await this._resultInitiativeBudgetRepository.ensureMissingBudgetsForPrimaryInitiatives(
+        manager,
+        dataResult.id,
+        user,
+      );
 
       return dataResult;
     });
@@ -358,6 +372,7 @@ export class VersioningService {
     phase: Version,
     user: TokenDto,
     entity_id?: number,
+    same_portfolio_phase_change?: boolean,
   ) {
     this._logger.log(
       `IPSR: Phase change in the ${result.id} result to the phase [${phase.id}]:${phase.phase_name} .`,
@@ -402,6 +417,7 @@ export class VersioningService {
         new_ipsr_id: null,
         old_ipsr_id: null,
         entity_id: entity_id,
+        same_portfolio_phase_change: same_portfolio_phase_change,
       };
 
       const portfolioP25 = await this._versionRepository.findOne({
@@ -422,7 +438,10 @@ export class VersioningService {
 
       // RESULT
       await this._resultByInitiativesRepository.replicate(manager, config);
-      if (!portfolioP25) {
+      const shouldReplicateShareRequests =
+        (!config.entity_id && !portfolioP25) ||
+        (!!config.entity_id && config.same_portfolio_phase_change === true);
+      if (shouldReplicateShareRequests) {
         await this._shareResultRequestRepository.replicate(manager, config);
       }
       await this._nonPooledProjectRepository.replicate(manager, config);
@@ -439,7 +458,9 @@ export class VersioningService {
       await this._linkedResultRepository.replicate(manager, config);
       await this._evidencesRepository.replicate(manager, config);
       await this._resultActorRepository.replicate(manager, config);
-      if (!config?.entity_id) {
+      const shouldReplicateFullBudgets =
+        !config.entity_id || config.same_portfolio_phase_change === true;
+      if (shouldReplicateFullBudgets) {
         await this._resultInitiativeBudgetRepository.replicate(manager, config);
         await this._resultNonPooledProjectBudgetRepository.replicate(
           manager,
@@ -483,6 +504,12 @@ export class VersioningService {
       await this._resultsIpResultMeasuresRespository.replicate(manager, config);
       await this._resultsIpInstitutionTypeRepository.replicate(manager, config);
 
+      await this._resultInitiativeBudgetRepository.ensureMissingBudgetsForPrimaryInitiatives(
+        manager,
+        dataResult.id,
+        user,
+      );
+
       return dataResult;
     });
 
@@ -501,6 +528,7 @@ export class VersioningService {
     user: TokenDto,
     module_id: number,
     entity_id?: number,
+    same_portfolio_phase_change?: boolean,
   ) {
     switch (module_id) {
       case 1:
@@ -509,10 +537,17 @@ export class VersioningService {
           phase,
           user,
           entity_id,
+          same_portfolio_phase_change,
         );
         break;
       case 2:
-        return await this.$_phaseChangeIPSR(result, phase, user, entity_id);
+        return await this.$_phaseChangeIPSR(
+          result,
+          phase,
+          user,
+          entity_id,
+          same_portfolio_phase_change,
+        );
         break;
       default:
         break;
@@ -550,6 +585,26 @@ export class VersioningService {
     }
 
     const module_id = this.$_validationModule(legacy_result.result_type_id);
+
+    const ownerInitiative =
+      await this._resultByInitiativesRepository.getOwnerInitiativeByResult(
+        legacy_result.id,
+      );
+    if (ownerInitiative?.inititiative_id) {
+      const primaryPortfolio = await this._clarisaInitiativesRepository.findOne(
+        {
+          where: { id: ownerInitiative.inititiative_id },
+          select: { portfolio_id: true },
+        },
+      );
+      if (primaryPortfolio?.portfolio_id === PORTFOLIO_CGIAR_PROGRAMS_P25_ID) {
+        throw ReturnResponseUtil.format({
+          message: `Results whose primary submitter is already a P25 CGIAR Program must use phase change with entityId (V2).`,
+          response: legacy_result.id,
+          statusCode: HttpStatus.CONFLICT,
+        });
+      }
+    }
 
     const phase = await this._versionRepository.findOne({
       where: {
@@ -602,9 +657,9 @@ export class VersioningService {
       where: { id: entity_id, active: true },
     });
 
-    if (!entity || entity.portfolio_id !== 3) {
+    if (!entity || entity.portfolio_id !== PORTFOLIO_CGIAR_PROGRAMS_P25_ID) {
       throw ReturnResponseUtil.format({
-        message: `Replication is only allowed for entities with portfolio_id = 3`,
+        message: `Replication is only allowed for entities with portfolio_id = ${PORTFOLIO_CGIAR_PROGRAMS_P25_ID}`,
         response: entity_id,
         statusCode: HttpStatus.FORBIDDEN,
       });
@@ -657,6 +712,14 @@ export class VersioningService {
       });
     }
 
+    const primarySourceInitiative =
+      await this._clarisaInitiativesRepository.findOne({
+        where: { id: mainInitiative.initiative_id, active: true },
+        select: { id: true, portfolio_id: true },
+      });
+    const same_portfolio_phase_change =
+      primarySourceInitiative?.portfolio_id === PORTFOLIO_CGIAR_PROGRAMS_P25_ID;
+
     if (legacy_result.result_type_id == 6) {
       throw ReturnResponseUtil.format({
         message: `Result ID: ${result_id} is a Knowledge Product, this type of result is not possible to phase shift it contact support`,
@@ -691,6 +754,7 @@ export class VersioningService {
         user,
         module_id,
         entity_id,
+        same_portfolio_phase_change,
       );
       if (res?.error) {
         throw ReturnResponseUtil.format({

--- a/onecgiar-pr-server/src/shared/globalInterfaces/replicable.interface.ts
+++ b/onecgiar-pr-server/src/shared/globalInterfaces/replicable.interface.ts
@@ -13,6 +13,8 @@ export interface ReplicableConfigInterface<T> {
   new_ipsr_id?: number;
   old_ipsr_id?: number;
   entity_id?: number;
+  /** When using V2 (entity_id): true if the source result primary initiative is already P25 (portfolio_id = 3). */
+  same_portfolio_phase_change?: boolean;
   f?: {
     custonFunction?: (res: T | T[]) => T | T[];
     errorFunction?: (error: any) => void;


### PR DESCRIPTION
## Summary
  Improves **phase change** when using **V2 replication** (`entityId`) for **P25 (CGIAR Programs, portfolio_id = 3)** entities. It separates 
  **cross-portfolio** from **same-portfolio** moves and prevents active primary initiatives from ending up without a budget row.
  ## Key changes
  - **`same_portfolio_phase_change`**: new flag on `ReplicableConfigInterface` and phase-change paths in `VersioningService`, derived from the 
  primary initiative’s `portfolio_id` vs P25.
  - **`ResultByInitiativesRepository.createQueries`**: for V2 cross-portfolio vs same-portfolio, adjusts `inititiative_id` SQL and the 
  `initiative_role_id` filter (primary-only when applicable).
  - **Conditional replication**: for Reporting and IPSR, share requests, budgets, and related tables replicate based on `entity_id` and whether 
  the change is cross-portfolio (`isV2CrossPortfolio` / `shouldReplicateShareRequests` / `shouldReplicateFullBudgets`).
  - **`ensureMissingBudgetsForPrimaryInitiatives`** (`result_initiative_budget.repository`): after phase change, inserts missing 
  `result_initiative_budget` rows for each **active primary** with no active budget (P22→P25 and safety net if `replicate` inserts nothing).
  - **Validation**: if the result’s primary submitter is **already P25**, **legacy** phase change without `entityId` returns **409**; V2 with 
  `entityId` must be used.
  - **`PORTFOLIO_CGIAR_PROGRAMS_P25_ID = 3`** constant instead of magic numbers in validation and messages.
  - **Tests** updated in `versioning.service.spec.ts`.
  ## Files touched
  - `versioning.service.ts`, `versioning.service.spec.ts`
  - `result_initiative_budget.repository.ts`, `resultByInitiatives.repository.ts`
  - `replicable.interface.ts`
  - `.cursor/settings.json` (IDE settings; consider a separate PR if you want a clean feature diff)
  ## Suggested verification
  - [x] Unit tests for versioning (`versioning.service.spec.ts`)
  - [x] Manual / QA: V2 phase change for results whose primary is P25 vs not P25, and check `result_initiative_budget` rows