### PR TITLE
* Feat Bilateral summaries, Innovation Development questionnaire, and results list filters

### DIFF
--- a/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/components/results-list-filters/results-list-filters.component.html
+++ b/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/components/results-list-filters/results-list-filters.component.html
@@ -73,6 +73,7 @@
       icon="pi pi-download"
       (click)="onDownLoadTableAsExcel()"
       (keydown.enter)="onDownLoadTableAsExcel()"
+      [disabled]="!hasFilteredResults"
       [loading]="this.gettingReport()" />
   </div>
 </div>

--- a/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/components/results-list-filters/results-list-filters.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/components/results-list-filters/results-list-filters.component.spec.ts
@@ -281,18 +281,28 @@ describe('ResultsListFiltersComponent', () => {
     });
   });
 
-  it('onSelectPhases should NOT filter submittersOptions (portfolios control filtering now)', () => {
-    // Set up initial submittersOptions from beforeEach initialization
-    const initialSubmittersOptions = mockResultsListFilterService.submittersOptions();
-
-    component.tempSelectedPhases.set([{ portfolio_id: 2 } as any]);
+  it('onSelectPhases should filter admin submitters by selected phase portfolio', () => {
+    mockResultsListFilterService.submittersOptionsAdminOld.set(createMockAdminSubmittersOptions());
+    component.tempSelectedPhases.set([{ id: 102, portfolio_id: 2 } as any]);
+    component.tempSelectedSubmittersAdmin.set([
+      { id: 1, name: 'Admin User A', portfolio_id: 1 },
+      { id: 2, name: 'Admin User B', portfolio_id: 2 }
+    ] as any);
 
     component.onSelectPhases();
 
-    // submittersOptions should remain completely unchanged (phases don't affect submitters anymore)
-    expect(mockResultsListFilterService.submittersOptions()).toEqual(initialSubmittersOptions);
-    // submittersOptions is not initialized anymore (empty array)
-    expect(mockResultsListFilterService.submittersOptions()).toEqual([]);
+    expect(mockResultsListFilterService.submittersOptionsAdmin()).toEqual([{ id: 2, name: 'Admin User B', portfolio_id: 2 }]);
+    expect(component.tempSelectedSubmittersAdmin()).toEqual([{ id: 2, name: 'Admin User B', portfolio_id: 2 }]);
+  });
+
+  it('onSelectPhases should show all submitters when no phase and no portfolio are selected', () => {
+    mockResultsListFilterService.submittersOptionsAdminOld.set(createMockAdminSubmittersOptions());
+    component.tempSelectedPhases.set([]);
+    component.tempSelectedClarisaPortfolios.set([]);
+
+    component.onSelectPhases();
+
+    expect(mockResultsListFilterService.submittersOptionsAdmin()).toEqual(createMockAdminSubmittersOptions());
   });
 
   it('onDownLoadTableAsExcel should export and toggle gettingReport', done => {
@@ -989,13 +999,15 @@ describe('ResultsListFiltersComponent', () => {
       // Only portfolio 1 submitter should remain
       expect(component.tempSelectedSubmittersAdmin()).toEqual([{ id: 1, name: 'Admin User A', portfolio_id: 1 }]);
     });
+
   });
 
   describe('openFiltersDrawer', () => {
     it('should copy current filter values to temp signals and open drawer', () => {
+      mockResultsListFilterService.submittersOptionsAdminOld.set([{ id: 4, name: 'Admin User', portfolio_id: 1 }]);
       mockResultsListFilterService.selectedClarisaPortfolios.set([{ id: 1 }]);
       mockResultsListFilterService.selectedFundingSource.set([{ id: 2 }]);
-      mockResultsListFilterService.selectedPhases.set([{ id: 3 }]);
+      mockResultsListFilterService.selectedPhases.set([{ id: 3, portfolio_id: 1 }]);
       mockResultsListFilterService.selectedSubmittersAdmin.set([{ id: 4 }]);
       mockResultsListFilterService.selectedIndicatorCategories.set([{ id: 5 }]);
       mockResultsListFilterService.selectedStatus.set([{ id: 6 }]);
@@ -1005,7 +1017,7 @@ describe('ResultsListFiltersComponent', () => {
 
       expect(component.tempSelectedClarisaPortfolios()).toEqual([{ id: 1 }]);
       expect(component.tempSelectedFundingSource()).toEqual([{ id: 2 }]);
-      expect(component.tempSelectedPhases()).toEqual([{ id: 3 }]);
+      expect(component.tempSelectedPhases()).toEqual([{ id: 3, portfolio_id: 1 }]);
       expect(component.tempSelectedSubmittersAdmin()).toEqual([{ id: 4 }]);
       expect(component.tempSelectedIndicatorCategories()).toEqual([{ id: 5 }]);
       expect(component.tempSelectedStatus()).toEqual([{ id: 6 }]);

--- a/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/components/results-list-filters/results-list-filters.component.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/components/results-list-filters/results-list-filters.component.ts
@@ -188,6 +188,7 @@ export class ResultsListFiltersComponent implements OnInit, OnChanges, OnDestroy
   });
 
   @Input() isAdmin = false;
+  @Input() hasFilteredResults = true;
 
   constructor(
     public resultsListFilterSE: ResultsListFilterService,

--- a/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/components/results-list-filters/results-list-filters.component.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/components/results-list-filters/results-list-filters.component.ts
@@ -273,11 +273,14 @@ export class ResultsListFiltersComponent implements OnInit, OnChanges, OnDestroy
       this.resultsListFilterSE.phasesOptions().filter(item => this.api.dataControlSE?.reportingCurrentPhase?.portfolioId == item.portfolio_id)
     );
 
-    // Show all submitters initially (not filtered by phases)
-    this.resultsListFilterSE.submittersOptionsAdmin.set(this.resultsListFilterSE.submittersOptionsAdminOld());
-
-    // No submitters selected initially
-    this.resultsListFilterSE.selectedSubmittersAdmin.set([]);
+    const initialSubmitterOptions = this.getFilteredSubmitterOptions(
+      this.resultsListFilterSE.selectedPhases(),
+      this.resultsListFilterSE.selectedClarisaPortfolios()
+    );
+    this.resultsListFilterSE.submittersOptionsAdmin.set(initialSubmitterOptions);
+    this.resultsListFilterSE.selectedSubmittersAdmin.set(
+      this.resultsListFilterSE.selectedSubmittersAdmin().filter(submitter => initialSubmitterOptions.some(option => option.id === submitter.id))
+    );
   }
 
   private buildPhaseOptions(response: any[]) {
@@ -302,6 +305,25 @@ export class ResultsListFiltersComponent implements OnInit, OnChanges, OnDestroy
     }
     // Filter by selected portfolios
     return options.filter(item => selectedPortfolios.some(portfolio => portfolio.id == item.portfolio_id));
+  }
+
+  private getFilteredSubmitterOptions(selectedPhases: any[] = [], selectedPortfolios: any[] = []) {
+    const sourceOptions = this.resultsListFilterSE.submittersOptionsAdminOld();
+    if (selectedPhases.length > 0) {
+      return sourceOptions.filter(item => selectedPhases.some(phase => phase.portfolio_id == item.portfolio_id));
+    }
+    if (selectedPortfolios.length > 0) {
+      return sourceOptions.filter(item => selectedPortfolios.some(portfolio => portfolio.id == item.portfolio_id));
+    }
+    return sourceOptions;
+  }
+
+  private refreshTempSubmitterOptions() {
+    const filteredOptions = this.getFilteredSubmitterOptions(this.tempSelectedPhases(), this.tempSelectedClarisaPortfolios());
+    this.resultsListFilterSE.submittersOptionsAdmin.set(filteredOptions);
+    this.tempSelectedSubmittersAdmin.set(
+      this.tempSelectedSubmittersAdmin().filter(submitter => filteredOptions.some(option => option.id === submitter.id))
+    );
   }
 
   clearAllNewFilters() {
@@ -399,26 +421,11 @@ export class ResultsListFiltersComponent implements OnInit, OnChanges, OnDestroy
     // Reset phases if they don't match selected portfolios
     this.tempSelectedPhases.set(this.tempSelectedPhases().filter(phase => filteredPhases.some(p => p.id === phase.id)));
 
-    // Update submitter options based on selected portfolios (not phases)
-    this.resultsListFilterSE.submittersOptionsAdmin.set(
-      this.tempSelectedClarisaPortfolios().length === 0
-        ? this.resultsListFilterSE.submittersOptionsAdminOld()
-        : this.resultsListFilterSE
-            .submittersOptionsAdminOld()
-            .filter(item => this.tempSelectedClarisaPortfolios().some(portfolio => portfolio.id == item.portfolio_id))
-    );
-
-    // Don't reset selected submitters - they should remain if valid for the selected portfolios
-    this.tempSelectedSubmittersAdmin.set(
-      this.tempSelectedSubmittersAdmin().filter(submitter =>
-        this.resultsListFilterSE.submittersOptionsAdmin().some(option => option.id === submitter.id)
-      )
-    );
+    this.refreshTempSubmitterOptions();
   }
 
   onSelectPhases() {
-    // Phases selection no longer affects submitters
-    // Submitters are now filtered by portfolios only
+    this.refreshTempSubmitterOptions();
   }
 
   // Initialize temp values when opening the drawer
@@ -430,6 +437,7 @@ export class ResultsListFiltersComponent implements OnInit, OnChanges, OnDestroy
     this.tempSelectedIndicatorCategories.set([...this.resultsListFilterSE.selectedIndicatorCategories()]);
     this.tempSelectedStatus.set([...this.resultsListFilterSE.selectedStatus()]);
     this.tempSelectedLeadCenters.set([...this.resultsListFilterSE.selectedLeadCenters()]);
+    this.refreshTempSubmitterOptions();
     this.visible.set(true);
   }
 

--- a/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/results-list.component.html
+++ b/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/results-list.component.html
@@ -15,7 +15,7 @@
   <div class="title_section_header">Results table</div>
 
   <div>
-    <app-results-list-filters [isAdmin]="this.api.rolesSE.isAdmin"></app-results-list-filters>
+    <app-results-list-filters [isAdmin]="this.api.rolesSE.isAdmin" [hasFilteredResults]="(filteredResults?.length ?? 0) > 0"></app-results-list-filters>
   </div>
 
   <div class="action_buttons">

--- a/onecgiar-pr-server/docs/bilateral-result-summaries.en.md
+++ b/onecgiar-pr-server/docs/bilateral-result-summaries.en.md
@@ -256,6 +256,23 @@ Structured demand **without** internal ids:
 | `evidence_of_user_need_user_demand[]` | `{ link }` from evidence type user need / demand. |
 | `scaling_study_urls[]` | URLs when readiness is high enough to require scaling studies. |
 
+### `innovation_development_summary.innovation_development_questionnaire`
+
+**When:** same as above (`type === "innovation_development"`). Nested **inside** `innovation_development_summary` (not a sibling on `data`). If the core summary is `null` (e.g. inactive dev object), the API still returns an object that contains **only** `innovation_development_questionnaire` so the key remains discoverable.
+
+**Shape:** four arrays (one per thematic block). Each element is **`{ question, question_id, answer, selected_sub_options? }`**. Catalogue **option lines** (radio / checkbox labels) are **not** `question`; the PRMS **sub-question** or **section** prompt is `question`. **`answer`** may use `{ text }`, `{ boolean }`, and/or **`{ selections: string[] }`** (megatrends multi-select: one array element per ticked option). Macro blocks may join several labels in `answer.text` when applicable.
+
+| Field | Meaning |
+|-------|---------|
+| `responsible_innovation_and_scaling[]` | One row per answered **`q1`–`q4`** block: `question` / `question_id` = level-2 prompt; `answer.text` = label(s) of **selected** options only (`answer_boolean` true / `1`, or free text); optional `selected_sub_options` under those branches. |
+| `intellectual_property_rights[]` | Same pattern as responsible innovation (macro `q1`–`q4`). |
+| `innovation_team_diversity[]` | One row: parent section prompt + `answer.text` = **selected** row label(s); `selected_sub_options` only under selected rows. |
+| `megatrends[]` | At most **one** row: parent megatrends prompt + **`answer.selections`**: string array with **one entry per checked** megatrend (multi-select), not a single joined `text` field. |
+
+**`selected_sub_options`:** nested catalogue rows **selected** for this result (`answer_boolean` true / `1`, or non-empty `answer_text` on sub-rows). Omitted when empty. **Unselected** options (e.g. `false` only) are omitted from the payload.
+
+Portfolio **P25** uses the **V2** question set; otherwise legacy P22. On load failure, all four arrays are **empty** `[]`.
+
 ---
 
 ## 3. Innovation use — `innovation_use_summary`

--- a/onecgiar-pr-server/docs/bilateral-result-summaries.en.md
+++ b/onecgiar-pr-server/docs/bilateral-result-summaries.en.md
@@ -320,7 +320,7 @@ Structured demand **without** internal ids:
 | `policy_stage` | `{ id, name, definition }` from Clarisa policy stage. |
 | `linked_innovation_dev` / `linked_innovation_use` | Booleans: user indicated linkage to those result families. |
 | `result_related_to[]` | Each `{ parent_question, option_text }` for options ticked under **“Is this result related to”** (backed by `result_questions` + `result_answers`). Empty array if none. |
-| `institutions[]` | `{ id, name, acronym, institution_type_name }` for **implementing** org rows (PRMS role 4); `id` is the Clarisa institution id. |
+| `policy_implementing_organizations[]` | `{ id, name, acronym, institution_type_name }` for **implementing** org rows (PRMS role 4); `id` is the Clarisa institution id. |
 
 **Note:** Internal audit timestamps are **not** included on this summary; use core result fields elsewhere if needed.
 
@@ -339,7 +339,7 @@ Other bilateral-supported types (e.g. other output / other outcome) may **not** 
 | 2026 | Expanded **Common fields on `data`** with tables + reference JSON fragment (identity, TOC, geography, centres, DAC, status, evidences, links, etc.). |
 | 2026 | Policy change: `result_related_to` from `ResultQuestionsService`; removed duplicate engagement-only field from bilateral JSON. |
 | 2026 | Policy change & capacity sharing summaries: omit `created_date` / `last_updated_date` on the **type summary** object only (core `data` still carries result-level dates). |
-| 2026 | `leading_result` reflects `is_lead_by_partner` (partner vs centre); `last_submission` for status QA/Submitted; Clarisa `id` on policy type/stage, implementing orgs, innovation typology; KP summary = `handle` only; cap sharing `institutions` renamed to `on_behalf_organizations`. |
+| 2026 | `leading_result` reflects `is_lead_by_partner` (partner vs centre); `last_submission` for status QA/Submitted; Clarisa `id` on policy type/stage, implementing orgs, innovation typology; KP summary = `handle` only; cap sharing `institutions` renamed to `on_behalf_organizations`; policy change implementing orgs as `policy_implementing_organizations`. |
 
 ---
 

--- a/onecgiar-pr-server/docs/bilateral-result-summaries.en.md
+++ b/onecgiar-pr-server/docs/bilateral-result-summaries.en.md
@@ -1,0 +1,346 @@
+# Bilateral / list API — result payload summaries (English)
+
+This document describes the **type-specific summary objects** attached to a **Result** when it is returned through the bilateral list flow (after enrichment). It is written for a **mixed audience**: programme staff, data consumers, and engineers.
+
+---
+
+## How to read this
+
+- Each PRMS **result type** (indicator family) can expose one **summary** object on the result’s `data` object, in addition to a **large set of shared “core result” fields** (identity, status, geography, TOC, centres, evidence, DAC, links, etc.). Those commons are documented in the next section.
+- Summaries are **curated views**: they favour **labels and readable structures** over internal database IDs, where the product already has that pattern.
+- Field names below match the **JSON** property names returned by the API (`camelCase` unless noted).
+
+---
+
+## Wrapper shape (list entry)
+
+Each item in a list response typically looks like:
+
+| Property       | Meaning |
+|----------------|---------|
+| `type`         | String discriminator, e.g. `knowledge_product`, `capacity_sharing`, `innovation_development`, `innovation_use`, `policy_change`. |
+| `result_id`    | Numeric id of the result row. |
+| `data`         | Full enriched result document: common PRMS fields **plus** the summary for that type (when applicable). |
+
+---
+
+## Common fields on `data` (core result — all or many types)
+
+These fields sit on the same object as the type-specific `*_summary` (when present). They describe **the result record in PRMS**: what it is, where it applies, who leads it, how it scores on cross-cutting markers, and how to open it in reporting tools. They are **not** replaced by the type summary; the summary **adds** type-specific detail.
+
+### Identity, lifecycle, and reporting links
+
+| Property | Technical | Plain language |
+|----------|-----------|----------------|
+| `created_date` | Timestamp when the result row was created. | When this record first entered PRMS. |
+| `last_updated_date` | Timestamp of last structural/metadata update. | Last change to the result. |
+| `last_update_at` | Often mirrors last update; used for display/sorting. | “As of” moment for freshness. |
+| `result_code` | Stable public-facing numeric code for the result. | The number users see in reports and URLs. |
+| `is_active` | Soft-delete / validity flag. | Whether this version of the result is current. |
+| `year` | Reporting year context for the result. | Which reporting cycle it belongs to. |
+| `status_id` | Numeric workflow status id. | Where the result is in the submission workflow. |
+| `pdf_link` | URL to the PRMS PDF / report view for this result code. | One-click “report” view. |
+| `prms_link` | URL to the PRMS web UI for general information. | Deep link into the full result editor. |
+
+### Title, narrative, level, and indicator family
+
+| Property | Technical | Plain language |
+|----------|-----------|----------------|
+| `result_title` | Short title string (bilateral-friendly name). | Headline title of the result. |
+| `description` | Long text description. | What was achieved and how. |
+| `result_level` | `{ code, name, description }` from result level reference. | How “high” in the results chain this is (output, outcome, etc.). |
+| `indicator_category` | `{ code, name }` — maps to result type family for display. | Which indicator family this belongs to (e.g. Innovation use). |
+
+### Theory of change and primary initiative
+
+| Property | Technical | Plain language |
+|----------|-----------|----------------|
+| `toc_alignment[]` | Per contributing initiative: `entity` (official_code, name), `initiative_role` (e.g. primary submitter), `toc_results[]` with level, `sub_entity`, `result_name`. | How the result is tied to initiatives and ToC outcome statements. |
+| `primary_entity` | `{ official_code, name }` of the main initiative. | Which initiative “owns” or leads this result in the UI sense. |
+
+### Geography
+
+| Property | Technical | Plain language |
+|----------|-----------|----------------|
+| `geographic_focus` | `{ code, name, description }` — geographic scope type. | Whether work is national, regional, multi-national, etc. |
+| `regions[]` | Region objects (structure depends on data). | Broader geographic areas when used. |
+| `countries[]` | e.g. `{ code, name }` ISO-style country entries. | Countries where the result applies. |
+
+### Centres and partners
+
+| Property | Technical | Plain language |
+|----------|-----------|----------------|
+| `contributing_centers[]` | `{ code, name, acronym, is_lead }` per centre. | CGIAR centres involved; `is_lead` marks the lead centre. |
+| `contributing_partners[]` | Partner objects (structure depends on data). | Non-CGIAR or additional partners when captured. |
+| `leading_result` | `{ lead_kind, id, code, name, acronym }`. If `is_lead_by_partner` is true: **partner** lead from `results_by_institution` (Clarisa institution `id`, `code` null). If false: **centre** lead from `result_center_array` (`code` = Clarisa center code, `id` = linked Clarisa institution when present). | Who leads the result (partner vs centre), with stable Clarisa identifiers. |
+| `last_submission` | Present when `status_id` is **2** (Quality assessed) or **3** (Submitted): latest active `submission` row — `id`, `created_date`, `comment`, `status`, `status_id`, `submitted_by` (`user_id`, `first_name`, `last_name`). | When and by whom the result was last submitted in that workflow state. |
+| `lead_contact_person` | Contact object or `null`. | Named focal point when stored. |
+
+**May also appear (bilateral enrichment):** `result_by_institution_array` — slim partner list for bilateral contexts; `obj_results_toc_result` — raw ToC mapping rows before or alongside `toc_alignment`, depending on serializer.
+
+### DAC cross-cutting scores
+
+| Property | Technical | Plain language |
+|----------|-----------|----------------|
+| `dac_scores` | Object with keys `gender`, `climate_change`, `nutrition`, `environmental_biodiversity`, `poverty`. Each: `tag_title` (e.g. significance level text) and `impact_area_names[]` when applicable. | How the result targets SDG-aligned themes; nutrition can list impact areas such as “Food Security”. |
+
+### Workflow status object
+
+| Property | Technical | Plain language |
+|----------|-----------|----------------|
+| `obj_status` | `{ result_status_id, status_name, status_description }`. | Human-readable submission state (e.g. Submitted). |
+
+### Evidence (main links)
+
+| Property | Technical | Plain language |
+|----------|-----------|----------------|
+| `evidences[]` | `{ link, description }` per main evidence row (slim export). | Proof or references attached to the result. *Some pipelines may still expose the richer `evidence_array` from the ORM before mapping to this slim list.* |
+
+### Bilateral projects and who created the record
+
+| Property | Technical | Plain language |
+|----------|-----------|----------------|
+| `bilateral_projects[]` | Bilateral grant / project summaries tied to the result. | Which bilateral-funded projects are linked. |
+| `created_by` | `{ first_name, last_name, email }` (submitter / creator). | Who created or owns the record in PRMS. |
+| `source` | Source enum string (e.g. `Result`). | Where the data came from (PRMS vs API). |
+| `source_definition` | Human-readable source qualifier (e.g. W1/W2). | Funding / reporting stream label when set. |
+
+### Reference fragment (realistic shape)
+
+The following is an **illustrative fragment** of `data` showing how commons compose (values are examples only):
+
+```json
+{
+  "created_date": "2026-03-20T07:29:33.151Z",
+  "last_updated_date": "2026-03-24T13:08:43.000Z",
+  "result_code": 28738,
+  "status_id": 3,
+  "year": 2025,
+  "pdf_link": "https://reporting.cgiar.org/reports/result-details/28738?phase=6",
+  "prms_link": "https://reporting.cgiar.org/result/result-detail/28738/general-information?phase=6",
+  "last_update_at": "2026-03-24T13:08:43.000Z",
+  "is_active": true,
+  "result_title": "…",
+  "description": "…",
+  "result_level": { "code": 3, "name": "Outcome", "description": "…" },
+  "indicator_category": { "code": 2, "name": "Innovation use" },
+  "toc_alignment": [
+    {
+      "entity": { "official_code": "SP09", "name": "Scaling for Impact" },
+      "initiative_role": "Primary submitter",
+      "toc_results": [
+        {
+          "level": "2030 Outcome",
+          "sub_entity": { "official_code": "SP09", "description": null },
+          "result_name": "2030-OC 2: …"
+        }
+      ]
+    }
+  ],
+  "geographic_focus": { "code": 3, "name": "Multi-national", "description": "…" },
+  "regions": [],
+  "countries": [{ "code": "BD", "name": "Bangladesh" }],
+  "contributing_centers": [
+    {
+      "code": "CENTER-15",
+      "name": "WorldFish",
+      "acronym": "WorldFish",
+      "is_lead": true
+    }
+  ],
+  "contributing_partners": [],
+  "dac_scores": {
+    "gender": { "tag_title": "(1) Significant", "impact_area_names": [] },
+    "climate_change": { "tag_title": "(0) Not targeted", "impact_area_names": [] },
+    "nutrition": {
+      "tag_title": "(2) Principal",
+      "impact_area_names": ["Food Security"]
+    },
+    "environmental_biodiversity": {
+      "tag_title": "(0) Not targeted",
+      "impact_area_names": []
+    },
+    "poverty": { "tag_title": "(1) Significant", "impact_area_names": [] }
+  },
+  "obj_status": {
+    "result_status_id": "3",
+    "status_name": "Submitted",
+    "status_description": null
+  },
+  "bilateral_projects": [],
+  "evidences": [{ "link": "https://…", "description": null }],
+  "primary_entity": { "official_code": "SP09", "name": "Scaling for Impact" },
+  "created_by": {
+    "first_name": "Justin",
+    "last_name": "Dela Rueda",
+    "email": "j.delarueda@cgiar.org"
+  },
+  "source": "Result",
+  "source_definition": "W1/W2",
+  "leading_result": {
+    "lead_kind": "center",
+    "id": 12345,
+    "code": "CENTER-15",
+    "name": "WorldFish",
+    "acronym": "WorldFish"
+  },
+  "last_submission": {
+    "id": 901,
+    "created_date": "2026-03-22T10:00:00.000Z",
+    "comment": null,
+    "status": true,
+    "status_id": 3,
+    "submitted_by": {
+      "user_id": 42,
+      "first_name": "Jane",
+      "last_name": "Doe"
+    }
+  },
+  "lead_contact_person": null
+}
+```
+
+Exact field set can vary slightly by **result type**, **phase**, and **serializer**; type-specific summaries are documented in the sections below.
+
+---
+
+## 1. Knowledge product — `knowledge_product_summary`
+
+**When:** `type === "knowledge_product"` (result type id = Knowledge product).
+
+**Purpose:** Exposes the stable **handle** only for bilateral / discovery consumers.
+
+| Field | Technical | Non-technical |
+|-------|-----------|----------------|
+| `handle` | CGSpace / product handle. | Stable public identifier string. |
+
+**Note:** The heavy `result_knowledge_product_array` tree is **removed** from `data` after enrichment and replaced by this summary.
+
+---
+
+## 2. Innovation development — `innovation_development_summary`
+
+**When:** `type === "innovation_development"`.
+
+**Purpose:** Innovation profile (typology, readiness, who develops it) plus **anticipated user demand** and **budget / evidence** blocks aligned with PRMS.
+
+### Core (innovation card)
+
+| Field | Meaning |
+|-------|---------|
+| `short_name` | Short title of the innovation. |
+| `characterization` | `{ id, name, definition }` from Clarisa characteristic. |
+| `typology` | `{ id, code, name, definition }` — Clarisa innovation type (`id` matches `code`, the table primary key). |
+| `innovation_user_to_be_determined` | Boolean: totals TBD vs detailed demand captured. |
+| `innovation_developers` / `innovation_collaborators` | Free text fields from PRMS. |
+| `innovation_readiness_level` | `{ id, level, name, definition }` — TRL-style scale. |
+| `evidences_justification` | Text justification for evidence. |
+| `has_scaling_studies` | Boolean flag. |
+
+### `anticipated_user_demand`
+
+Structured demand **without** internal ids:
+
+- **`actors[]`**: actor type name, optional `other_actor_type`, sex/age disaggregation flag, `addressing_demands`; if not disaggregated, boolean flags `has_women`, `has_women_youth`, `has_men`, `has_men_youth`.
+- **`organizations[]`**: institution type name, `addressing_demands`, optional `other_institution` for “Other” type.
+- **`measures[]`**: `unit_of_measure`, `quantity`, `addressing_demands`.
+
+### Budgets and evidence (shared pattern with Innovation use budgets)
+
+| Field | Meaning |
+|-------|---------|
+| `initiative_budget[]` | Per contributing initiative: codes, names, year amounts, `kind_cash`, `is_determined`. |
+| `bilateral_project_budget[]` | Per bilateral project: short name, cash/in-kind splits, `is_determined`. |
+| `partner_budget[]` | Per partner institution budget line. |
+| `reference_materials[]` | `{ link }` from evidence type “materials”. |
+| `evidence_of_user_need_user_demand[]` | `{ link }` from evidence type user need / demand. |
+| `scaling_study_urls[]` | URLs when readiness is high enough to require scaling studies. |
+
+---
+
+## 3. Innovation use — `innovation_use_summary`
+
+**When:** `type === "innovation_use"`.
+
+**Purpose:** Current vs 2030 use sections, **use level** from Clarisa, links to other results, budgets — **without** the Inno Dev–style reference / user-need evidence links (those two arrays are **omitted** here by design).
+
+### Linkage and flags
+
+| Field | Meaning |
+|-------|---------|
+| `has_innovation_link` | Whether the result is flagged as linked to another innovation. |
+| `linked_results[]` | `{ result_id, title, result_type_id, result_type_name }` for linked CGIAR results. |
+| `innov_use_to_be_determined` | If `true`, headline counts only; if `false`, detailed `current_section` is populated. |
+| `current_core_innovation_use_supported_by_evidence` | When “to be determined” is **true**: `{ male_using, female_using }`. |
+| `current_section` | When “to be determined” is **false**: actors, organisations, quantitative measures for **reporting year** (`section_id = 1`). |
+| `innovation_use_level` | `{ id, level, name, definition }` — evidence-based use level. |
+| `readiness_level_explanation` | Free text. |
+| `has_scaling_studies` / `scaling_study_urls` | Same idea as Inno Dev when use level ≥ threshold. |
+| `innov_use_2030_to_be_determined` | If **false**, `innovation_use_2030_section` holds 2030 block (`section_id = 2`). |
+
+### `current_section` / `innovation_use_2030_section` (when present)
+
+- **`actors[]`**: if sex/age disaggregated → `how_many`; else `women`, `women_youth`, `men`, `men_youth`, plus type and `addressing_demands`.
+- **`organizations[]`**: type name, `how_many`, `graduate_students`, `addressing_demands`, optional `other_institution`.
+- **`other_quantitative[]`**: `unit_of_measure`, `quantity`, `addressing_demands`.
+
+### Budgets (same structure as Inno Dev)
+
+`initiative_budget`, `bilateral_project_budget`, `partner_budget` only — **no** `reference_materials` or `evidence_of_user_need_user_demand` on Innovation use bilateral summary.
+
+---
+
+## 4. Capacity sharing for development — `capacity_development_summary`
+
+**When:** `type === "capacity_sharing"`.
+
+**Purpose:** Training / cap dev numbers, delivery mode, training length, and **implementing organisations** (same business rules as the summary service).
+
+| Field | Meaning |
+|-------|---------|
+| `male_using`, `female_using`, `non_binary_using`, `has_unkown_using` | Participant counts (numbers or null). |
+| `is_attending_for_organization` | Whether trainees attended on behalf of an organisation. |
+| `delivery_method` | `{ name, description }` resolved from cap dev delivery methods (no raw FK in the payload). |
+| `training_length` | `{ name, term, description }` from the cap dev **term** catalogue (length of training). |
+| `on_behalf_organizations[]` | `{ id, name, acronym, institution_type_name }` for **implementing** org rows (PRMS role 3); `id` is the Clarisa institution id. |
+
+---
+
+## 5. Policy change — `policy_change_summary`
+
+**When:** `type === "policy_change"`.
+
+**Purpose:** Policy type and stage as **readable Clarisa objects**, financial amount status, links to innovation flags, **“Is this result related to”** selections from the question engine, and implementing organisations.
+
+| Field | Meaning |
+|-------|---------|
+| `amount` | Policy-related USD amount when applicable (number or null). |
+| `amount_status_label` | Human label: `Confirmed`, `Estimated`, or `Unknown` (from internal status code). |
+| `policy_type` | `{ id, name, definition }` from Clarisa policy type. |
+| `policy_stage` | `{ id, name, definition }` from Clarisa policy stage. |
+| `linked_innovation_dev` / `linked_innovation_use` | Booleans: user indicated linkage to those result families. |
+| `result_related_to[]` | Each `{ parent_question, option_text }` for options ticked under **“Is this result related to”** (backed by `result_questions` + `result_answers`). Empty array if none. |
+| `institutions[]` | `{ id, name, acronym, institution_type_name }` for **implementing** org rows (PRMS role 4); `id` is the Clarisa institution id. |
+
+**Note:** Internal audit timestamps are **not** included on this summary; use core result fields elsewhere if needed.
+
+---
+
+## Types without a dedicated summary in this flow
+
+Other bilateral-supported types (e.g. other output / other outcome) may **not** add a `*_summary` object; they still receive the **shared** enrichment on `data`.
+
+---
+
+## Change log (maintainers)
+
+| Date (approx.) | Change |
+|----------------|--------|
+| 2026 | Expanded **Common fields on `data`** with tables + reference JSON fragment (identity, TOC, geography, centres, DAC, status, evidences, links, etc.). |
+| 2026 | Policy change: `result_related_to` from `ResultQuestionsService`; removed duplicate engagement-only field from bilateral JSON. |
+| 2026 | Policy change & capacity sharing summaries: omit `created_date` / `last_updated_date` on the **type summary** object only (core `data` still carries result-level dates). |
+| 2026 | `leading_result` reflects `is_lead_by_partner` (partner vs centre); `last_submission` for status QA/Submitted; Clarisa `id` on policy type/stage, implementing orgs, innovation typology; KP summary = `handle` only; cap sharing `institutions` renamed to `on_behalf_organizations`. |
+
+---
+
+*Generated from server implementation in `bilateral.service.ts` (`enrichBilateralResultResponse` and related builders). If the API diverges, treat this file as documentation debt and update it alongside code changes.*

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.controller.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.controller.ts
@@ -67,7 +67,7 @@ export class BilateralController {
   @ApiOperation({
     summary: 'List all results with pagination and filters',
     description:
-      'Returns all registered results with pagination (page, limit), filter by source (Result/W1/W2 or API/W3/Bilateral), portfolio acronym (e.g. P22, P25), phase year, status (id or name), dates (created/last_updated), leading center (id or acronym), initiative official_code (results where that initiative is the lead), and search by title. Limit is capped for robustness.',
+      'Returns all registered results with pagination (page, limit), filter by source (Result/W1/W2 or API/W3/Bilateral), portfolio acronym (e.g. P22, P25), phase year, status (id or name), dates (created/last_updated), leading center (id or acronym), initiative official_code (results where that initiative is the lead), and search by title. Limit is capped for robustness. Each item includes type-specific summaries on `data`; Innovation Development rows include `innovation_development_summary.innovation_development_questionnaire` (four arrays of `{ question, question_id, answer, selected_sub_options? }`; megatrends multi-select uses `answer.selections[]` one per checked option; P25 uses V2 catalog).',
   })
   @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
   @ApiQuery({ name: 'limit', required: false, type: Number, example: 10 })

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.controller.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.controller.ts
@@ -4,7 +4,6 @@ import {
   Get,
   Param,
   ParseIntPipe,
-  Patch,
   Post,
   Query,
   UseInterceptors,
@@ -43,38 +42,6 @@ export class BilateralController {
     body: RootResultsDto,
   ) {
     return this.bilateralService.create(body);
-  }
-
-  @Patch('update/:id')
-  @ApiOperation({
-    summary: 'Update bilateral result',
-    description:
-      'Updates an existing bilateral-created result. Body is identical to the create payload.',
-  })
-  @ApiParam({ name: 'id', type: Number, required: true })
-  @ApiBody({ type: RootResultsDto })
-  async update(
-    @Param('id', ParseIntPipe) id: number,
-    @Body(
-      new ValidationPipe({
-        whitelist: true,
-        forbidNonWhitelisted: false,
-        transform: true,
-      }),
-    )
-    body: RootResultsDto,
-  ) {
-    return this.bilateralService.update(id, body);
-  }
-
-  @Patch('delete/:id')
-  @ApiOperation({
-    summary: 'Soft delete bilateral result',
-    description: 'Marks a bilateral-created result as inactive.',
-  })
-  @ApiParam({ name: 'id', type: Number, required: true })
-  async delete(@Param('id', ParseIntPipe) id: number) {
-    return this.bilateralService.delete(id);
   }
 
   @Get()
@@ -222,7 +189,7 @@ export class BilateralController {
   @ApiOperation({
     summary: 'Get all bilateral results for synchronization',
     description:
-      'Retrieves all active bilateral results for external synchronization. Returns results in the same structure as create/update endpoints. Supports optional filtering by bilateral flag and result type.',
+      'Retrieves all active bilateral results for external synchronization. Returns results in the same structure as the create endpoint. Supports optional filtering by bilateral flag and result type.',
   })
   @ApiQuery({
     name: 'bilateral',

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.module.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.module.ts
@@ -40,6 +40,7 @@ import { InnovationUseBilateralHandler } from './handlers/innovation-use.handler
 import { PolicyChangeBilateralHandler } from './handlers/policy-change.handler';
 import { ResultsInnovationsDevRepository } from '../results/summary/repositories/results-innovations-dev.repository';
 import { ResultsInnovationsUseRepository } from '../results/summary/repositories/results-innovations-use.repository';
+import { ResultsCapacityDevelopmentsRepository } from '../results/summary/repositories/results-capacity-developments.repository';
 import { ResultsPolicyChangesRepository } from '../results/summary/repositories/results-policy-changes.repository';
 import { NoopBilateralHandler } from './handlers/noop.handler';
 import { NonPooledProjectBudgetRepository } from '../results/result_budget/repositories/non_pooled_proyect_budget.repository';
@@ -90,6 +91,7 @@ import { NonPooledProjectBudgetRepository } from '../results/result_budget/repos
     NoopBilateralHandler,
     ResultsInnovationsDevRepository,
     ResultsInnovationsUseRepository,
+    ResultsCapacityDevelopmentsRepository,
     ResultsPolicyChangesRepository,
     NonPooledProjectBudgetRepository,
   ],

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.service.spec.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.service.spec.ts
@@ -9,7 +9,6 @@ describe('BilateralService (unit)', () => {
       findOne: jest.fn(),
       save: jest.fn(async (x) => x),
     };
-    const resultsService = {} as any;
     const handlersError = {} as any;
     const versioningService = {} as any;
     const userRepository = { findOne: jest.fn() };
@@ -82,7 +81,6 @@ describe('BilateralService (unit)', () => {
     const service = new BilateralService(
       dataSource,
       resultRepository as any,
-      resultsService,
       handlersError,
       versioningService,
       userRepository as any,

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.service.spec.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.service.spec.ts
@@ -59,6 +59,9 @@ describe('BilateralService (unit)', () => {
       logicalDelete: jest.fn().mockResolvedValue(undefined),
     } as any;
     const nonPooledProjectBudgetRepository = { save: jest.fn() };
+    const resultsInnovationsUseRepository = {
+      getLinkedResultsByOrigin: jest.fn().mockResolvedValue([]),
+    };
 
     const makeHandler = (resultType: number) => ({
       resultType,
@@ -111,6 +114,7 @@ describe('BilateralService (unit)', () => {
       resultByInitiativesRepository as any,
       shareResultRequestRepository,
       nonPooledProjectBudgetRepository as any,
+      resultsInnovationsUseRepository as any,
       knowledgeProductHandler as any,
       capacityChangeHandler as any,
       innovationDevelopmentHandler as any,

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.service.spec.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.service.spec.ts
@@ -62,6 +62,9 @@ describe('BilateralService (unit)', () => {
     const resultsInnovationsUseRepository = {
       getLinkedResultsByOrigin: jest.fn().mockResolvedValue([]),
     };
+    const resultsCapacityDevelopmentsRepository = {
+      capDevExists: jest.fn().mockResolvedValue(undefined),
+    };
 
     const makeHandler = (resultType: number) => ({
       resultType,
@@ -115,6 +118,7 @@ describe('BilateralService (unit)', () => {
       shareResultRequestRepository,
       nonPooledProjectBudgetRepository as any,
       resultsInnovationsUseRepository as any,
+      resultsCapacityDevelopmentsRepository as any,
       knowledgeProductHandler as any,
       capacityChangeHandler as any,
       innovationDevelopmentHandler as any,
@@ -185,9 +189,7 @@ describe('BilateralService (unit)', () => {
     const cap = service.buildResultRelations(
       ResultTypeEnum.CAPACITY_SHARING_FOR_DEVELOPMENT,
     );
-    expect(cap).toEqual(
-      expect.objectContaining({ results_capacity_development_object: true }),
-    );
+    expect(cap).not.toHaveProperty('results_capacity_development_object');
   });
 
   it('filterActiveRelations should filter arrays by is_active (includes null/undefined/1/true)', () => {

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.service.spec.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.service.spec.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  HttpStatus,
+  NotFoundException,
+} from '@nestjs/common';
 import { BilateralService } from './bilateral.service';
 import { ResultTypeEnum } from '../../shared/constants/result-type.enum';
 
@@ -65,6 +69,18 @@ describe('BilateralService (unit)', () => {
     const resultsCapacityDevelopmentsRepository = {
       capDevExists: jest.fn().mockResolvedValue(undefined),
     };
+    const resultsPolicyChangesRepository = {
+      ResultsPolicyChangesExists: jest.fn().mockResolvedValue(undefined),
+    };
+    const resultQuestionsService = {
+      findQuestionPolicyChange: jest.fn().mockResolvedValue({
+        status: HttpStatus.OK,
+        response: {
+          question_text: 'Is this result related to:',
+          optionsWithAnswers: [],
+        },
+      }),
+    };
 
     const makeHandler = (resultType: number) => ({
       resultType,
@@ -119,6 +135,8 @@ describe('BilateralService (unit)', () => {
       nonPooledProjectBudgetRepository as any,
       resultsInnovationsUseRepository as any,
       resultsCapacityDevelopmentsRepository as any,
+      resultsPolicyChangesRepository as any,
+      resultQuestionsService as any,
       knowledgeProductHandler as any,
       capacityChangeHandler as any,
       innovationDevelopmentHandler as any,

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
@@ -1548,11 +1548,15 @@ export class BilateralService {
     return {
       clarisa_subnational_scope_code: sn.clarisa_subnational_scope_code ?? null,
       geo_scope_role_id: sn.geo_scope_role_id ?? null,
-      clarisa_subnational_scope_object: sn.clarisa_subnational_scope_object ?? null,
+      clarisa_subnational_scope_object:
+        sn.clarisa_subnational_scope_object ?? null,
     };
   }
 
-  private slimBilateralResultCountryRow(rc: any, onlyActive: (arr: any[]) => any[]) {
+  private slimBilateralResultCountryRow(
+    rc: any,
+    onlyActive: (arr: any[]) => any[],
+  ) {
     const subs = onlyActive(rc?.result_countries_subnational_array).map((sn) =>
       this.slimBilateralResultCountrySubnationalRow(sn),
     );
@@ -1675,9 +1679,7 @@ export class BilateralService {
   /**
    * Latest active submission row for QA / Submitted results (who submitted and when).
    */
-  private async buildLastSubmissionMetadata(
-    resultId: number,
-  ): Promise<{
+  private async buildLastSubmissionMetadata(resultId: number): Promise<{
     id: number;
     created_date: Date;
     comment: string | null;
@@ -1717,8 +1719,7 @@ export class BilateralService {
       created_date: row.created_date,
       comment: row.comment ?? null,
       status: row.status === true || row.status === 1,
-      status_id:
-        row.status_id == null ? null : Number(row.status_id),
+      status_id: row.status_id == null ? null : Number(row.status_id),
       submitted_by: {
         user_id: Number(row.user_id),
         first_name: row.first_name ?? null,
@@ -2647,13 +2648,10 @@ export class BilateralService {
       return [];
     }
     return opts
-      .filter(
-        (o) => o?.answer_boolean === true || o?.answer_boolean === 1,
-      )
+      .filter((o) => o?.answer_boolean === true || o?.answer_boolean === 1)
       .map((o) => ({
         parent_question: parent,
-        option_text:
-          o?.question_text != null ? String(o.question_text) : null,
+        option_text: o?.question_text != null ? String(o.question_text) : null,
       }));
   }
 

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
@@ -86,6 +86,10 @@ import { InnovationUseLevel } from '../results-framework-reporting/innovation-us
 import { ResultsInnovationsUseRepository } from '../results/summary/repositories/results-innovations-use.repository';
 import { ResultsCapacityDevelopmentsRepository } from '../results/summary/repositories/results-capacity-developments.repository';
 import { CapdevsDeliveryMethod } from '../results/capdevs-delivery-methods/entities/capdevs-delivery-method.entity';
+import { ClarisaPolicyType } from '../../clarisa/clarisa-policy-types/entities/clarisa-policy-type.entity';
+import { ClarisaPolicyStage } from '../../clarisa/clarisa-policy-stages/entities/clarisa-policy-stage.entity';
+import { ResultsPolicyChangesRepository } from '../results/summary/repositories/results-policy-changes.repository';
+import { ResultQuestionsService } from '../results/result-questions/result-questions.service';
 
 /** Anticipated innovation user — organization-type rows (same role as PRMS Innovation Dev). */
 const INNOVATION_DEV_ANTICIPATED_USER_ORG_ROLE_ID = 5;
@@ -98,6 +102,9 @@ const INNOVATION_USE_SECTION_2030 = 2;
 
 /** Capacity sharing — implementing organizations (`summary.service` / PRMS role 3). */
 const CAPACITY_SHARING_IMPLEMENTING_ORG_ROLE_ID = 3;
+
+/** Policy change — implementing organizations (`summary.service` / PRMS role 4). */
+const POLICY_CHANGE_IMPLEMENTING_ORG_ROLE_ID = 4;
 
 /** Map result_type name (ListResultsResultTypeEnum) to result_type.id */
 const RESULT_TYPE_NAME_TO_ID: Partial<
@@ -185,6 +192,8 @@ export class BilateralService {
     private readonly _nonPooledProjectBudgetRepository: NonPooledProjectBudgetRepository,
     private readonly _resultsInnovationsUseRepository: ResultsInnovationsUseRepository,
     private readonly _resultsCapacityDevelopmentsRepository: ResultsCapacityDevelopmentsRepository,
+    private readonly _resultsPolicyChangesRepository: ResultsPolicyChangesRepository,
+    private readonly _resultQuestionsService: ResultQuestionsService,
     private readonly _knowledgeProductHandler: KnowledgeProductBilateralHandler,
     private readonly _capacityChangeHandler: CapacityChangeBilateralHandler,
     private readonly _innovationDevelopmentHandler: InnovationDevelopmentBilateralHandler,
@@ -797,8 +806,6 @@ export class BilateralService {
     const isInnovationDev =
       resultTypeId === ResultTypeEnum.INNOVATION_DEVELOPMENT;
     const isInnovationUse = resultTypeId === ResultTypeEnum.INNOVATION_USE;
-    const isPolicyChange = resultTypeId === ResultTypeEnum.POLICY_CHANGE;
-
     return {
       obj_result_by_initiatives: {
         obj_initiative: true,
@@ -844,9 +851,6 @@ export class BilateralService {
         results_innovations_use_object: {
           obj_innovation_use_level: true,
         },
-      }),
-      ...(isPolicyChange && {
-        results_policy_changes_object: true,
       }),
     };
   }
@@ -2591,6 +2595,136 @@ export class BilateralService {
     );
   }
 
+  private mapPolicyChangeAmountStatusLabel(status: unknown): string | null {
+    const n = Number(status);
+    if (n === 1) return 'Confirmed';
+    if (n === 2) return 'Estimated';
+    if (n === 3) return 'Unknown';
+    return null;
+  }
+
+  /**
+   * "Is this result related to" — same source as `ResultQuestionsService.findQuestionPolicyChange`
+   * (`result_questions` + `result_answers`, options with `answer_boolean` true).
+   */
+  private formatPolicyChangeRelatedToSelections(block: any): Array<{
+    parent_question: string | null;
+    option_text: string | null;
+  }> {
+    if (!block || typeof block !== 'object') {
+      return [];
+    }
+    const parent =
+      block.question_text != null ? String(block.question_text) : null;
+    const opts = block.optionsWithAnswers;
+    if (!Array.isArray(opts)) {
+      return [];
+    }
+    return opts
+      .filter(
+        (o) => o?.answer_boolean === true || o?.answer_boolean === 1,
+      )
+      .map((o) => ({
+        parent_question: parent,
+        option_text:
+          o?.question_text != null ? String(o.question_text) : null,
+      }));
+  }
+
+  private async loadPolicyChangeRelatedToSelections(
+    resultId: number,
+  ): Promise<
+    Array<{ parent_question: string | null; option_text: string | null }>
+  > {
+    try {
+      const res =
+        await this._resultQuestionsService.findQuestionPolicyChange(resultId);
+      if (!res || res.status !== HttpStatus.OK || !res.response) {
+        return [];
+      }
+      return this.formatPolicyChangeRelatedToSelections(res.response);
+    } catch {
+      return [];
+    }
+  }
+
+  /** Bilateral policy change: same data as `SummaryService.getPolicyChanges`, Clarisa labels instead of FK ids. */
+  private async buildPolicyChangeBilateralSummary(resultId: number) {
+    const [row, institutions, result_related_to] = await Promise.all([
+      this._resultsPolicyChangesRepository.ResultsPolicyChangesExists(resultId),
+      this._resultByIntitutionsRepository.getGenericAllResultByInstitutionByRole(
+        resultId,
+        POLICY_CHANGE_IMPLEMENTING_ORG_ROLE_ID,
+      ),
+      this.loadPolicyChangeRelatedToSelections(resultId),
+    ]);
+
+    const institutionsMapped = (institutions ?? []).map((r: any) =>
+      this.mapCapacitySharingImplementingInstitution(r),
+    );
+
+    const rawRow = row as any;
+    const inactive =
+      rawRow &&
+      (rawRow.is_active === false ||
+        rawRow.is_active === 0 ||
+        rawRow.is_active === '0');
+    if (!row || inactive) {
+      return {
+        created_date: null,
+        last_updated_date: null,
+        amount: null,
+        amount_status_label: null,
+        policy_type: null,
+        policy_stage: null,
+        linked_innovation_dev: null,
+        linked_innovation_use: null,
+        result_related_to,
+        institutions: institutionsMapped,
+      };
+    }
+
+    const ptId = Number(row.policy_type_id);
+    const psId = Number(row.policy_stage_id);
+    const [policyType, policyStage] = await Promise.all([
+      Number.isFinite(ptId) && ptId > 0
+        ? this.dataSource.getRepository(ClarisaPolicyType).findOne({
+            where: { id: ptId },
+          })
+        : Promise.resolve(null),
+      Number.isFinite(psId) && psId > 0
+        ? this.dataSource.getRepository(ClarisaPolicyStage).findOne({
+            where: { id: psId },
+          })
+        : Promise.resolve(null),
+    ]);
+
+    return {
+      created_date: row.created_date ?? null,
+      last_updated_date: row.last_updated_date ?? null,
+      amount: row.amount == null ? null : Number(row.amount),
+      amount_status_label: this.mapPolicyChangeAmountStatusLabel(
+        row.status_amount,
+      ),
+      policy_type: policyType
+        ? {
+            name: policyType.name ?? null,
+            definition: policyType.definition ?? null,
+          }
+        : null,
+      policy_stage: policyStage
+        ? {
+            name: policyStage.name ?? null,
+            definition: policyStage.definition ?? null,
+          }
+        : null,
+      linked_innovation_dev: !!row.linked_innovation_dev,
+      linked_innovation_use: !!row.linked_innovation_use,
+      result_related_to,
+      institutions: institutionsMapped,
+    };
+  }
+
   private async enrichBilateralResultResponse(filtered: any): Promise<void> {
     if (!filtered?.id) return;
     filtered.obj_results_toc_result =
@@ -2627,6 +2761,11 @@ export class BilateralService {
       filtered.capacity_development_summary =
         await this.buildCapacityDevelopmentBilateralSummary(filtered.id);
       delete filtered.results_capacity_development_object;
+    }
+    if (filtered.result_type_id === ResultTypeEnum.POLICY_CHANGE) {
+      filtered.policy_change_summary =
+        await this.buildPolicyChangeBilateralSummary(filtered.id);
+      delete filtered.results_policy_changes_object;
     }
     delete filtered.obj_result_by_project;
   }

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
@@ -70,7 +70,6 @@ import { PolicyChangeBilateralHandler } from './handlers/policy-change.handler';
 import { BilateralResultTypeHandler } from './handlers/bilateral-result-type-handler.interface';
 import { NoopBilateralHandler } from './handlers/noop.handler';
 import { ResultByInitiativesRepository } from '../results/results_by_inititiatives/resultByInitiatives.repository';
-import { ResultsService } from '../results/results.service';
 import { ShareResultRequestRepository } from '../results/share-result-request/share-result-request.repository';
 import { NonPooledProjectBudgetRepository } from '../results/result_budget/repositories/non_pooled_proyect_budget.repository';
 
@@ -128,7 +127,6 @@ export class BilateralService {
   constructor(
     private readonly dataSource: DataSource,
     private readonly _resultRepository: ResultRepository,
-    private readonly _resultsService: ResultsService,
     private readonly _handlersError: HandlersError,
     private readonly _versioningService: VersioningService,
     private readonly _userRepository: UserRepository,
@@ -427,216 +425,6 @@ export class BilateralService {
       message: 'Results Bilateral created successfully.',
       status: 201,
     };
-  }
-
-  async update(resultId: number, rootResultsDto: RootResultsDto) {
-    if (!resultId) {
-      throw new BadRequestException('Result id is required.');
-    }
-
-    const existingResult = await this._resultRepository.findOne({
-      where: { id: resultId },
-    });
-
-    if (!existingResult) {
-      throw new NotFoundException('Result not found.');
-    }
-
-    if (existingResult.source !== SourceEnum.Bilateral) {
-      throw new BadRequestException(
-        'The provided result does not belong to the bilateral API.',
-      );
-    }
-
-    const incomingResults = this.unwrapIncomingResults(rootResultsDto);
-    if (!incomingResults.length) {
-      throw new BadRequestException(
-        'At least one result payload is required in either "results" or "result".',
-      );
-    }
-
-    const firstResult = incomingResults[0];
-    if (!firstResult?.data || typeof firstResult.data !== 'object') {
-      throw new BadRequestException(
-        'Each result entry must include a "data" object with the bilateral payload.',
-      );
-    }
-
-    const bilateralDto = firstResult.data;
-
-    // Validate science_program_id before starting to save
-    await this.validateTocMappingInitiatives(
-      bilateralDto.toc_mapping,
-      bilateralDto.contributing_programs,
-    );
-
-    let resultInfo: any = null;
-
-    await this.dataSource.transaction(async () => {
-      const adminUser = await this._userRepository.findOne({
-        where: { email: 'admin@prms.pr' },
-      });
-
-      const createdByUser = await this.findOrCreateUser(
-        bilateralDto.created_by,
-        adminUser,
-      );
-      const userId = createdByUser.id;
-
-      const submittedPayload = this.resolveSubmitterPayload(bilateralDto);
-      const submittedUser = await this.findOrCreateUser(
-        submittedPayload,
-        createdByUser,
-      );
-      const submittedUserId = submittedUser.id;
-
-      const version = await this._versioningService.$_findActivePhase(
-        AppModuleIdEnum.REPORTING,
-      );
-      if (!version)
-        throw this._handlersError.returnErrorRes({
-          error: version,
-          debug: true,
-        });
-
-      const year = await this._yearRepository.findOne({
-        where: { active: true },
-      });
-      if (!year) throw new NotFoundException('Active year not found');
-
-      const updatedHeader = await this._resultRepository.save({
-        ...existingResult,
-        title: bilateralDto.title,
-        description: bilateralDto.description,
-        version_id: version.id,
-        reported_year_id: year.year,
-        result_type_id: bilateralDto.result_type_id,
-        result_level_id: bilateralDto.result_level_id,
-        external_submitter: submittedUserId,
-        external_submitted_date:
-          bilateralDto.submitted_by?.submitted_date ?? null,
-        external_submitted_comment: bilateralDto.submitted_by?.comment ?? null,
-        last_updated_by: userId,
-        ...(bilateralDto.created_date && {
-          created_date: bilateralDto.created_date,
-        }),
-      });
-
-      await this._resultsCenterRepository.fisicalDelete(resultId);
-      await this.handleLeadCenter(resultId, bilateralDto.lead_center, userId);
-
-      const { scope_code, scope_label, regions, countries, subnational_areas } =
-        bilateralDto.geo_focus;
-      const scope = await this.findScope(scope_code, scope_label);
-      this.validateGeoFocus(scope, regions, countries, subnational_areas);
-
-      await this.handleRegions(updatedHeader, scope, regions);
-      await this.handleCountries(
-        updatedHeader,
-        countries,
-        subnational_areas,
-        scope.id,
-        userId,
-      );
-
-      await this._resultRepository.update(resultId, {
-        geographic_scope_id: this.resolveScopeId(scope.id, countries),
-        has_countries: Array.isArray(countries) && countries.length > 0,
-      });
-
-      await this.resetTocData(resultId);
-      await this.handleTocMapping(
-        bilateralDto.toc_mapping,
-        bilateralDto.contributing_programs,
-        userId,
-        resultId,
-      );
-
-      await this.handleInstitutions(
-        resultId,
-        bilateralDto.contributing_partners || [],
-        userId,
-        bilateralDto.result_type_id,
-      );
-
-      await this._evidencesRepository.logicalDelete(resultId);
-      if (bilateralDto.result_type_id !== ResultTypeEnum.KNOWLEDGE_PRODUCT) {
-        await this.handleEvidence(
-          resultId,
-          bilateralDto.evidence || [],
-          userId,
-        );
-      }
-
-      await this._resultsByProjectsRepository.delete({ result_id: resultId });
-      await this.handleNonPooledProject(
-        resultId,
-        userId,
-        bilateralDto.contributing_bilateral_projects,
-        bilateralDto.result_type_id,
-      );
-
-      await this.handleContributingCenters(
-        resultId,
-        bilateralDto.contributing_center || [],
-        userId,
-        bilateralDto.lead_center,
-      );
-
-      await this.runResultTypeHandlers({
-        resultId,
-        userId,
-        bilateralDto,
-        isDuplicateResult: false,
-      });
-
-      resultInfo = await this._resultRepository.findOne({
-        where: { id: resultId },
-        relations: this.buildResultRelations(bilateralDto.result_type_id),
-      });
-
-      resultInfo = this.filterActiveRelations(resultInfo);
-      if (resultInfo) {
-        await this.enrichBilateralResultResponse(resultInfo);
-      }
-
-      this.logger.log(
-        `Successfully updated bilateral result ${resultId} (code: ${existingResult.result_code})`,
-      );
-    });
-
-    return {
-      response: resultInfo,
-      message: 'Results Bilateral updated successfully.',
-      status: 200,
-    };
-  }
-
-  async delete(resultId: number) {
-    try {
-      if (!resultId) {
-        throw new BadRequestException('Result id is required.');
-      }
-
-      const result = await this._resultRepository.findOne({
-        where: { id: resultId },
-      });
-
-      if (!result) {
-        throw new NotFoundException('Result not found.');
-      }
-
-      if (result.source !== SourceEnum.Bilateral) {
-        throw new BadRequestException(
-          'The provided result does not belong to the bilateral API.',
-        );
-      }
-
-      const systemUser = await this.getSystemUserToken();
-      return await this._resultsService.deleteResult(resultId, systemUser);
-    } catch (error) {
-      return this._handlersError.returnErrorRes({ error, debug: true });
-    }
   }
 
   async findOne(id: number) {
@@ -1016,6 +804,7 @@ export class BilateralService {
         result_knowledge_product_array: {
           result_knowledge_product_keyword_array: true,
           result_knowledge_product_metadata_array: true,
+          result_knowledge_product_author_array: true,
         },
       }),
       ...(isCapacitySharing && {
@@ -1865,6 +1654,128 @@ export class BilateralService {
       });
   }
 
+  private static triStateBool(value: unknown): boolean | null {
+    if (value === true || value === 1) return true;
+    if (value === false || value === 0) return false;
+    return null;
+  }
+
+  private collectKnowledgeProductRelatedResultIds(
+    evidenceArray: unknown,
+  ): number[] {
+    if (!Array.isArray(evidenceArray)) return [];
+    const ids = new Set<number>();
+    for (const ev of evidenceArray as Record<string, unknown>[]) {
+      if (ev?.is_active === false || ev?.is_active === 0) continue;
+      const ref = ev?.knowledge_product_related;
+      let id: number | null = null;
+      if (typeof ref === 'number' && Number.isFinite(ref)) id = ref;
+      else if (ref && typeof ref === 'object' && 'id' in ref) {
+        const rid = Number((ref as { id: unknown }).id);
+        if (Number.isFinite(rid)) id = rid;
+      }
+      if (id != null) ids.add(id);
+    }
+    return [...ids];
+  }
+
+  /**
+   * Human-facing accessibility per metadata row (e.g. CGSpace "Limited Access"):
+   * prefer `open_access`; fallback to legacy `accesibility` column.
+   */
+  /** FAIR values stored 0–1 → whole-number percent (e.g. 0.667 → 67). */
+  private static fairScorePercent(value: unknown): number | null {
+    if (value == null) return null;
+    const n = Number(value);
+    if (!Number.isFinite(n)) return null;
+    return Math.round(n * 100);
+  }
+
+  private static metadataAccessibilityLabel(m: {
+    open_access?: string | null;
+    accesibility?: string | boolean | null;
+  }): string | null {
+    const oa = m.open_access;
+    if (oa != null && String(oa).trim() !== '') return String(oa);
+    const acc = m.accesibility;
+    if (acc == null) return null;
+    return String(acc);
+  }
+
+  /**
+   * Knowledge products: slim payload for bilateral / OpenSearch (handle, metadata
+   * per source, authors, type, peer review / WoS flags, DOI, accessibility, keywords,
+   * agrovoc_keywords, commodity, sponsors, links to other results via evidence,
+   * FAIR pillar percents only: findable, accessible, interoperable, reusable.
+   */
+  private buildKnowledgeProductBilateralSummary(result: any) {
+    const onlyActive = (arr: any[] | undefined) =>
+      Array.isArray(arr)
+        ? arr.filter(
+            (item) =>
+              item?.is_active === undefined ||
+              item?.is_active === null ||
+              item.is_active === true ||
+              item.is_active === 1,
+          )
+        : [];
+
+    const kps = onlyActive(result?.result_knowledge_product_array);
+    const kp = kps[0];
+    if (!kp) return null;
+
+    const metadata_by_source = onlyActive(
+      kp.result_knowledge_product_metadata_array,
+    ).map((m: any) => ({
+      source: m.source ?? null,
+      issue_year: m.year == null ? null : Number(m.year),
+      online_year: m.online_year == null ? null : Number(m.online_year),
+      is_peer_reviewed: BilateralService.triStateBool(m.is_peer_reviewed),
+      web_of_science_core_collection: BilateralService.triStateBool(m.is_isi),
+      accessibility: BilateralService.metadataAccessibilityLabel(m),
+      doi: m.doi ?? null,
+    }));
+
+    const authors = onlyActive(kp.result_knowledge_product_author_array).map(
+      (a: any) => ({
+        name: a.author_name ?? null,
+        orcid: a.orcid ?? null,
+      }),
+    );
+
+    const keywordRows = onlyActive(kp.result_knowledge_product_keyword_array);
+    const keywords: string[] = [];
+    const agrovoc_keywords: string[] = [];
+    for (const k of keywordRows) {
+      const text = (k.keyword ?? '').trim();
+      if (!text) continue;
+      const isAg = k.is_agrovoc === true || k.is_agrovoc === 1;
+      if (isAg) agrovoc_keywords.push(text);
+      else keywords.push(text);
+    }
+
+    return {
+      handle: kp.handle ?? null,
+      doi: kp.doi ?? null,
+      knowledge_product_type: kp.knowledge_product_type ?? null,
+      commodity: kp.comodity ?? null,
+      sponsors: kp.sponsors ?? null,
+      authors,
+      keywords,
+      agrovoc_keywords,
+      metadata_by_source,
+      fair: {
+        findable: BilateralService.fairScorePercent(kp.findable),
+        accessible: BilateralService.fairScorePercent(kp.accesible),
+        interoperable: BilateralService.fairScorePercent(kp.interoperable),
+        reusable: BilateralService.fairScorePercent(kp.reusable),
+      },
+      referenced_result_ids: this.collectKnowledgeProductRelatedResultIds(
+        result.evidence_array,
+      ),
+    };
+  }
+
   /**
    * Slim DAC payload: tag description only from GenderTagLevel; when tag level id is
    * {@link DAC_IMPACT_AREA_TAG_LEVEL_ID}, impact_area_names from result_impact_area_score
@@ -1945,6 +1856,11 @@ export class BilateralService {
     );
     filtered.result_by_institution_array =
       await this.buildBilateralPartnerInstitutionsSummary(filtered.id);
+    if (filtered.result_type_id === ResultTypeEnum.KNOWLEDGE_PRODUCT) {
+      filtered.knowledge_product_summary =
+        this.buildKnowledgeProductBilateralSummary(filtered);
+      delete filtered.result_knowledge_product_array;
+    }
     delete filtered.obj_result_by_project;
   }
 

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
@@ -1582,14 +1582,42 @@ export class BilateralService {
   }
 
   /**
-   * Builds leading_result from the result's result_center_array (center with is_leading_result = 1, active).
-   * Uses ClarisaCenter (code) and ClarisaInstitution (name, acronym).
+   * Leading org for the result: when `is_lead_by_partner` is true, the **partner** row
+   * with `is_leading_result` (Clarisa institution); otherwise the **lead centre** from
+   * `result_center_array` (Clarisa center code + institution).
    */
-  private buildLeadingResult(result: any): {
-    code: string;
+  private async buildLeadingResult(result: any): Promise<{
+    lead_kind: 'center' | 'partner';
+    id: number | null;
+    code: string | null;
     name: string;
     acronym: string;
-  } | null {
+  } | null> {
+    const isLeadByPartner =
+      result?.is_lead_by_partner === true || result?.is_lead_by_partner === 1;
+
+    if (isLeadByPartner && result?.id != null) {
+      const rows = await this._resultByIntitutionsRepository.find({
+        where: {
+          result_id: result.id,
+          is_active: true,
+          institution_roles_id: InstitutionRoleEnum.PARTNER,
+          is_leading_result: true,
+        },
+        relations: { obj_institutions: true },
+      });
+      const row = rows[0];
+      const inst = row?.obj_institutions;
+      if (!inst) return null;
+      return {
+        lead_kind: 'partner',
+        id: inst.id ?? null,
+        code: null,
+        name: inst.name ?? '',
+        acronym: inst.acronym ?? '',
+      };
+    }
+
     const centers = result?.result_center_array;
     if (!Array.isArray(centers)) return null;
     const leading = centers.find(
@@ -1598,10 +1626,75 @@ export class BilateralService {
     if (!leading?.clarisa_center_object) return null;
     const cc = leading.clarisa_center_object;
     const inst = cc?.clarisa_institution;
+    let institutionId: number | null = null;
+    if (cc.institutionId != null) {
+      const n = Number(cc.institutionId);
+      if (Number.isFinite(n)) institutionId = n;
+    } else if (inst?.id != null) {
+      const n = Number(inst.id);
+      if (Number.isFinite(n)) institutionId = n;
+    }
     return {
-      code: cc.code ?? '',
+      lead_kind: 'center',
+      id: institutionId,
+      code: cc.code ?? null,
       name: inst?.name ?? '',
       acronym: inst?.acronym ?? '',
+    };
+  }
+
+  /**
+   * Latest active submission row for QA / Submitted results (who submitted and when).
+   */
+  private async buildLastSubmissionMetadata(
+    resultId: number,
+  ): Promise<{
+    id: number;
+    created_date: Date;
+    comment: string | null;
+    status: boolean;
+    status_id: number | null;
+    submitted_by: {
+      user_id: number;
+      first_name: string | null;
+      last_name: string | null;
+    };
+  } | null> {
+    const rows = (await this.dataSource.query(
+      `SELECT s.id, s.created_date, s.comment, s.status, s.status_id, s.user_id,
+              u.first_name, u.last_name
+       FROM submission s
+       LEFT JOIN users u ON u.id = s.user_id
+       WHERE s.results_id = ? AND s.is_active = 1
+       ORDER BY s.created_date DESC
+       LIMIT 1`,
+      [resultId],
+    )) as Array<{
+      id: number;
+      created_date: Date;
+      comment: string | null;
+      status: boolean | number;
+      status_id: number | null;
+      user_id: number;
+      first_name: string | null;
+      last_name: string | null;
+    }>;
+
+    const row = rows[0];
+    if (!row) return null;
+
+    return {
+      id: Number(row.id),
+      created_date: row.created_date,
+      comment: row.comment ?? null,
+      status: row.status === true || row.status === 1,
+      status_id:
+        row.status_id == null ? null : Number(row.status_id),
+      submitted_by: {
+        user_id: Number(row.user_id),
+        first_name: row.first_name ?? null,
+        last_name: row.last_name ?? null,
+      },
     };
   }
 
@@ -1692,59 +1785,8 @@ export class BilateralService {
       });
   }
 
-  private static triStateBool(value: unknown): boolean | null {
-    if (value === true || value === 1) return true;
-    if (value === false || value === 0) return false;
-    return null;
-  }
-
-  private collectKnowledgeProductRelatedResultIds(
-    evidenceArray: unknown,
-  ): number[] {
-    if (!Array.isArray(evidenceArray)) return [];
-    const ids = new Set<number>();
-    for (const ev of evidenceArray as Record<string, unknown>[]) {
-      if (ev?.is_active === false || ev?.is_active === 0) continue;
-      const ref = ev?.knowledge_product_related;
-      let id: number | null = null;
-      if (typeof ref === 'number' && Number.isFinite(ref)) id = ref;
-      else if (ref && typeof ref === 'object' && 'id' in ref) {
-        const rid = Number((ref as { id: unknown }).id);
-        if (Number.isFinite(rid)) id = rid;
-      }
-      if (id != null) ids.add(id);
-    }
-    return [...ids];
-  }
-
   /**
-   * Human-facing accessibility per metadata row (e.g. CGSpace "Limited Access"):
-   * prefer `open_access`; fallback to legacy `accesibility` column.
-   */
-  /** FAIR values stored 0–1 → whole-number percent (e.g. 0.667 → 67). */
-  private static fairScorePercent(value: unknown): number | null {
-    if (value == null) return null;
-    const n = Number(value);
-    if (!Number.isFinite(n)) return null;
-    return Math.round(n * 100);
-  }
-
-  private static metadataAccessibilityLabel(m: {
-    open_access?: string | null;
-    accesibility?: string | boolean | null;
-  }): string | null {
-    const oa = m.open_access;
-    if (oa != null && String(oa).trim() !== '') return String(oa);
-    const acc = m.accesibility;
-    if (acc == null) return null;
-    return String(acc);
-  }
-
-  /**
-   * Knowledge products: slim payload for bilateral / OpenSearch (handle, metadata
-   * per source, authors, type, peer review / WoS flags, DOI, accessibility, keywords,
-   * agrovoc_keywords, commodity, sponsors, links to other results via evidence,
-   * FAIR pillar percents only: findable, accessible, interoperable, reusable.
+   * Knowledge products: bilateral payload exposes only the public **handle**.
    */
   private buildKnowledgeProductBilateralSummary(result: any) {
     const onlyActive = (arr: any[] | undefined) =>
@@ -1762,55 +1804,8 @@ export class BilateralService {
     const kp = kps[0];
     if (!kp) return null;
 
-    const metadata_by_source = onlyActive(
-      kp.result_knowledge_product_metadata_array,
-    ).map((m: any) => ({
-      source: m.source ?? null,
-      issue_year: m.year == null ? null : Number(m.year),
-      online_year: m.online_year == null ? null : Number(m.online_year),
-      is_peer_reviewed: BilateralService.triStateBool(m.is_peer_reviewed),
-      web_of_science_core_collection: BilateralService.triStateBool(m.is_isi),
-      accessibility: BilateralService.metadataAccessibilityLabel(m),
-      doi: m.doi ?? null,
-    }));
-
-    const authors = onlyActive(kp.result_knowledge_product_author_array).map(
-      (a: any) => ({
-        name: a.author_name ?? null,
-        orcid: a.orcid ?? null,
-      }),
-    );
-
-    const keywordRows = onlyActive(kp.result_knowledge_product_keyword_array);
-    const keywords: string[] = [];
-    const agrovoc_keywords: string[] = [];
-    for (const k of keywordRows) {
-      const text = (k.keyword ?? '').trim();
-      if (!text) continue;
-      const isAg = k.is_agrovoc === true || k.is_agrovoc === 1;
-      if (isAg) agrovoc_keywords.push(text);
-      else keywords.push(text);
-    }
-
     return {
       handle: kp.handle ?? null,
-      doi: kp.doi ?? null,
-      knowledge_product_type: kp.knowledge_product_type ?? null,
-      commodity: kp.comodity ?? null,
-      sponsors: kp.sponsors ?? null,
-      authors,
-      keywords,
-      agrovoc_keywords,
-      metadata_by_source,
-      fair: {
-        findable: BilateralService.fairScorePercent(kp.findable),
-        accessible: BilateralService.fairScorePercent(kp.accesible),
-        interoperable: BilateralService.fairScorePercent(kp.interoperable),
-        reusable: BilateralService.fairScorePercent(kp.reusable),
-      },
-      referenced_result_ids: this.collectKnowledgeProductRelatedResultIds(
-        result.evidence_array,
-      ),
     };
   }
 
@@ -2193,6 +2188,7 @@ export class BilateralService {
         : null,
       typology: typology
         ? {
+            id: typology.code == null ? null : Number(typology.code),
             code: typology.code ?? null,
             name: typology.name ?? null,
             definition: typology.definition ?? null,
@@ -2478,7 +2474,11 @@ export class BilateralService {
   }
 
   private mapCapacitySharingImplementingInstitution(row: any) {
+    const rawId = row.institutions_id;
+    const id =
+      rawId != null && Number.isFinite(Number(rawId)) ? Number(rawId) : null;
     return {
+      id,
       name: row.institutions_name ?? null,
       acronym: row.institutions_acronym ?? null,
       institution_type_name: row.institutions_type_name ?? null,
@@ -2493,7 +2493,8 @@ export class BilateralService {
 
   private shapeCapacityDevelopmentBilateralPayload(
     capDev: any,
-    institutionsMapped: Array<{
+    onBehalfOrganizationsMapped: Array<{
+      id: number | null;
       name: string | null;
       acronym: string | null;
       institution_type_name: string | null;
@@ -2536,8 +2537,6 @@ export class BilateralService {
           : null;
 
     return {
-      created_date: capDev.created_date ?? null,
-      last_updated_date: capDev.last_updated_date ?? null,
       male_using: this.toCapdevCount(capDev.male_using),
       female_using: this.toCapdevCount(capDev.female_using),
       non_binary_using: this.toCapdevCount(capDev.non_binary_using),
@@ -2545,7 +2544,7 @@ export class BilateralService {
       is_attending_for_organization,
       delivery_method,
       training_length,
-      institutions: institutionsMapped,
+      on_behalf_organizations: onBehalfOrganizationsMapped,
     };
   }
 
@@ -2559,14 +2558,12 @@ export class BilateralService {
       ),
     ]);
 
-    const institutionsMapped = (institutions ?? []).map((r: any) =>
+    const onBehalfOrganizationsMapped = (institutions ?? []).map((r: any) =>
       this.mapCapacitySharingImplementingInstitution(r),
     );
 
     if (!capDev) {
       return {
-        created_date: null,
-        last_updated_date: null,
         male_using: null,
         female_using: null,
         non_binary_using: null,
@@ -2574,7 +2571,7 @@ export class BilateralService {
         is_attending_for_organization: null,
         delivery_method: null,
         training_length: null,
-        institutions: institutionsMapped,
+        on_behalf_organizations: onBehalfOrganizationsMapped,
       };
     }
 
@@ -2590,7 +2587,7 @@ export class BilateralService {
 
     return this.shapeCapacityDevelopmentBilateralPayload(
       capDev,
-      institutionsMapped,
+      onBehalfOrganizationsMapped,
       deliveryMethod,
     );
   }
@@ -2671,8 +2668,6 @@ export class BilateralService {
         rawRow.is_active === '0');
     if (!row || inactive) {
       return {
-        created_date: null,
-        last_updated_date: null,
         amount: null,
         amount_status_label: null,
         policy_type: null,
@@ -2700,20 +2695,20 @@ export class BilateralService {
     ]);
 
     return {
-      created_date: row.created_date ?? null,
-      last_updated_date: row.last_updated_date ?? null,
       amount: row.amount == null ? null : Number(row.amount),
       amount_status_label: this.mapPolicyChangeAmountStatusLabel(
         row.status_amount,
       ),
       policy_type: policyType
         ? {
+            id: policyType.id,
             name: policyType.name ?? null,
             definition: policyType.definition ?? null,
           }
         : null,
       policy_stage: policyStage
         ? {
+            id: policyStage.id,
             name: policyStage.name ?? null,
             definition: policyStage.definition ?? null,
           }
@@ -2729,7 +2724,16 @@ export class BilateralService {
     if (!filtered?.id) return;
     filtered.obj_results_toc_result =
       await this._resultRepository.getTocMappingsByResultId(filtered.id);
-    filtered.leading_result = this.buildLeadingResult(filtered);
+    filtered.leading_result = await this.buildLeadingResult(filtered);
+    const statusId = Number(filtered.status_id);
+    if (
+      statusId === ResultStatusData.QualityAssessed.value ||
+      statusId === ResultStatusData.Submitted.value
+    ) {
+      filtered.last_submission = await this.buildLastSubmissionMetadata(
+        filtered.id,
+      );
+    }
     filtered.dac_scores = await this.buildDacScoresSummary(
       filtered.id,
       filtered,

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
@@ -81,11 +81,18 @@ import { ResultScalingStudyUrl } from '../results-framework-reporting/result_sca
 import { ClarisaInnovationCharacteristic } from '../../clarisa/clarisa-innovation-characteristics/entities/clarisa-innovation-characteristic.entity';
 import { ClarisaInnovationType } from '../../clarisa/clarisa-innovation-type/entities/clarisa-innovation-type.entity';
 import { ClarisaInnovationReadinessLevel } from '../../clarisa/clarisa-innovation-readiness-levels/entities/clarisa-innovation-readiness-level.entity';
+import { ClarisaInnovationUseLevel } from '../../clarisa/clarisa-innovation-use-levels/entities/clarisa-innovation-use-level.entity';
+import { InnovationUseLevel } from '../results-framework-reporting/innovation-use/enum/innov-use-levels.enum';
+import { ResultsInnovationsUseRepository } from '../results/summary/repositories/results-innovations-use.repository';
 
 /** Anticipated innovation user — organization-type rows (same role as PRMS Innovation Dev). */
 const INNOVATION_DEV_ANTICIPATED_USER_ORG_ROLE_ID = 5;
 /** `clarisa_institution_types.code` for "Other" (anticipated user organizations). */
 const INNOVATION_DEV_INSTITUTION_TYPE_OTHER_CODE = 78;
+
+/** PRMS Innovation Use — current (reporting year) vs 2030 sections on actors / orgs / measures. */
+const INNOVATION_USE_SECTION_CURRENT = 1;
+const INNOVATION_USE_SECTION_2030 = 2;
 
 /** Map result_type name (ListResultsResultTypeEnum) to result_type.id */
 const RESULT_TYPE_NAME_TO_ID: Partial<
@@ -171,6 +178,7 @@ export class BilateralService {
     private readonly _resultByInitiativesRepository: ResultByInitiativesRepository,
     private readonly _shareResultRequestRepository: ShareResultRequestRepository,
     private readonly _nonPooledProjectBudgetRepository: NonPooledProjectBudgetRepository,
+    private readonly _resultsInnovationsUseRepository: ResultsInnovationsUseRepository,
     private readonly _knowledgeProductHandler: KnowledgeProductBilateralHandler,
     private readonly _capacityChangeHandler: CapacityChangeBilateralHandler,
     private readonly _innovationDevelopmentHandler: InnovationDevelopmentBilateralHandler,
@@ -832,7 +840,9 @@ export class BilateralService {
         },
       }),
       ...(isInnovationUse && {
-        results_innovations_use_object: true,
+        results_innovations_use_object: {
+          obj_innovation_use_level: true,
+        },
       }),
       ...(isPolicyChange && {
         results_policy_changes_object: true,
@@ -1865,6 +1875,132 @@ export class BilateralService {
     return out;
   }
 
+  /**
+   * Initiative / bilateral / partner budgets; optionally reference materials &
+   * user-need evidence (Inno Dev only — Inno Use bilateral omits the latter two).
+   */
+  private async buildInnovationSharedBudgetAndEvidenceExtras(
+    resultId: number,
+    options?: { includeReferenceAndUserNeedEvidence?: boolean },
+  ) {
+    const includeEvidence =
+      options?.includeReferenceAndUserNeedEvidence !== false;
+
+    const [initiatives, rbpRows, institutions] = await Promise.all([
+      this._resultByInitiativesRepository.find({
+        where: { result_id: resultId, is_active: true },
+      }),
+      this._resultsByProjectsRepository.find({
+        where: { result_id: resultId, is_active: true },
+      }),
+      this._resultByIntitutionsRepository.find({
+        where: { result_id: resultId, is_active: true },
+      }),
+    ]);
+
+    let refs: Evidence[] = [];
+    let userNeedDemandEvidence: Evidence[] = [];
+    if (includeEvidence) {
+      [refs, userNeedDemandEvidence] = await Promise.all([
+        this._evidencesRepository.find({
+          where: {
+            result_id: resultId,
+            evidence_type_id: EvidenceTypeEnum.MATERIALS,
+            is_active: 1,
+          },
+        }),
+        this._evidencesRepository.find({
+          where: {
+            result_id: resultId,
+            evidence_type_id: EvidenceTypeEnum.USER_NEED_USER_DEMAND,
+            is_active: 1,
+          },
+        }),
+      ]);
+    }
+
+    let initiativeBudgetRows: ResultInitiativeBudget[] = [];
+    if (initiatives.length) {
+      initiativeBudgetRows = await this.dataSource
+        .getRepository(ResultInitiativeBudget)
+        .find({
+          where: {
+            result_initiative_id: In(initiatives.map((i) => i.id)),
+            is_active: true,
+          },
+          relations: {
+            obj_result_initiative: { obj_initiative: true },
+          },
+        });
+    }
+
+    let bilateralBudgetRows: any[] = [];
+    if (rbpRows.length) {
+      bilateralBudgetRows = await this._nonPooledProjectBudgetRepository.find({
+        where: {
+          result_project_id: In(rbpRows.map((r) => r.id)),
+          is_active: true,
+        },
+        relations: {
+          obj_result_project: { obj_clarisa_project: true },
+        },
+      });
+    }
+
+    let partnerBudgetRows: ResultInstitutionsBudget[] = [];
+    if (institutions.length) {
+      partnerBudgetRows = await this._resultInstitutionsBudgetRepository.find({
+        where: {
+          result_institution_id: In(institutions.map((i) => i.id)),
+          is_active: true,
+        },
+        relations: {
+          obj_result_institution: { obj_institutions: true },
+        },
+      });
+    }
+
+    return {
+      initiative_budget: initiativeBudgetRows.map((b) => ({
+        initiative_official_code:
+          b.obj_result_initiative?.obj_initiative?.official_code ?? null,
+        initiative_name: b.obj_result_initiative?.obj_initiative?.name ?? null,
+        current_year: b.current_year == null ? null : Number(b.current_year),
+        next_year: b.next_year == null ? null : Number(b.next_year),
+        kind_cash: b.kind_cash == null ? null : Number(b.kind_cash),
+        is_determined: b.is_determined ?? null,
+      })),
+      bilateral_project_budget: bilateralBudgetRows.map((b) => ({
+        project_short_name:
+          b.obj_result_project?.obj_clarisa_project?.shortName ?? null,
+        in_cash: b.in_cash == null ? null : Number(b.in_cash),
+        in_kind: b.in_kind == null ? null : Number(b.in_kind),
+        kind_cash: b.kind_cash == null ? null : Number(b.kind_cash),
+        is_determined: b.is_determined ?? null,
+      })),
+      partner_budget: partnerBudgetRows.map((b) => ({
+        institution_name:
+          b.obj_result_institution?.obj_institutions?.name ?? null,
+        institution_acronym:
+          b.obj_result_institution?.obj_institutions?.acronym ?? null,
+        in_cash: b.in_cash == null ? null : Number(b.in_cash),
+        in_kind: b.in_kind == null ? null : Number(b.in_kind),
+        kind_cash: b.kind_cash == null ? null : Number(b.kind_cash),
+        is_determined: b.is_determined ?? null,
+      })),
+      ...(includeEvidence
+        ? {
+            reference_materials: refs.map((e) => ({ link: e.link })),
+            evidence_of_user_need_user_demand: userNeedDemandEvidence.map(
+              (e) => ({
+                link: e.link,
+              }),
+            ),
+          }
+        : {}),
+    };
+  }
+
   private async buildInnovationDevelopmentBilateralExtra(
     resultId: number,
     dev: any,
@@ -1892,16 +2028,7 @@ export class BilateralService {
       }>,
     };
 
-    const [
-      actors,
-      measures,
-      orgTypes,
-      initiatives,
-      rbpRows,
-      institutions,
-      refs,
-      userNeedDemandEvidence,
-    ] = await Promise.all([
+    const [actors, measures, orgTypes, sharedBudget] = await Promise.all([
       this.dataSource.getRepository(ResultActor).find({
         where: { result_id: resultId, is_active: true },
         relations: { obj_actor_type: true },
@@ -1917,29 +2044,7 @@ export class BilateralService {
         },
         relations: { obj_institution_types: true },
       }),
-      this._resultByInitiativesRepository.find({
-        where: { result_id: resultId, is_active: true },
-      }),
-      this._resultsByProjectsRepository.find({
-        where: { result_id: resultId, is_active: true },
-      }),
-      this._resultByIntitutionsRepository.find({
-        where: { result_id: resultId, is_active: true },
-      }),
-      this._evidencesRepository.find({
-        where: {
-          result_id: resultId,
-          evidence_type_id: EvidenceTypeEnum.MATERIALS,
-          is_active: 1,
-        },
-      }),
-      this._evidencesRepository.find({
-        where: {
-          result_id: resultId,
-          evidence_type_id: EvidenceTypeEnum.USER_NEED_USER_DEMAND,
-          is_active: 1,
-        },
-      }),
+      this.buildInnovationSharedBudgetAndEvidenceExtras(resultId),
     ]);
 
     anticipated_user_demand.actors = actors.map((a) => {
@@ -1997,47 +2102,6 @@ export class BilateralService {
         : base;
     });
 
-    let initiativeBudgetRows: ResultInitiativeBudget[] = [];
-    if (initiatives.length) {
-      initiativeBudgetRows = await this.dataSource
-        .getRepository(ResultInitiativeBudget)
-        .find({
-          where: {
-            result_initiative_id: In(initiatives.map((i) => i.id)),
-            is_active: true,
-          },
-          relations: {
-            obj_result_initiative: { obj_initiative: true },
-          },
-        });
-    }
-
-    let bilateralBudgetRows: any[] = [];
-    if (rbpRows.length) {
-      bilateralBudgetRows = await this._nonPooledProjectBudgetRepository.find({
-        where: {
-          result_project_id: In(rbpRows.map((r) => r.id)),
-          is_active: true,
-        },
-        relations: {
-          obj_result_project: { obj_clarisa_project: true },
-        },
-      });
-    }
-
-    let partnerBudgetRows: ResultInstitutionsBudget[] = [];
-    if (institutions.length) {
-      partnerBudgetRows = await this._resultInstitutionsBudgetRepository.find({
-        where: {
-          result_institution_id: In(institutions.map((i) => i.id)),
-          is_active: true,
-        },
-        relations: {
-          obj_result_institution: { obj_institutions: true },
-        },
-      });
-    }
-
     let scaling_study_urls: string[] = [];
     const readinessId = Number(dev?.innovation_readiness_level_id);
     if (
@@ -2060,37 +2124,7 @@ export class BilateralService {
 
     return {
       anticipated_user_demand,
-      initiative_budget: initiativeBudgetRows.map((b) => ({
-        initiative_official_code:
-          b.obj_result_initiative?.obj_initiative?.official_code ?? null,
-        initiative_name: b.obj_result_initiative?.obj_initiative?.name ?? null,
-        current_year: b.current_year == null ? null : Number(b.current_year),
-        next_year: b.next_year == null ? null : Number(b.next_year),
-        kind_cash: b.kind_cash == null ? null : Number(b.kind_cash),
-        is_determined: b.is_determined ?? null,
-      })),
-      bilateral_project_budget: bilateralBudgetRows.map((b) => ({
-        project_short_name:
-          b.obj_result_project?.obj_clarisa_project?.shortName ?? null,
-        in_cash: b.in_cash == null ? null : Number(b.in_cash),
-        in_kind: b.in_kind == null ? null : Number(b.in_kind),
-        kind_cash: b.kind_cash == null ? null : Number(b.kind_cash),
-        is_determined: b.is_determined ?? null,
-      })),
-      partner_budget: partnerBudgetRows.map((b) => ({
-        institution_name:
-          b.obj_result_institution?.obj_institutions?.name ?? null,
-        institution_acronym:
-          b.obj_result_institution?.obj_institutions?.acronym ?? null,
-        in_cash: b.in_cash == null ? null : Number(b.in_cash),
-        in_kind: b.in_kind == null ? null : Number(b.in_kind),
-        kind_cash: b.kind_cash == null ? null : Number(b.kind_cash),
-        is_determined: b.is_determined ?? null,
-      })),
-      reference_materials: refs.map((e) => ({ link: e.link })),
-      evidence_of_user_need_user_demand: userNeedDemandEvidence.map((e) => ({
-        link: e.link,
-      })),
+      ...sharedBudget,
       scaling_study_urls,
     };
   }
@@ -2184,6 +2218,260 @@ export class BilateralService {
     return { ...core, ...extra };
   }
 
+  private mapInnovationUseBilateralActor(a: ResultActor) {
+    const disagg = a.sex_and_age_disaggregation === true;
+    let sexAndAgeDisaggregation: boolean | null = null;
+    if (a.sex_and_age_disaggregation === true) {
+      sexAndAgeDisaggregation = true;
+    } else if (a.sex_and_age_disaggregation === false) {
+      sexAndAgeDisaggregation = false;
+    }
+    const actorTypeId = Number(
+      a.actor_type_id ?? a.obj_actor_type?.actor_type_id,
+    );
+    const isOtherActorType = Number.isFinite(actorTypeId) && actorTypeId === 5;
+    const base = {
+      actor_type_name: a.obj_actor_type?.name ?? null,
+      ...(isOtherActorType
+        ? { other_actor_type: a.other_actor_type ?? null }
+        : {}),
+      sex_and_age_disaggregation: sexAndAgeDisaggregation,
+      addressing_demands: a.addressing_demands ?? null,
+    };
+    if (disagg) {
+      return {
+        ...base,
+        how_many: a.how_many == null ? null : Number(a.how_many),
+      };
+    }
+    return {
+      ...base,
+      women: a.women == null ? null : Number(a.women),
+      women_youth: a.women_youth == null ? null : Number(a.women_youth),
+      men: a.men == null ? null : Number(a.men),
+      men_youth: a.men_youth == null ? null : Number(a.men_youth),
+    };
+  }
+
+  private mapInnovationUseBilateralOrganization(o: ResultsByInstitutionType) {
+    const institutionTypeId = Number(
+      o.institution_types_id ?? o.obj_institution_types?.code,
+    );
+    const isOtherInstitutionType =
+      Number.isFinite(institutionTypeId) &&
+      institutionTypeId === INNOVATION_DEV_INSTITUTION_TYPE_OTHER_CODE;
+    const base = {
+      institution_type_name: o.obj_institution_types?.name ?? null,
+      addressing_demands: o.addressing_demands ?? null,
+      how_many: o.how_many == null ? null : Number(o.how_many),
+      graduate_students:
+        o.graduate_students == null ? null : Number(o.graduate_students),
+    };
+    return isOtherInstitutionType
+      ? { ...base, other_institution: o.other_institution ?? null }
+      : base;
+  }
+
+  private mapInnovationUseBilateralMeasure(m: ResultIpMeasure) {
+    return {
+      unit_of_measure: m.unit_of_measure ?? null,
+      quantity: m.quantity == null ? null : Number(m.quantity),
+      addressing_demands: m.addressing_demands ?? null,
+    };
+  }
+
+  private async resolveInnovationUseLevelForSummary(
+    use: any,
+  ): Promise<ClarisaInnovationUseLevel | null> {
+    if (use?.obj_innovation_use_level) {
+      return use.obj_innovation_use_level;
+    }
+    const fk = Number(use?.innovation_use_level_id);
+    if (!Number.isFinite(fk)) {
+      return null;
+    }
+    return this.dataSource.getRepository(ClarisaInnovationUseLevel).findOne({
+      where: { id: fk },
+    });
+  }
+
+  private async buildInnovationUseLinkedResultsList(originResultId: number) {
+    const ids =
+      await this._resultsInnovationsUseRepository.getLinkedResultsByOrigin(
+        originResultId,
+      );
+    if (!ids.length) {
+      return [];
+    }
+    const rows = await this.dataSource.getRepository(Result).find({
+      where: { id: In(ids), is_active: true },
+      relations: { obj_result_type: true },
+    });
+    const byId = new Map(rows.map((r) => [r.id, r]));
+    return ids.map((id) => {
+      const r = byId.get(id);
+      return {
+        result_id: id,
+        title: r?.title ?? null,
+        result_type_id: r?.result_type_id ?? null,
+        result_type_name: r?.obj_result_type?.name ?? null,
+      };
+    });
+  }
+
+  private async buildInnovationUseBilateralSummary(filtered: any) {
+    const use = filtered?.results_innovations_use_object;
+    if (!use || use.is_active === false) {
+      return null;
+    }
+
+    const resultId = filtered.id;
+    const innov_use_to_be_determined = !!use.innov_use_to_be_determined;
+    const innov_use_2030_to_be_determined =
+      !!use.innov_use_2030_to_be_determined;
+
+    const [
+      sharedBudget,
+      linked_results,
+      actorsS1,
+      orgsS1,
+      measuresS1,
+      actorsS2,
+      orgsS2,
+      measuresS2,
+      useLevelEntity,
+    ] = await Promise.all([
+      this.buildInnovationSharedBudgetAndEvidenceExtras(resultId, {
+        includeReferenceAndUserNeedEvidence: false,
+      }),
+      this.buildInnovationUseLinkedResultsList(resultId),
+      this.dataSource.getRepository(ResultActor).find({
+        where: {
+          result_id: resultId,
+          is_active: true,
+          section_id: INNOVATION_USE_SECTION_CURRENT,
+        },
+        relations: { obj_actor_type: true },
+      }),
+      this.dataSource.getRepository(ResultsByInstitutionType).find({
+        where: {
+          results_id: resultId,
+          institution_roles_id: INNOVATION_DEV_ANTICIPATED_USER_ORG_ROLE_ID,
+          is_active: true,
+          section_id: INNOVATION_USE_SECTION_CURRENT,
+        },
+        relations: { obj_institution_types: true },
+      }),
+      this.dataSource.getRepository(ResultIpMeasure).find({
+        where: {
+          result_id: resultId,
+          is_active: true,
+          section_id: INNOVATION_USE_SECTION_CURRENT,
+        },
+      }),
+      this.dataSource.getRepository(ResultActor).find({
+        where: {
+          result_id: resultId,
+          is_active: true,
+          section_id: INNOVATION_USE_SECTION_2030,
+        },
+        relations: { obj_actor_type: true },
+      }),
+      this.dataSource.getRepository(ResultsByInstitutionType).find({
+        where: {
+          results_id: resultId,
+          institution_roles_id: INNOVATION_DEV_ANTICIPATED_USER_ORG_ROLE_ID,
+          is_active: true,
+          section_id: INNOVATION_USE_SECTION_2030,
+        },
+        relations: { obj_institution_types: true },
+      }),
+      this.dataSource.getRepository(ResultIpMeasure).find({
+        where: {
+          result_id: resultId,
+          is_active: true,
+          section_id: INNOVATION_USE_SECTION_2030,
+        },
+      }),
+      this.resolveInnovationUseLevelForSummary(use),
+    ]);
+
+    const innovation_use_level = useLevelEntity
+      ? {
+          id: useLevelEntity.id,
+          level:
+            useLevelEntity.level == null ? null : Number(useLevelEntity.level),
+          name: useLevelEntity.name ?? null,
+          definition: useLevelEntity.definition ?? null,
+        }
+      : null;
+
+    let scaling_study_urls: string[] = [];
+    const levelNum = innovation_use_level?.level;
+    if (
+      levelNum != null &&
+      Number.isFinite(Number(levelNum)) &&
+      Number(levelNum) >= InnovationUseLevel.Level_6 &&
+      use?.result_innovation_use_id
+    ) {
+      const urls = await this.dataSource
+        .getRepository(ResultScalingStudyUrl)
+        .find({
+          where: {
+            result_innov_use_id: use.result_innovation_use_id,
+            is_active: true,
+          },
+        });
+      scaling_study_urls = urls
+        .map((u) => u.study_url)
+        .filter((s): s is string => typeof s === 'string' && s.length > 0);
+    }
+
+    const male_using = use.male_using == null ? null : Number(use.male_using);
+    const female_using =
+      use.female_using == null ? null : Number(use.female_using);
+
+    const current_section = innov_use_to_be_determined
+      ? null
+      : {
+          actors: actorsS1.map((a) => this.mapInnovationUseBilateralActor(a)),
+          organizations: orgsS1.map((o) =>
+            this.mapInnovationUseBilateralOrganization(o),
+          ),
+          other_quantitative: measuresS1.map((m) =>
+            this.mapInnovationUseBilateralMeasure(m),
+          ),
+        };
+
+    const innovation_use_2030_section = innov_use_2030_to_be_determined
+      ? null
+      : {
+          actors: actorsS2.map((a) => this.mapInnovationUseBilateralActor(a)),
+          organizations: orgsS2.map((o) =>
+            this.mapInnovationUseBilateralOrganization(o),
+          ),
+          other_quantitative: measuresS2.map((m) =>
+            this.mapInnovationUseBilateralMeasure(m),
+          ),
+        };
+
+    return {
+      has_innovation_link: !!use.has_innovation_link,
+      linked_results,
+      innov_use_to_be_determined,
+      current_core_innovation_use_supported_by_evidence:
+        innov_use_to_be_determined ? { male_using, female_using } : null,
+      current_section,
+      innovation_use_level,
+      readiness_level_explanation: use.readiness_level_explanation ?? null,
+      has_scaling_studies: !!use.has_scaling_studies,
+      scaling_study_urls,
+      innov_use_2030_to_be_determined,
+      innovation_use_2030_section,
+      ...sharedBudget,
+    };
+  }
+
   private async enrichBilateralResultResponse(filtered: any): Promise<void> {
     if (!filtered?.id) return;
     filtered.obj_results_toc_result =
@@ -2207,6 +2495,11 @@ export class BilateralService {
       filtered.innovation_development_summary =
         await this.buildInnovationDevelopmentBilateralSummary(filtered);
       delete filtered.results_innovations_dev_object;
+    }
+    if (filtered.result_type_id === ResultTypeEnum.INNOVATION_USE) {
+      filtered.innovation_use_summary =
+        await this.buildInnovationUseBilateralSummary(filtered);
+      delete filtered.results_innovations_use_object;
     }
     delete filtered.obj_result_by_project;
   }

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
@@ -2778,8 +2778,38 @@ export class BilateralService {
       delete filtered.result_knowledge_product_array;
     }
     if (filtered.result_type_id === ResultTypeEnum.INNOVATION_DEVELOPMENT) {
-      filtered.innovation_development_summary =
+      const innovationDevelopmentCoreSummary =
         await this.buildInnovationDevelopmentBilateralSummary(filtered);
+      let innovation_development_questionnaire: {
+        responsible_innovation_and_scaling: unknown[];
+        intellectual_property_rights: unknown[];
+        innovation_team_diversity: unknown[];
+        megatrends: unknown[];
+      } = {
+        responsible_innovation_and_scaling: [],
+        intellectual_property_rights: [],
+        innovation_team_diversity: [],
+        megatrends: [],
+      };
+      try {
+        const header = await this._resultRepository.getResultById(filtered.id);
+        innovation_development_questionnaire =
+          await this._resultQuestionsService.buildInnovationDevelopmentQuestionnaireForBilateral(
+            filtered.id,
+            header?.portfolio,
+          );
+      } catch {
+        this.logger.warn(
+          `Bilateral enrich: could not load innovation dev questions/answers for result ${filtered.id}`,
+        );
+      }
+      filtered.innovation_development_summary =
+        innovationDevelopmentCoreSummary == null
+          ? { innovation_development_questionnaire }
+          : {
+              ...innovationDevelopmentCoreSummary,
+              innovation_development_questionnaire,
+            };
       delete filtered.results_innovations_dev_object;
     }
     if (filtered.result_type_id === ResultTypeEnum.INNOVATION_USE) {

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
@@ -72,6 +72,20 @@ import { NoopBilateralHandler } from './handlers/noop.handler';
 import { ResultByInitiativesRepository } from '../results/results_by_inititiatives/resultByInitiatives.repository';
 import { ShareResultRequestRepository } from '../results/share-result-request/share-result-request.repository';
 import { NonPooledProjectBudgetRepository } from '../results/result_budget/repositories/non_pooled_proyect_budget.repository';
+import { InnovationReadinessLevelByLevel } from '../results-framework-reporting/innovation_dev/enum/innov-readiness-level.enum';
+import { ResultActor } from '../results/result-actors/entities/result-actor.entity';
+import { ResultIpMeasure } from '../ipsr/result-ip-measures/entities/result-ip-measure.entity';
+import { ResultsByInstitutionType } from '../results/results_by_institution_types/entities/results_by_institution_type.entity';
+import { ResultInitiativeBudget } from '../results/result_budget/entities/result_initiative_budget.entity';
+import { ResultScalingStudyUrl } from '../results-framework-reporting/result_scaling_study_urls/entities/result_scaling_study_url.entity';
+import { ClarisaInnovationCharacteristic } from '../../clarisa/clarisa-innovation-characteristics/entities/clarisa-innovation-characteristic.entity';
+import { ClarisaInnovationType } from '../../clarisa/clarisa-innovation-type/entities/clarisa-innovation-type.entity';
+import { ClarisaInnovationReadinessLevel } from '../../clarisa/clarisa-innovation-readiness-levels/entities/clarisa-innovation-readiness-level.entity';
+
+/** Anticipated innovation user — organization-type rows (same role as PRMS Innovation Dev). */
+const INNOVATION_DEV_ANTICIPATED_USER_ORG_ROLE_ID = 5;
+/** `clarisa_institution_types.code` for "Other" (anticipated user organizations). */
+const INNOVATION_DEV_INSTITUTION_TYPE_OTHER_CODE = 78;
 
 /** Map result_type name (ListResultsResultTypeEnum) to result_type.id */
 const RESULT_TYPE_NAME_TO_ID: Partial<
@@ -811,7 +825,11 @@ export class BilateralService {
         results_capacity_development_object: true,
       }),
       ...(isInnovationDev && {
-        results_innovations_dev_object: true,
+        results_innovations_dev_object: {
+          innovation_characterization: true,
+          innovation_nature: true,
+          innovation_readiness_level: true,
+        },
       }),
       ...(isInnovationUse && {
         results_innovations_use_object: true,
@@ -1527,7 +1545,12 @@ export class BilateralService {
     result.result_center_array = onlyActive(result.result_center_array);
     result.obj_results_toc_result = onlyActive(result.obj_results_toc_result);
     result.obj_result_by_project = onlyActive(result.obj_result_by_project);
-    result.evidence_array = onlyActive(result.evidence_array);
+    const activeEvidence = onlyActive(result.evidence_array);
+    result.evidence_array = Array.isArray(activeEvidence)
+      ? activeEvidence.filter(
+          (e) => Number(e?.evidence_type_id) === EvidenceTypeEnum.MAIN,
+        )
+      : activeEvidence;
     result.result_knowledge_product_array = onlyActive(
       result.result_knowledge_product_array,
     );
@@ -1842,6 +1865,325 @@ export class BilateralService {
     return out;
   }
 
+  private async buildInnovationDevelopmentBilateralExtra(
+    resultId: number,
+    dev: any,
+  ) {
+    const anticipated_user_demand = {
+      actors: [] as Array<{
+        actor_type_name: string | null;
+        other_actor_type?: string | null;
+        sex_and_age_disaggregation: boolean | null;
+        addressing_demands: string | null;
+        has_women?: boolean | null;
+        has_women_youth?: boolean | null;
+        has_men?: boolean | null;
+        has_men_youth?: boolean | null;
+      }>,
+      organizations: [] as Array<{
+        institution_type_name: string | null;
+        addressing_demands: string | null;
+        other_institution?: string | null;
+      }>,
+      measures: [] as Array<{
+        unit_of_measure: string | null;
+        quantity: number | null;
+        addressing_demands: string | null;
+      }>,
+    };
+
+    const [
+      actors,
+      measures,
+      orgTypes,
+      initiatives,
+      rbpRows,
+      institutions,
+      refs,
+      userNeedDemandEvidence,
+    ] = await Promise.all([
+      this.dataSource.getRepository(ResultActor).find({
+        where: { result_id: resultId, is_active: true },
+        relations: { obj_actor_type: true },
+      }),
+      this.dataSource.getRepository(ResultIpMeasure).find({
+        where: { result_id: resultId, is_active: true },
+      }),
+      this.dataSource.getRepository(ResultsByInstitutionType).find({
+        where: {
+          results_id: resultId,
+          institution_roles_id: INNOVATION_DEV_ANTICIPATED_USER_ORG_ROLE_ID,
+          is_active: true,
+        },
+        relations: { obj_institution_types: true },
+      }),
+      this._resultByInitiativesRepository.find({
+        where: { result_id: resultId, is_active: true },
+      }),
+      this._resultsByProjectsRepository.find({
+        where: { result_id: resultId, is_active: true },
+      }),
+      this._resultByIntitutionsRepository.find({
+        where: { result_id: resultId, is_active: true },
+      }),
+      this._evidencesRepository.find({
+        where: {
+          result_id: resultId,
+          evidence_type_id: EvidenceTypeEnum.MATERIALS,
+          is_active: 1,
+        },
+      }),
+      this._evidencesRepository.find({
+        where: {
+          result_id: resultId,
+          evidence_type_id: EvidenceTypeEnum.USER_NEED_USER_DEMAND,
+          is_active: 1,
+        },
+      }),
+    ]);
+
+    anticipated_user_demand.actors = actors.map((a) => {
+      const disagg = a.sex_and_age_disaggregation === true;
+      let sexAndAgeDisaggregation: boolean | null = null;
+      if (a.sex_and_age_disaggregation === true) {
+        sexAndAgeDisaggregation = true;
+      } else if (a.sex_and_age_disaggregation === false) {
+        sexAndAgeDisaggregation = false;
+      }
+      const actorTypeId = Number(
+        a.actor_type_id ?? a.obj_actor_type?.actor_type_id,
+      );
+      const isOtherActorType =
+        Number.isFinite(actorTypeId) && actorTypeId === 5;
+      const base = {
+        actor_type_name: a.obj_actor_type?.name ?? null,
+        ...(isOtherActorType
+          ? { other_actor_type: a.other_actor_type ?? null }
+          : {}),
+        sex_and_age_disaggregation: sexAndAgeDisaggregation,
+        addressing_demands: a.addressing_demands ?? null,
+      };
+      if (disagg) {
+        return base;
+      }
+      return {
+        ...base,
+        has_women: a.has_women ?? null,
+        has_women_youth: a.has_women_youth ?? null,
+        has_men: a.has_men ?? null,
+        has_men_youth: a.has_men_youth ?? null,
+      };
+    });
+
+    anticipated_user_demand.measures = measures.map((m) => ({
+      unit_of_measure: m.unit_of_measure ?? null,
+      quantity: m.quantity == null ? null : Number(m.quantity),
+      addressing_demands: m.addressing_demands ?? null,
+    }));
+
+    anticipated_user_demand.organizations = orgTypes.map((o) => {
+      const institutionTypeId = Number(
+        o.institution_types_id ?? o.obj_institution_types?.code,
+      );
+      const isOtherInstitutionType =
+        Number.isFinite(institutionTypeId) &&
+        institutionTypeId === INNOVATION_DEV_INSTITUTION_TYPE_OTHER_CODE;
+      const base = {
+        institution_type_name: o.obj_institution_types?.name ?? null,
+        addressing_demands: o.addressing_demands ?? null,
+      };
+      return isOtherInstitutionType
+        ? { ...base, other_institution: o.other_institution ?? null }
+        : base;
+    });
+
+    let initiativeBudgetRows: ResultInitiativeBudget[] = [];
+    if (initiatives.length) {
+      initiativeBudgetRows = await this.dataSource
+        .getRepository(ResultInitiativeBudget)
+        .find({
+          where: {
+            result_initiative_id: In(initiatives.map((i) => i.id)),
+            is_active: true,
+          },
+          relations: {
+            obj_result_initiative: { obj_initiative: true },
+          },
+        });
+    }
+
+    let bilateralBudgetRows: any[] = [];
+    if (rbpRows.length) {
+      bilateralBudgetRows = await this._nonPooledProjectBudgetRepository.find({
+        where: {
+          result_project_id: In(rbpRows.map((r) => r.id)),
+          is_active: true,
+        },
+        relations: {
+          obj_result_project: { obj_clarisa_project: true },
+        },
+      });
+    }
+
+    let partnerBudgetRows: ResultInstitutionsBudget[] = [];
+    if (institutions.length) {
+      partnerBudgetRows = await this._resultInstitutionsBudgetRepository.find({
+        where: {
+          result_institution_id: In(institutions.map((i) => i.id)),
+          is_active: true,
+        },
+        relations: {
+          obj_result_institution: { obj_institutions: true },
+        },
+      });
+    }
+
+    let scaling_study_urls: string[] = [];
+    const readinessId = Number(dev?.innovation_readiness_level_id);
+    if (
+      Number.isFinite(readinessId) &&
+      readinessId >= InnovationReadinessLevelByLevel.Level_6 &&
+      dev?.result_innovation_dev_id
+    ) {
+      const urls = await this.dataSource
+        .getRepository(ResultScalingStudyUrl)
+        .find({
+          where: {
+            result_innov_dev_id: dev.result_innovation_dev_id,
+            is_active: true,
+          },
+        });
+      scaling_study_urls = urls
+        .map((u) => u.study_url)
+        .filter((s): s is string => typeof s === 'string' && s.length > 0);
+    }
+
+    return {
+      anticipated_user_demand,
+      initiative_budget: initiativeBudgetRows.map((b) => ({
+        initiative_official_code:
+          b.obj_result_initiative?.obj_initiative?.official_code ?? null,
+        initiative_name: b.obj_result_initiative?.obj_initiative?.name ?? null,
+        current_year: b.current_year == null ? null : Number(b.current_year),
+        next_year: b.next_year == null ? null : Number(b.next_year),
+        kind_cash: b.kind_cash == null ? null : Number(b.kind_cash),
+        is_determined: b.is_determined ?? null,
+      })),
+      bilateral_project_budget: bilateralBudgetRows.map((b) => ({
+        project_short_name:
+          b.obj_result_project?.obj_clarisa_project?.shortName ?? null,
+        in_cash: b.in_cash == null ? null : Number(b.in_cash),
+        in_kind: b.in_kind == null ? null : Number(b.in_kind),
+        kind_cash: b.kind_cash == null ? null : Number(b.kind_cash),
+        is_determined: b.is_determined ?? null,
+      })),
+      partner_budget: partnerBudgetRows.map((b) => ({
+        institution_name:
+          b.obj_result_institution?.obj_institutions?.name ?? null,
+        institution_acronym:
+          b.obj_result_institution?.obj_institutions?.acronym ?? null,
+        in_cash: b.in_cash == null ? null : Number(b.in_cash),
+        in_kind: b.in_kind == null ? null : Number(b.in_kind),
+        kind_cash: b.kind_cash == null ? null : Number(b.kind_cash),
+        is_determined: b.is_determined ?? null,
+      })),
+      reference_materials: refs.map((e) => ({ link: e.link })),
+      evidence_of_user_need_user_demand: userNeedDemandEvidence.map((e) => ({
+        link: e.link,
+      })),
+      scaling_study_urls,
+    };
+  }
+
+  private async buildInnovationDevelopmentBilateralSummary(filtered: any) {
+    const dev = filtered?.results_innovations_dev_object;
+    if (!dev || dev.is_active === false) return null;
+
+    const natureCode = Number(dev.innovation_nature_id);
+    let typologyPromise: Promise<ClarisaInnovationType | null>;
+    if (dev.innovation_nature) {
+      typologyPromise = Promise.resolve(dev.innovation_nature);
+    } else if (Number.isFinite(natureCode)) {
+      typologyPromise = this.dataSource
+        .getRepository(ClarisaInnovationType)
+        .findOne({ where: { code: natureCode } });
+    } else {
+      typologyPromise = Promise.resolve(null);
+    }
+
+    const readinessFk = Number(dev.innovation_readiness_level_id);
+    let readinessPromise: Promise<ClarisaInnovationReadinessLevel | null>;
+    if (dev.innovation_readiness_level) {
+      readinessPromise = Promise.resolve(dev.innovation_readiness_level);
+    } else if (Number.isFinite(readinessFk)) {
+      readinessPromise = this.dataSource
+        .getRepository(ClarisaInnovationReadinessLevel)
+        .findOne({ where: { id: readinessFk } });
+    } else {
+      readinessPromise = Promise.resolve(null);
+    }
+
+    const charFk = Number(dev.innovation_characterization_id);
+    let characterizationPromise: Promise<ClarisaInnovationCharacteristic | null>;
+    if (dev.innovation_characterization) {
+      characterizationPromise = Promise.resolve(
+        dev.innovation_characterization,
+      );
+    } else if (Number.isFinite(charFk)) {
+      characterizationPromise = this.dataSource
+        .getRepository(ClarisaInnovationCharacteristic)
+        .findOne({ where: { id: charFk } });
+    } else {
+      characterizationPromise = Promise.resolve(null);
+    }
+
+    const [characterization, typology, readinessEntity] = await Promise.all([
+      characterizationPromise,
+      typologyPromise,
+      readinessPromise,
+    ]);
+
+    const core = {
+      short_name: dev.short_title ?? null,
+      characterization: characterization
+        ? {
+            id: characterization.id,
+            name: characterization.name ?? null,
+            definition: characterization.definition ?? null,
+          }
+        : null,
+      typology: typology
+        ? {
+            code: typology.code ?? null,
+            name: typology.name ?? null,
+            definition: typology.definition ?? null,
+          }
+        : null,
+      innovation_user_to_be_determined: !!dev.innovation_user_to_be_determined,
+      innovation_developers: dev.innovation_developers ?? null,
+      innovation_collaborators: dev.innovation_collaborators ?? null,
+      innovation_readiness_level: readinessEntity
+        ? {
+            id: readinessEntity.id,
+            level:
+              readinessEntity.level == null
+                ? null
+                : Number(readinessEntity.level),
+            name: readinessEntity.name ?? null,
+            definition: readinessEntity.definition ?? null,
+          }
+        : null,
+      evidences_justification: dev.evidences_justification ?? null,
+      has_scaling_studies: !!dev.has_scaling_studies,
+    };
+
+    const extra = await this.buildInnovationDevelopmentBilateralExtra(
+      filtered.id,
+      dev,
+    );
+    return { ...core, ...extra };
+  }
+
   private async enrichBilateralResultResponse(filtered: any): Promise<void> {
     if (!filtered?.id) return;
     filtered.obj_results_toc_result =
@@ -1860,6 +2202,11 @@ export class BilateralService {
       filtered.knowledge_product_summary =
         this.buildKnowledgeProductBilateralSummary(filtered);
       delete filtered.result_knowledge_product_array;
+    }
+    if (filtered.result_type_id === ResultTypeEnum.INNOVATION_DEVELOPMENT) {
+      filtered.innovation_development_summary =
+        await this.buildInnovationDevelopmentBilateralSummary(filtered);
+      delete filtered.results_innovations_dev_object;
     }
     delete filtered.obj_result_by_project;
   }

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
@@ -84,6 +84,8 @@ import { ClarisaInnovationReadinessLevel } from '../../clarisa/clarisa-innovatio
 import { ClarisaInnovationUseLevel } from '../../clarisa/clarisa-innovation-use-levels/entities/clarisa-innovation-use-level.entity';
 import { InnovationUseLevel } from '../results-framework-reporting/innovation-use/enum/innov-use-levels.enum';
 import { ResultsInnovationsUseRepository } from '../results/summary/repositories/results-innovations-use.repository';
+import { ResultsCapacityDevelopmentsRepository } from '../results/summary/repositories/results-capacity-developments.repository';
+import { CapdevsDeliveryMethod } from '../results/capdevs-delivery-methods/entities/capdevs-delivery-method.entity';
 
 /** Anticipated innovation user — organization-type rows (same role as PRMS Innovation Dev). */
 const INNOVATION_DEV_ANTICIPATED_USER_ORG_ROLE_ID = 5;
@@ -93,6 +95,9 @@ const INNOVATION_DEV_INSTITUTION_TYPE_OTHER_CODE = 78;
 /** PRMS Innovation Use — current (reporting year) vs 2030 sections on actors / orgs / measures. */
 const INNOVATION_USE_SECTION_CURRENT = 1;
 const INNOVATION_USE_SECTION_2030 = 2;
+
+/** Capacity sharing — implementing organizations (`summary.service` / PRMS role 3). */
+const CAPACITY_SHARING_IMPLEMENTING_ORG_ROLE_ID = 3;
 
 /** Map result_type name (ListResultsResultTypeEnum) to result_type.id */
 const RESULT_TYPE_NAME_TO_ID: Partial<
@@ -179,6 +184,7 @@ export class BilateralService {
     private readonly _shareResultRequestRepository: ShareResultRequestRepository,
     private readonly _nonPooledProjectBudgetRepository: NonPooledProjectBudgetRepository,
     private readonly _resultsInnovationsUseRepository: ResultsInnovationsUseRepository,
+    private readonly _resultsCapacityDevelopmentsRepository: ResultsCapacityDevelopmentsRepository,
     private readonly _knowledgeProductHandler: KnowledgeProductBilateralHandler,
     private readonly _capacityChangeHandler: CapacityChangeBilateralHandler,
     private readonly _innovationDevelopmentHandler: InnovationDevelopmentBilateralHandler,
@@ -788,8 +794,6 @@ export class BilateralService {
 
   private buildResultRelations(resultTypeId?: number) {
     const isKpType = resultTypeId === ResultTypeEnum.KNOWLEDGE_PRODUCT;
-    const isCapacitySharing =
-      resultTypeId === ResultTypeEnum.CAPACITY_SHARING_FOR_DEVELOPMENT;
     const isInnovationDev =
       resultTypeId === ResultTypeEnum.INNOVATION_DEVELOPMENT;
     const isInnovationUse = resultTypeId === ResultTypeEnum.INNOVATION_USE;
@@ -828,9 +832,6 @@ export class BilateralService {
           result_knowledge_product_metadata_array: true,
           result_knowledge_product_author_array: true,
         },
-      }),
-      ...(isCapacitySharing && {
-        results_capacity_development_object: true,
       }),
       ...(isInnovationDev && {
         results_innovations_dev_object: {
@@ -2472,6 +2473,124 @@ export class BilateralService {
     };
   }
 
+  private mapCapacitySharingImplementingInstitution(row: any) {
+    return {
+      name: row.institutions_name ?? null,
+      acronym: row.institutions_acronym ?? null,
+      institution_type_name: row.institutions_type_name ?? null,
+    };
+  }
+
+  private toCapdevCount(value: unknown): number | null {
+    if (value === null || value === undefined) return null;
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  }
+
+  private shapeCapacityDevelopmentBilateralPayload(
+    capDev: any,
+    institutionsMapped: Array<{
+      name: string | null;
+      acronym: string | null;
+      institution_type_name: string | null;
+    }>,
+    deliveryMethod: CapdevsDeliveryMethod | null,
+  ) {
+    const training_length =
+      capDev.capdev_term_name != null ||
+      capDev.capdev_term_term != null ||
+      capDev.capdev_term_description != null
+        ? {
+            name:
+              capDev.capdev_term_name != null
+                ? String(capDev.capdev_term_name)
+                : null,
+            term:
+              capDev.capdev_term_term != null
+                ? String(capDev.capdev_term_term)
+                : null,
+            description:
+              capDev.capdev_term_description != null
+                ? String(capDev.capdev_term_description)
+                : null,
+          }
+        : null;
+
+    const delivery_method = deliveryMethod
+      ? {
+          name: deliveryMethod.name ?? null,
+          description: deliveryMethod.description ?? null,
+        }
+      : null;
+
+    const orgFlag = capDev.is_attending_for_organization;
+    const is_attending_for_organization =
+      orgFlag === true || orgFlag === 1 || orgFlag === '1'
+        ? true
+        : orgFlag === false || orgFlag === 0 || orgFlag === '0'
+          ? false
+          : null;
+
+    return {
+      created_date: capDev.created_date ?? null,
+      last_updated_date: capDev.last_updated_date ?? null,
+      male_using: this.toCapdevCount(capDev.male_using),
+      female_using: this.toCapdevCount(capDev.female_using),
+      non_binary_using: this.toCapdevCount(capDev.non_binary_using),
+      has_unkown_using: this.toCapdevCount(capDev.has_unkown_using),
+      is_attending_for_organization,
+      delivery_method,
+      training_length,
+      institutions: institutionsMapped,
+    };
+  }
+
+  /** Bilateral CapDev: human-readable delivery method & training length (no lookup FKs). */
+  private async buildCapacityDevelopmentBilateralSummary(resultId: number) {
+    const [capDev, institutions] = await Promise.all([
+      this._resultsCapacityDevelopmentsRepository.capDevExists(resultId),
+      this._resultByIntitutionsRepository.getGenericAllResultByInstitutionByRole(
+        resultId,
+        CAPACITY_SHARING_IMPLEMENTING_ORG_ROLE_ID,
+      ),
+    ]);
+
+    const institutionsMapped = (institutions ?? []).map((r: any) =>
+      this.mapCapacitySharingImplementingInstitution(r),
+    );
+
+    if (!capDev) {
+      return {
+        created_date: null,
+        last_updated_date: null,
+        male_using: null,
+        female_using: null,
+        non_binary_using: null,
+        has_unkown_using: null,
+        is_attending_for_organization: null,
+        delivery_method: null,
+        training_length: null,
+        institutions: institutionsMapped,
+      };
+    }
+
+    const dmId = Number(capDev.capdev_delivery_method_id);
+    let deliveryMethod: CapdevsDeliveryMethod | null = null;
+    if (Number.isFinite(dmId) && dmId > 0) {
+      deliveryMethod = await this.dataSource
+        .getRepository(CapdevsDeliveryMethod)
+        .findOne({
+          where: { capdev_delivery_method_id: dmId },
+        });
+    }
+
+    return this.shapeCapacityDevelopmentBilateralPayload(
+      capDev,
+      institutionsMapped,
+      deliveryMethod,
+    );
+  }
+
   private async enrichBilateralResultResponse(filtered: any): Promise<void> {
     if (!filtered?.id) return;
     filtered.obj_results_toc_result =
@@ -2500,6 +2619,14 @@ export class BilateralService {
       filtered.innovation_use_summary =
         await this.buildInnovationUseBilateralSummary(filtered);
       delete filtered.results_innovations_use_object;
+    }
+    if (
+      filtered.result_type_id ===
+      ResultTypeEnum.CAPACITY_SHARING_FOR_DEVELOPMENT
+    ) {
+      filtered.capacity_development_summary =
+        await this.buildCapacityDevelopmentBilateralSummary(filtered.id);
+      delete filtered.results_capacity_development_object;
     }
     delete filtered.obj_result_by_project;
   }

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
@@ -2159,55 +2159,58 @@ export class BilateralService {
     };
   }
 
-  private async buildInnovationDevelopmentBilateralSummary(filtered: any) {
-    const dev = filtered?.results_innovations_dev_object;
-    if (!dev || dev.is_active === false) return null;
-
-    const natureCode = Number(dev.innovation_nature_id);
-    let typologyPromise: Promise<ClarisaInnovationType | null>;
+  private resolveInnovationDevTypologyPromise(
+    dev: any,
+    natureCode: number,
+  ): Promise<ClarisaInnovationType | null> {
     if (dev.innovation_nature) {
-      typologyPromise = Promise.resolve(dev.innovation_nature);
-    } else if (Number.isFinite(natureCode)) {
-      typologyPromise = this.dataSource
+      return Promise.resolve(dev.innovation_nature);
+    }
+    if (Number.isFinite(natureCode)) {
+      return this.dataSource
         .getRepository(ClarisaInnovationType)
         .findOne({ where: { code: natureCode } });
-    } else {
-      typologyPromise = Promise.resolve(null);
     }
+    return Promise.resolve(null);
+  }
 
-    const readinessFk = Number(dev.innovation_readiness_level_id);
-    let readinessPromise: Promise<ClarisaInnovationReadinessLevel | null>;
+  private resolveInnovationDevReadinessPromise(
+    dev: any,
+    readinessFk: number,
+  ): Promise<ClarisaInnovationReadinessLevel | null> {
     if (dev.innovation_readiness_level) {
-      readinessPromise = Promise.resolve(dev.innovation_readiness_level);
-    } else if (Number.isFinite(readinessFk)) {
-      readinessPromise = this.dataSource
+      return Promise.resolve(dev.innovation_readiness_level);
+    }
+    if (Number.isFinite(readinessFk)) {
+      return this.dataSource
         .getRepository(ClarisaInnovationReadinessLevel)
         .findOne({ where: { id: readinessFk } });
-    } else {
-      readinessPromise = Promise.resolve(null);
     }
+    return Promise.resolve(null);
+  }
 
-    const charFk = Number(dev.innovation_characterization_id);
-    let characterizationPromise: Promise<ClarisaInnovationCharacteristic | null>;
+  private resolveInnovationDevCharacterizationPromise(
+    dev: any,
+    charFk: number,
+  ): Promise<ClarisaInnovationCharacteristic | null> {
     if (dev.innovation_characterization) {
-      characterizationPromise = Promise.resolve(
-        dev.innovation_characterization,
-      );
-    } else if (Number.isFinite(charFk)) {
-      characterizationPromise = this.dataSource
+      return Promise.resolve(dev.innovation_characterization);
+    }
+    if (Number.isFinite(charFk)) {
+      return this.dataSource
         .getRepository(ClarisaInnovationCharacteristic)
         .findOne({ where: { id: charFk } });
-    } else {
-      characterizationPromise = Promise.resolve(null);
     }
+    return Promise.resolve(null);
+  }
 
-    const [characterization, typology, readinessEntity] = await Promise.all([
-      characterizationPromise,
-      typologyPromise,
-      readinessPromise,
-    ]);
-
-    const core = {
+  private mapInnovationDevBilateralCoreSummary(
+    dev: any,
+    characterization: ClarisaInnovationCharacteristic | null,
+    typology: ClarisaInnovationType | null,
+    readinessEntity: ClarisaInnovationReadinessLevel | null,
+  ) {
+    return {
       short_name: dev.short_title ?? null,
       characterization: characterization
         ? {
@@ -2241,6 +2244,28 @@ export class BilateralService {
       evidences_justification: dev.evidences_justification ?? null,
       has_scaling_studies: !!dev.has_scaling_studies,
     };
+  }
+
+  private async buildInnovationDevelopmentBilateralSummary(filtered: any) {
+    const dev = filtered?.results_innovations_dev_object;
+    if (!dev || dev.is_active === false) return null;
+
+    const natureCode = Number(dev.innovation_nature_id);
+    const readinessFk = Number(dev.innovation_readiness_level_id);
+    const charFk = Number(dev.innovation_characterization_id);
+
+    const [characterization, typology, readinessEntity] = await Promise.all([
+      this.resolveInnovationDevCharacterizationPromise(dev, charFk),
+      this.resolveInnovationDevTypologyPromise(dev, natureCode),
+      this.resolveInnovationDevReadinessPromise(dev, readinessFk),
+    ]);
+
+    const core = this.mapInnovationDevBilateralCoreSummary(
+      dev,
+      characterization,
+      typology,
+      readinessEntity,
+    );
 
     const extra = await this.buildInnovationDevelopmentBilateralExtra(
       filtered.id,
@@ -2559,12 +2584,12 @@ export class BilateralService {
       : null;
 
     const orgFlag = capDev.is_attending_for_organization;
-    const is_attending_for_organization =
-      orgFlag === true || orgFlag === 1 || orgFlag === '1'
-        ? true
-        : orgFlag === false || orgFlag === 0 || orgFlag === '0'
-          ? false
-          : null;
+    let is_attending_for_organization: boolean | null = null;
+    if (orgFlag === true || orgFlag === 1 || orgFlag === '1') {
+      is_attending_for_organization = true;
+    } else if (orgFlag === false || orgFlag === 0 || orgFlag === '0') {
+      is_attending_for_organization = false;
+    }
 
     return {
       male_using: this.toCapdevCount(capDev.male_using),

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
@@ -822,7 +822,9 @@ export class BilateralService {
       },
       result_country_array: {
         country_object: true,
-        result_countries_subnational_array: true,
+        result_countries_subnational_array: {
+          clarisa_subnational_scope_object: true,
+        },
       },
       result_center_array: {
         clarisa_center_object: {
@@ -1532,6 +1534,36 @@ export class BilateralService {
     await this._shareResultRequestRepository.logicalDelete(resultId);
   }
 
+  /** Bilateral JSON: region rows without internal ids / audit columns. */
+  private slimBilateralResultRegionRow(rr: any) {
+    return {
+      region_id: rr.region_id ?? null,
+      geo_scope_role_id: rr.geo_scope_role_id ?? null,
+      region_object: rr.region_object ?? null,
+    };
+  }
+
+  /** Bilateral JSON: country rows without internal ids / audit columns. */
+  private slimBilateralResultCountrySubnationalRow(sn: any) {
+    return {
+      clarisa_subnational_scope_code: sn.clarisa_subnational_scope_code ?? null,
+      geo_scope_role_id: sn.geo_scope_role_id ?? null,
+      clarisa_subnational_scope_object: sn.clarisa_subnational_scope_object ?? null,
+    };
+  }
+
+  private slimBilateralResultCountryRow(rc: any, onlyActive: (arr: any[]) => any[]) {
+    const subs = onlyActive(rc?.result_countries_subnational_array).map((sn) =>
+      this.slimBilateralResultCountrySubnationalRow(sn),
+    );
+    return {
+      country_id: rc.country_id ?? null,
+      geo_scope_role_id: rc.geo_scope_role_id ?? null,
+      country_object: rc.country_object ?? null,
+      result_countries_subnational_array: subs,
+    };
+  }
+
   private filterActiveRelations(result: any) {
     if (!result) return result;
     const onlyActive = (arr: any[]) =>
@@ -1545,14 +1577,11 @@ export class BilateralService {
           )
         : arr;
 
-    result.result_region_array = onlyActive(result.result_region_array);
+    result.result_region_array = onlyActive(result.result_region_array)?.map(
+      (rr) => this.slimBilateralResultRegionRow(rr),
+    );
     result.result_country_array = onlyActive(result.result_country_array)?.map(
-      (rc) => ({
-        ...rc,
-        result_countries_subnational_array: onlyActive(
-          rc?.result_countries_subnational_array,
-        ),
-      }),
+      (rc) => this.slimBilateralResultCountryRow(rc, onlyActive),
     );
     result.result_by_institution_array = onlyActive(
       result.result_by_institution_array,
@@ -2675,7 +2704,7 @@ export class BilateralService {
         linked_innovation_dev: null,
         linked_innovation_use: null,
         result_related_to,
-        institutions: institutionsMapped,
+        policy_implementing_organizations: institutionsMapped,
       };
     }
 
@@ -2716,7 +2745,7 @@ export class BilateralService {
       linked_innovation_dev: !!row.linked_innovation_dev,
       linked_innovation_use: !!row.linked_innovation_use,
       result_related_to,
-      institutions: institutionsMapped,
+      policy_implementing_organizations: institutionsMapped,
     };
   }
 

--- a/onecgiar-pr-server/src/api/results/result-questions/result-questions.module.ts
+++ b/onecgiar-pr-server/src/api/results/result-questions/result-questions.module.ts
@@ -13,6 +13,6 @@ import { HandlersError } from '../../../shared/handlers/error.utils';
     ResultQuestionsRepository,
     ResultAnswerRepository,
   ],
-  exports: [ResultAnswerRepository],
+  exports: [ResultAnswerRepository, ResultQuestionsService],
 })
 export class ResultQuestionsModule {}

--- a/onecgiar-pr-server/src/api/results/result-questions/result-questions.service.ts
+++ b/onecgiar-pr-server/src/api/results/result-questions/result-questions.service.ts
@@ -3,6 +3,29 @@ import { HandlersError } from '../../../shared/handlers/error.utils';
 import { ResultQuestionsRepository } from './repository/result-questions.repository';
 import { ResultAnswerRepository } from './repository/result-answers.repository';
 
+/** Bilateral innovation-dev questionnaire: PRMS prompt as `question`; answers via `text` / `boolean` and/or `selections`. */
+export type InnovationDevCleanAnswer = {
+  boolean?: boolean;
+  text?: string;
+  /** Multi-select (e.g. megatrends): one string per ticked option, same order as in the form. */
+  selections?: string[];
+};
+
+export type InnovationDevCleanQuestion = {
+  question: string;
+  question_id: number;
+  answer: InnovationDevCleanAnswer | null;
+  /** Sub-rows only if the result positively selected them (`true` or non-empty text). */
+  selected_sub_options?: InnovationDevCleanQuestion[];
+};
+
+export type InnovationDevCleanQuestionnaire = {
+  responsible_innovation_and_scaling: InnovationDevCleanQuestion[];
+  intellectual_property_rights: InnovationDevCleanQuestion[];
+  innovation_team_diversity: InnovationDevCleanQuestion[];
+  megatrends: InnovationDevCleanQuestion[];
+};
+
 @Injectable()
 export class ResultQuestionsService {
   constructor(
@@ -604,5 +627,314 @@ export class ResultQuestionsService {
     } catch (error) {
       return this._handlerError.returnErrorRes({ error, debug: true });
     }
+  }
+
+  private isInnovationDevHandlerErrorPayload(x: unknown): boolean {
+    if (!x || typeof x !== 'object') return false;
+    const o = x as Record<string, unknown>;
+    return (
+      typeof o.status === 'number' &&
+      typeof o.message === 'string' &&
+      'response' in o &&
+      !('question_text' in o)
+    );
+  }
+
+  private innovationDevTrimmedAnswerText(v: unknown): string {
+    if (v == null) return '';
+    if (typeof v === 'string') return v.trim();
+    if (typeof v === 'number' || typeof v === 'boolean') {
+      return String(v).trim();
+    }
+    return '';
+  }
+
+  private innovationDevQuestionLabel(v: unknown): string {
+    if (typeof v === 'string') return v.trim();
+    if (typeof v === 'number' || typeof v === 'boolean') {
+      return String(v).trim();
+    }
+    return '';
+  }
+
+  /** Positive selection or “other” text — used for `subOptions` only. */
+  private hasStrictInnovationSelection(o: Record<string, unknown>): boolean {
+    if (this.innovationDevTrimmedAnswerText(o.answer_text) !== '') {
+      return true;
+    }
+    const b = o.answer_boolean;
+    return b === true || b === 1;
+  }
+
+  private compactInnovationDevAnswer(
+    o: Record<string, unknown>,
+  ): InnovationDevCleanAnswer | null {
+    const out: InnovationDevCleanAnswer = {};
+    const t = this.innovationDevTrimmedAnswerText(o.answer_text);
+    if (t !== '') {
+      out.text = t;
+    }
+    const b = o.answer_boolean;
+    if (b === true || b === false || b === 0 || b === 1) {
+      out.boolean = Boolean(b);
+    }
+    return Object.keys(out).length ? out : null;
+  }
+
+  private simplifyInnovationDevOptionBranch(o: unknown): InnovationDevCleanQuestion | null {
+    if (!o || typeof o !== 'object') return null;
+    const row = o as Record<string, unknown>;
+    const subRaw = Array.isArray(row.subOptions) ? row.subOptions : [];
+    const selectedChildren = subRaw
+      .map((s) => this.simplifyInnovationDevOptionBranch(s))
+      .filter((n): n is InnovationDevCleanQuestion => n != null);
+
+    const answered = this.hasStrictInnovationSelection(row);
+
+    if (!answered && selectedChildren.length === 0) return null;
+
+    const id = Number(row.result_question_id);
+    if (!Number.isFinite(id)) return null;
+
+    return {
+      question: this.innovationDevQuestionLabel(row.question_text),
+      question_id: id,
+      answer: answered ? this.compactInnovationDevAnswer(row) : null,
+      ...(selectedChildren.length
+        ? { selected_sub_options: selectedChildren }
+        : {}),
+    };
+  }
+
+  /** Strip simple HTML from catalog labels (e.g. `<b>Other</b>`) for bilateral text answers. */
+  private stripHtmlForBilateralLabel(s: string): string {
+    if (!s) return '';
+    return s.replaceAll(/<[^>]+>/g, '').replaceAll(/\s+/g, ' ').trim();
+  }
+
+  /** Label for a selected catalog row (`question_text` + optional free-text answer). */
+  private formatBilateralSelectedOptionLabel(
+    row: Record<string, unknown>,
+  ): string | null {
+    const labelRaw = this.innovationDevQuestionLabel(row.question_text);
+    const label = this.stripHtmlForBilateralLabel(labelRaw);
+    const extra = this.innovationDevTrimmedAnswerText(row.answer_text);
+    if (label && extra && extra !== label) {
+      return `${label} (${extra})`;
+    }
+    if (label) return label;
+    if (extra) return extra;
+    return null;
+  }
+
+  private collectSelectedSubOptionsUnderMacroRows(
+    selectedTopRows: Record<string, unknown>[],
+  ): InnovationDevCleanQuestion[] {
+    const acc: InnovationDevCleanQuestion[] = [];
+    for (const row of selectedTopRows) {
+      const subs = Array.isArray(row.subOptions) ? row.subOptions : [];
+      for (const s of subs) {
+        const n = this.simplifyInnovationDevOptionBranch(s);
+        if (n) acc.push(n);
+      }
+    }
+    return acc;
+  }
+
+  /**
+   * Responsible innovation / IP rights: each `q1`…`q4` is the **question**; mutually exclusive
+   * (or multi) **options** are only reflected in `answer.text`, not as separate `question` rows.
+   */
+  private flattenMacroSubquestionsSection(
+    sectionRoot: unknown,
+  ): InnovationDevCleanQuestion[] {
+    if (!sectionRoot || typeof sectionRoot !== 'object') return [];
+    if (this.isInnovationDevHandlerErrorPayload(sectionRoot)) return [];
+
+    const root = sectionRoot as Record<string, unknown>;
+    const out: InnovationDevCleanQuestion[] = [];
+
+    for (const k of ['q1', 'q2', 'q3', 'q4'] as const) {
+      const q = root[k];
+      if (!q || typeof q !== 'object') continue;
+      const qRec = q as Record<string, unknown>;
+      if (!Array.isArray(qRec.options)) continue;
+
+      const qText = this.innovationDevQuestionLabel(qRec.question_text);
+      const qId = Number(qRec.result_question_id);
+      if (!qText || !Number.isFinite(qId)) continue;
+
+      const selected = (qRec.options as unknown[]).filter(
+        (o): o is Record<string, unknown> =>
+          !!o &&
+          typeof o === 'object' &&
+          this.hasStrictInnovationSelection(o as Record<string, unknown>),
+      );
+
+      if (!selected.length) continue;
+
+      const parts = selected
+        .map((r) => this.formatBilateralSelectedOptionLabel(r))
+        .filter((p): p is string => p != null && p !== '');
+
+      if (!parts.length) continue;
+
+      const subOpts = this.collectSelectedSubOptionsUnderMacroRows(selected);
+
+      out.push({
+        question: qText,
+        question_id: qId,
+        answer: { text: parts.join(' | ') },
+        ...(subOpts.length ? { selected_sub_options: subOpts } : {}),
+      });
+    }
+
+    return out;
+  }
+
+  /**
+   * Innovation team diversity: one parent prompt + rows; selected rows only in `answer.text`,
+   * nested `subOptions` only under selected rows.
+   */
+  private flattenInnovationTeamDiversitySection(
+    sectionRoot: unknown,
+  ): InnovationDevCleanQuestion[] {
+    if (!sectionRoot || typeof sectionRoot !== 'object') return [];
+    if (this.isInnovationDevHandlerErrorPayload(sectionRoot)) return [];
+
+    const root = sectionRoot as Record<string, unknown>;
+    const opts = root.options;
+    if (!Array.isArray(opts)) return [];
+
+    const parentQuestion =
+      this.innovationDevQuestionLabel(root.question_text) ||
+      'Innovation team diversity';
+    const parentId = Number(root.result_question_id);
+    if (!Number.isFinite(parentId)) return [];
+
+    const selected = opts.filter(
+      (o): o is Record<string, unknown> =>
+        !!o &&
+        typeof o === 'object' &&
+        this.hasStrictInnovationSelection(o as Record<string, unknown>),
+    );
+
+    if (!selected.length) return [];
+
+    const parts = selected
+      .map((r) => this.formatBilateralSelectedOptionLabel(r))
+      .filter((p): p is string => p != null && p !== '');
+
+    if (!parts.length) return [];
+
+    const subOpts = this.collectSelectedSubOptionsUnderMacroRows(selected);
+
+    return [
+      {
+        question: parentQuestion,
+        question_id: parentId,
+        answer: { text: parts.join(' | ') },
+        ...(subOpts.length ? { selected_sub_options: subOpts } : {}),
+      },
+    ];
+  }
+
+  /**
+   * Megatrends UI: one parent prompt + checkbox list. Bilateral exposes **parent** as `question`
+   * and each ticked option as one entry in **`answer.selections`** (not a single pipe-delimited string).
+   */
+  private flattenMegatrendsInnovationDevSection(
+    megatrendsRoot: unknown,
+  ): InnovationDevCleanQuestion[] {
+    if (!megatrendsRoot || typeof megatrendsRoot !== 'object') return [];
+    if (this.isInnovationDevHandlerErrorPayload(megatrendsRoot)) return [];
+
+    const root = megatrendsRoot as Record<string, unknown>;
+    const opts = root.options;
+    if (!Array.isArray(opts)) return [];
+
+    const parentId = Number(root.result_question_id);
+    if (!Number.isFinite(parentId)) return [];
+
+    const parentQuestion =
+      this.innovationDevQuestionLabel(root.question_text) || 'Megatrends';
+
+    const selectedLabels: string[] = [];
+    for (const raw of opts) {
+      if (!raw || typeof raw !== 'object') continue;
+      const row = raw as Record<string, unknown>;
+      if (!this.hasStrictInnovationSelection(row)) continue;
+      const line = this.formatBilateralSelectedOptionLabel(row);
+      if (line) selectedLabels.push(line);
+    }
+
+    if (!selectedLabels.length) return [];
+
+    return [
+      {
+        question: parentQuestion,
+        question_id: parentId,
+        answer: { selections: selectedLabels },
+      },
+    ];
+  }
+
+  /**
+   * Innovation Development for bilateral: **question → answer** per section.
+   * Reuses the same loaders as PRMS (`findQuestionInnovationDevelopment` / `V2`).
+   * Macro `q1`–`q4` and team diversity use **selected** option label(s) in `answer.text`.
+   * Megatrends (multi-select) uses **`answer.selections`** (one string per checked option).
+   * `selected_sub_options`: only
+   * positively selected sub-rows (`answer_boolean` true / 1, or non-empty `answer_text`).
+   */
+  async buildInnovationDevelopmentQuestionnaireForBilateral(
+    resultId: number,
+    portfolioAcronym: string | null | undefined,
+  ): Promise<InnovationDevCleanQuestionnaire> {
+    const isP25 =
+      String(portfolioAcronym ?? '')
+        .trim()
+        .toUpperCase() === 'P25';
+
+    if (isP25) {
+      const [scaling, intellectual, innovation, megatrends] =
+        await Promise.all([
+          this.responsibleInnovationAndScalingV2(resultId),
+          this.intellectualPropertyRightsV2(resultId),
+          this.innovationTeamDiversityV2(resultId),
+          this.getMegatrendsV2(resultId),
+        ]);
+      return {
+        responsible_innovation_and_scaling: this.flattenMacroSubquestionsSection(
+          Array.isArray(scaling) ? scaling[0] : null,
+        ),
+        intellectual_property_rights: this.flattenMacroSubquestionsSection(
+          Array.isArray(intellectual) ? intellectual[0] : null,
+        ),
+        innovation_team_diversity: this.flattenInnovationTeamDiversitySection(
+          Array.isArray(innovation) ? innovation[0] : null,
+        ),
+        megatrends: this.flattenMegatrendsInnovationDevSection(megatrends),
+      };
+    }
+
+    const [scaling, intellectual, innovation, megatrends] = await Promise.all([
+      this.responsibleInnovationAndScaling(resultId),
+      this.intellectualPropertyRights(resultId),
+      this.innovationTeamDiversity(resultId),
+      this.getMegatrends(resultId),
+    ]);
+    return {
+      responsible_innovation_and_scaling: this.flattenMacroSubquestionsSection(
+        Array.isArray(scaling) ? scaling[0] : null,
+      ),
+      intellectual_property_rights: this.flattenMacroSubquestionsSection(
+        Array.isArray(intellectual) ? intellectual[0] : null,
+      ),
+      innovation_team_diversity: this.flattenInnovationTeamDiversitySection(
+        Array.isArray(innovation) ? innovation[0] : null,
+      ),
+      megatrends: this.flattenMegatrendsInnovationDevSection(megatrends),
+    };
   }
 }

--- a/onecgiar-pr-server/src/api/results/result-questions/result-questions.service.ts
+++ b/onecgiar-pr-server/src/api/results/result-questions/result-questions.service.ts
@@ -712,8 +712,8 @@ export class ResultQuestionsService {
   private stripHtmlForBilateralLabel(s: string): string {
     if (!s) return '';
     return s
-      .replaceAll(/<[^>]+>/g, '')
-      .replaceAll(/\s+/g, ' ')
+      .replace(/<[^>]+>/g, '')
+      .replace(/\s+/g, ' ')
       .trim();
   }
 

--- a/onecgiar-pr-server/src/api/results/result-questions/result-questions.service.ts
+++ b/onecgiar-pr-server/src/api/results/result-questions/result-questions.service.ts
@@ -28,6 +28,9 @@ export type InnovationDevCleanQuestionnaire = {
 
 @Injectable()
 export class ResultQuestionsService {
+  /** Upper bound on label length before stripping; avoids unbounded work on hostile input. */
+  private static readonly BILATERAL_LABEL_MAX_CHARS = 16_384;
+
   constructor(
     private readonly _handlerError: HandlersError,
     private readonly _resultQuestionRepository: ResultQuestionsRepository,
@@ -708,13 +711,35 @@ export class ResultQuestionsService {
     };
   }
 
-  /** Strip simple HTML from catalog labels (e.g. `<b>Other</b>`) for bilateral text answers. */
+  /**
+   * Strip simple HTML from catalog labels (e.g. `<b>Other</b>`) for bilateral text answers.
+   * Uses a single linear pass (no tag regex) so runtime stays O(n) with n capped.
+   */
   private stripHtmlForBilateralLabel(s: string): string {
     if (!s) return '';
-    return s
-      .replace(/<[^>]+>/g, '')
-      .replace(/\s+/g, ' ')
-      .trim();
+    const max = ResultQuestionsService.BILATERAL_LABEL_MAX_CHARS;
+    const input = s.length > max ? s.slice(0, max) : s;
+
+    let out = '';
+    for (let i = 0; i < input.length; ) {
+      if (input[i] === '<') {
+        let j = i + 1;
+        while (j < input.length && input[j] !== '>') {
+          j++;
+        }
+        if (j < input.length) {
+          i = j + 1;
+        } else {
+          out += '<';
+          i++;
+        }
+      } else {
+        out += input[i];
+        i++;
+      }
+    }
+
+    return out.replaceAll(/\s+/g, ' ').trim();
   }
 
   /** Label for a selected catalog row (`question_text` + optional free-text answer). */

--- a/onecgiar-pr-server/src/api/results/result-questions/result-questions.service.ts
+++ b/onecgiar-pr-server/src/api/results/result-questions/result-questions.service.ts
@@ -681,7 +681,9 @@ export class ResultQuestionsService {
     return Object.keys(out).length ? out : null;
   }
 
-  private simplifyInnovationDevOptionBranch(o: unknown): InnovationDevCleanQuestion | null {
+  private simplifyInnovationDevOptionBranch(
+    o: unknown,
+  ): InnovationDevCleanQuestion | null {
     if (!o || typeof o !== 'object') return null;
     const row = o as Record<string, unknown>;
     const subRaw = Array.isArray(row.subOptions) ? row.subOptions : [];
@@ -709,7 +711,10 @@ export class ResultQuestionsService {
   /** Strip simple HTML from catalog labels (e.g. `<b>Other</b>`) for bilateral text answers. */
   private stripHtmlForBilateralLabel(s: string): string {
     if (!s) return '';
-    return s.replaceAll(/<[^>]+>/g, '').replaceAll(/\s+/g, ' ').trim();
+    return s
+      .replaceAll(/<[^>]+>/g, '')
+      .replaceAll(/\s+/g, ' ')
+      .trim();
   }
 
   /** Label for a selected catalog row (`question_text` + optional free-text answer). */
@@ -897,17 +902,19 @@ export class ResultQuestionsService {
         .toUpperCase() === 'P25';
 
     if (isP25) {
-      const [scaling, intellectual, innovation, megatrends] =
-        await Promise.all([
+      const [scaling, intellectual, innovation, megatrends] = await Promise.all(
+        [
           this.responsibleInnovationAndScalingV2(resultId),
           this.intellectualPropertyRightsV2(resultId),
           this.innovationTeamDiversityV2(resultId),
           this.getMegatrendsV2(resultId),
-        ]);
+        ],
+      );
       return {
-        responsible_innovation_and_scaling: this.flattenMacroSubquestionsSection(
-          Array.isArray(scaling) ? scaling[0] : null,
-        ),
+        responsible_innovation_and_scaling:
+          this.flattenMacroSubquestionsSection(
+            Array.isArray(scaling) ? scaling[0] : null,
+          ),
         intellectual_property_rights: this.flattenMacroSubquestionsSection(
           Array.isArray(intellectual) ? intellectual[0] : null,
         ),

--- a/onecgiar-pr-server/src/api/results/results.module.ts
+++ b/onecgiar-pr-server/src/api/results/results.module.ts
@@ -206,7 +206,7 @@ import { InnovationUseModule } from '../results-framework-reporting/innovation-u
     ResultReviewHistoryRepository,
     ShareResultRequestRepository,
   ],
-  exports: [ResultRepository, JwtMiddleware, ResultsService],
+  exports: [ResultRepository, JwtMiddleware, ResultsService, ResultQuestionsService],
 })
 export class ResultsModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {

--- a/onecgiar-pr-server/src/api/results/results.module.ts
+++ b/onecgiar-pr-server/src/api/results/results.module.ts
@@ -206,7 +206,12 @@ import { InnovationUseModule } from '../results-framework-reporting/innovation-u
     ResultReviewHistoryRepository,
     ShareResultRequestRepository,
   ],
-  exports: [ResultRepository, JwtMiddleware, ResultsService, ResultQuestionsService],
+  exports: [
+    ResultRepository,
+    JwtMiddleware,
+    ResultsService,
+    ResultQuestionsService,
+  ],
 })
 export class ResultsModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {

--- a/onecgiar-pr-server/src/api/results/summary/entities/results-innovations-dev.entity.ts
+++ b/onecgiar-pr-server/src/api/results/summary/entities/results-innovations-dev.entity.ts
@@ -47,13 +47,19 @@ export class ResultsInnovationsDev {
   @JoinColumn({
     name: 'innovation_characterization_id',
   })
-  innovation_characterization_id!: number;
+  innovation_characterization?: ClarisaInnovationCharacteristic;
+
+  @RelationId((rid: ResultsInnovationsDev) => rid.innovation_characterization)
+  innovation_characterization_id!: number | null;
 
   @ManyToOne(() => ClarisaInnovationType, (cit) => cit.code, { nullable: true })
   @JoinColumn({
     name: 'innovation_nature_id',
   })
-  innovation_nature_id!: number;
+  innovation_nature?: ClarisaInnovationType;
+
+  @RelationId((rid: ResultsInnovationsDev) => rid.innovation_nature)
+  innovation_nature_id!: number | null;
 
   @ManyToOne(() => ClarisaInnovationReadinessLevel, (cir) => cir.id, {
     nullable: true,
@@ -61,7 +67,10 @@ export class ResultsInnovationsDev {
   @JoinColumn({
     name: 'innovation_readiness_level_id',
   })
-  innovation_readiness_level_id!: number;
+  innovation_readiness_level?: ClarisaInnovationReadinessLevel;
+
+  @RelationId((rid: ResultsInnovationsDev) => rid.innovation_readiness_level)
+  innovation_readiness_level_id!: number | null;
 
   @Column({
     name: 'is_new_variety',

--- a/onecgiar-pr-server/src/shared/constants/evidence-type.enum.ts
+++ b/onecgiar-pr-server/src/shared/constants/evidence-type.enum.ts
@@ -4,4 +4,6 @@ export enum EvidenceTypeEnum {
   PICTURES = 3,
   MATERIALS = 4,
   IPSR_WORKSHOP = 5,
+  /** Evidence of user need / user demand (e.g. innovation development). */
+  USER_NEED_USER_DEMAND = 6,
 }


### PR DESCRIPTION
## Summary

Merges **`staging` → `master`** with reporting-tool and bilateral API enhancements, results list UX, and supporting refactors. This batch focuses on **richer bilateral list payloads** (summaries and Innovation Development questionnaire), **capacity development / innovation use / policy change** bilateral handling, **leading result & submission metadata**, and **client-side results list filtering** improvements.

---

## Bilateral / reporting tool (server)

### Knowledge product & innovation payloads

- **Knowledge product:** bilateral summary for KP in the API; related bilateral service updates (including soft-delete handling adjustments where applicable).
- **Innovation development:** extended bilateral enrichment for innovation development entities and summaries; **`innovation_development_questionnaire`** is built via `ResultQuestionsService.buildInnovationDevelopmentQuestionnaireForBilateral` and nested under **`innovation_development_summary`** (not a top-level `data` sibling). Questionnaire exposes four thematic arrays aligned with PRMS semantics (macro blocks, team diversity, megatrends with multi-select `answer.selections`, positive selections only, P25 vs P22 catalog).
- **Innovation use & capacity development:** repository integration for bilateral summaries (`ResultsInnovationsUseRepository`, `ResultsCapacityDevelopmentsRepository`) and budget-related handling improvements.
- **Policy change:** `ResultsPolicyChangesRepository` integration and policy change bilateral handling.

### Other bilateral enrichments

- **Leading result & submission metadata** improvements on enriched `data`.
- **DAC scores**, **bilateral projects**, **partner institutions** summaries (prior patterns preserved/extended as in commit history).
- **`institutions_id`** on institution response structure where applicable.
- Documentation: **`onecgiar-pr-server/docs/bilateral-result-summaries.en.md`** (terminology and structure updates for summaries and questionnaire).

### Modules / wiring

- **`ResultsModule`**: exports and DI adjustments so `BilateralService` can use **`ResultQuestionsService`** for the questionnaire.

### Build compatibility

- **`result-questions.service`:** HTML stripping uses `String.prototype.replace` with global regex instead of `replaceAll` for TypeScript targets without ES2021 `lib` (CI-safe).

---

## Client (Angular)

- **Results list filters:** `hasFilteredResults` input to drive button state; submitter filtering aligned with selected **phases** and **portfolios**.

---

## Documentation & API surface

- **Swagger (`BilateralController`):** list operation description updated for Innovation Development questionnaire location and shape.
- **In-repo English doc:** `bilateral-result-summaries.en.md` — common `data` fields vs type-specific summaries; Innovation Development summary + nested questionnaire.

---

## Commits included (since `master`)

```
4964587f5 refactor(result-questions.service): Optimize HTML stripping method for improved performance
469844bd7 refactor(bilateral.service, result-questions.service, results.module): Improve code readability and formatting
5fc1efd8f feat(bilateral.service, bilateral-result-summaries, result-questions.service): Introduce innovation development questionnaire structure and enhance API documentation
213fb00c6 feat(bilateral.service, bilateral-result-summaries): Update terminology and enhance data structure
abc076b64 feat(bilateral.service): Enhance leading result and submission metadata handling
bdb137c7b Merge branch 'staging-front-upload' …
60febd859 feat(bilateral.service): Integrate ResultsPolicyChangesRepository and enhance policy change handling
e5540ea24 Refactor(results-list-filters): Add hasFilteredResults input …
725e599e9 Refactor(results-list-filters): Update submitter filtering logic …
1e47ddd7c Merge branch 'staging' into staging-front-upload
1729a3017 feat(bilateral.service): Integrate ResultsCapacityDevelopmentsRepository …
dd7b60da8 feat(bilateral.service): Integrate ResultsInnovationsUseRepository …
ce1e1febc feat(bilateral.service, results-innovations-dev.entity): Enhance innovation development data handling
f21d0103d Added KP summary for API and remove soft delete and update bilateral services
```

---

## Testing / verification

- [x] `npx tsc --noEmit` (server)
- [x] Bilateral service unit tests (`bilateral.service.spec.ts`) as run in development
- [x] Full CI pipeline on the PR

---

## Notes for reviewers

- **Consumers of the bilateral list** should read **`data.innovation_development_summary.innovation_development_questionnaire`** for Innovation Development Q&A; common fields remain on **`data`** alongside **`innovation_development_summary`**.
- Confirm **OpenSearch / indexing** consumers if they deserialize `data` and expect previous top-level keys (breaking change only if anything relied on a flat `innovation_development_questionnaire` on `data` — it is now nested in the summary object).
