### PR TITLE
* Feat Persist result deletion audit (user, source, optional justification)

### DIFF
--- a/onecgiar-pr-server/src/api/delete-recover-data/delete-recover-data.controller.spec.ts
+++ b/onecgiar-pr-server/src/api/delete-recover-data/delete-recover-data.controller.spec.ts
@@ -32,7 +32,7 @@ describe('DeleteRecoverDataController', () => {
 
   it('deleteResult delegates to service with parsed id and user', async () => {
     const res = await controller.deleteResult('12', user);
-    expect(mockService.deleteResult).toHaveBeenCalledWith(12, user);
+    expect(mockService.deleteResult).toHaveBeenCalledWith(12, user, undefined);
     expect(res.statusCode).toBe(200);
   });
 

--- a/onecgiar-pr-server/src/api/delete-recover-data/delete-recover-data.controller.ts
+++ b/onecgiar-pr-server/src/api/delete-recover-data/delete-recover-data.controller.ts
@@ -5,6 +5,7 @@ import {
   Patch,
   UseInterceptors,
   Body,
+  Query,
 } from '@nestjs/common';
 import { DeleteRecoverDataService } from './delete-recover-data.service';
 import { ResponseInterceptor } from '../../shared/Interceptors/Return-data.interceptor';
@@ -20,8 +21,12 @@ export class DeleteRecoverDataController {
   ) {}
 
   @Delete('result/:id/delete')
-  deleteResult(@Param('id') id: string, @UserToken() user: TokenDto) {
-    return this.deleteRecoverDataService.deleteResult(+id, user);
+  deleteResult(
+    @Param('id') id: string,
+    @UserToken() user: TokenDto,
+    @Query('justification') justification?: string,
+  ) {
+    return this.deleteRecoverDataService.deleteResult(+id, user, justification);
   }
 
   @Patch('change/result/:id')

--- a/onecgiar-pr-server/src/api/delete-recover-data/delete-recover-data.module.ts
+++ b/onecgiar-pr-server/src/api/delete-recover-data/delete-recover-data.module.ts
@@ -100,6 +100,7 @@ import { ResultReviewHistoryRepository } from '../results/result-review-history/
 import { ResultImpactAreaScoresModule } from '../result-impact-area-scores/result-impact-area-scores.module';
 import { ResultsTocResultsModule } from '../results/results-toc-results/results-toc-results.module';
 import { ResultsByInstitutionsModule } from '../results/results_by_institutions/results_by_institutions.module';
+import { ResultDeletionAuditModule } from '../results/result-deletion-audit/result-deletion-audit.module';
 
 @Module({
   controllers: [DeleteRecoverDataController],
@@ -204,6 +205,7 @@ import { ResultsByInstitutionsModule } from '../results/results_by_institutions/
     ResultImpactAreaScoresModule,
     ResultsTocResultsModule,
     ResultsByInstitutionsModule,
+    ResultDeletionAuditModule,
   ],
   exports: [
     EvidencesService,

--- a/onecgiar-pr-server/src/api/delete-recover-data/delete-recover-data.service.ts
+++ b/onecgiar-pr-server/src/api/delete-recover-data/delete-recover-data.service.ts
@@ -80,6 +80,8 @@ import { ResultInstitutionsBudget } from '../results/result_budget/entities/resu
 import { VersionRepository } from '../versioning/versioning.repository';
 import { RoleByUserRepository } from '../../auth/modules/role-by-user/RoleByUser.repository';
 import { RoleEnum } from '../../shared/constants/role-type.enum';
+import { ResultDeletionAuditService } from '../results/result-deletion-audit/result-deletion-audit.service';
+import { ResultDeletionAuditSource } from '../results/result-deletion-audit/result-deletion-audit-source.enum';
 
 const P25_PORTFOLIO_ACRONYM = 'P25';
 
@@ -153,9 +155,14 @@ export class DeleteRecoverDataService {
     private readonly _logRepository: LogRepository,
     private readonly _roleByUserRepository: RoleByUserRepository,
     private readonly _versionRepository: VersionRepository,
+    private readonly _resultDeletionAuditService: ResultDeletionAuditService,
   ) {}
 
-  async deleteResult(result_id: number, user: TokenDto) {
+  async deleteResult(
+    result_id: number,
+    user: TokenDto,
+    justification?: string,
+  ) {
     try {
       const resultData = await this._resultRepository.findOne({
         where: {
@@ -206,6 +213,13 @@ export class DeleteRecoverDataService {
           statusCode: HttpStatus.CONFLICT,
         });
       }
+
+      await this._resultDeletionAuditService.recordDeletion({
+        resultId: resultData.id,
+        userId: user.id,
+        deletionSource: ResultDeletionAuditSource.ManageData,
+        justification,
+      });
 
       await this._ipsrRepository.logicalDelete(resultData.id);
       await this._innovationPackagingExpertRepository.logicalDelete(

--- a/onecgiar-pr-server/src/api/ipsr/innovation-pathway/innovation-pathway.module.ts
+++ b/onecgiar-pr-server/src/api/ipsr/innovation-pathway/innovation-pathway.module.ts
@@ -60,10 +60,15 @@ import { IpsrService } from '../ipsr.service';
 import { ResultsInvestmentDiscontinuedOptionRepository } from '../../results/results-investment-discontinued-options/results-investment-discontinued-options.repository';
 import { AdUsersModule } from '../../ad_users';
 import { InitiativeEntityMapRepository } from '../../initiative_entity_map/initiative_entity_map.repository';
+import { ResultDeletionAuditModule } from '../../results/result-deletion-audit/result-deletion-audit.module';
 
 @Module({
   controllers: [InnovationPathwayController],
-  imports: [forwardRef(() => VersioningModule), AdUsersModule],
+  imports: [
+    forwardRef(() => VersioningModule),
+    AdUsersModule,
+    ResultDeletionAuditModule,
+  ],
   providers: [
     InnovationPathwayStepOneService,
     InnovationPathwayStepTwoService,

--- a/onecgiar-pr-server/src/api/ipsr/result-innovation-package/result-innovation-package.controller.spec.ts
+++ b/onecgiar-pr-server/src/api/ipsr/result-innovation-package/result-innovation-package.controller.spec.ts
@@ -76,7 +76,7 @@ describe('ResultInnovationPackageController', () => {
 
   it('delete delegates with parsed id and user', async () => {
     await controller.delete(9 as any, user);
-    expect(mockService.delete).toHaveBeenCalledWith(9, user);
+    expect(mockService.delete).toHaveBeenCalledWith(9, user, undefined);
   });
 
   it('findUnitTime delegates', async () => {

--- a/onecgiar-pr-server/src/api/ipsr/result-innovation-package/result-innovation-package.controller.ts
+++ b/onecgiar-pr-server/src/api/ipsr/result-innovation-package/result-innovation-package.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Delete,
   UseInterceptors,
+  Query,
 } from '@nestjs/common';
 import { ResultInnovationPackageService } from './result-innovation-package.service';
 import {
@@ -74,8 +75,16 @@ export class ResultInnovationPackageController {
   }
 
   @Delete(':resultId')
-  delete(@Param('resultId') resultId: number, @UserToken() user: TokenDto) {
-    return this.resultInnovationPackageService.delete(resultId, user);
+  delete(
+    @Param('resultId') resultId: number,
+    @UserToken() user: TokenDto,
+    @Query('justification') justification?: string,
+  ) {
+    return this.resultInnovationPackageService.delete(
+      resultId,
+      user,
+      justification,
+    );
   }
 
   @Get('unit-time')

--- a/onecgiar-pr-server/src/api/ipsr/result-innovation-package/result-innovation-package.module.ts
+++ b/onecgiar-pr-server/src/api/ipsr/result-innovation-package/result-innovation-package.module.ts
@@ -42,6 +42,7 @@ import { ResultsInvestmentDiscontinuedOptionRepository } from '../../results/res
 import { AdUsersModule } from '../../ad_users';
 import { InitiativeEntityMapRepository } from '../../initiative_entity_map/initiative_entity_map.repository';
 import { RoleByUserRepository } from '../../../auth/modules/role-by-user/RoleByUser.repository';
+import { ResultDeletionAuditModule } from '../../results/result-deletion-audit/result-deletion-audit.module';
 
 @Module({
   controllers: [ResultInnovationPackageController],
@@ -84,7 +85,12 @@ import { RoleByUserRepository } from '../../../auth/modules/role-by-user/RoleByU
     InitiativeEntityMapRepository,
     RoleByUserRepository,
   ],
-  imports: [VersionsModule, forwardRef(() => VersioningModule), AdUsersModule],
+  imports: [
+    VersionsModule,
+    forwardRef(() => VersioningModule),
+    AdUsersModule,
+    ResultDeletionAuditModule,
+  ],
   exports: [ResultInnovationPackageRepository],
 })
 export class ResultInnovationPackageModule {}

--- a/onecgiar-pr-server/src/api/ipsr/result-innovation-package/result-innovation-package.service.ts
+++ b/onecgiar-pr-server/src/api/ipsr/result-innovation-package/result-innovation-package.service.ts
@@ -58,6 +58,8 @@ import { ResultsInvestmentDiscontinuedOptionRepository } from '../../results/res
 import { AdUserService, AdUserRepository } from '../../ad_users';
 import { RoleByUserRepository } from '../../../auth/modules/role-by-user/RoleByUser.repository';
 import { VersionRepository } from '../../versioning/versioning.repository';
+import { ResultDeletionAuditService } from '../../results/result-deletion-audit/result-deletion-audit.service';
+import { ResultDeletionAuditSource } from '../../results/result-deletion-audit/result-deletion-audit-source.enum';
 
 @Injectable()
 export class ResultInnovationPackageService {
@@ -98,6 +100,7 @@ export class ResultInnovationPackageService {
     private readonly _versioningService: VersioningService,
     private readonly _resultCountrySubnationalRepository: ResultCountrySubnationalRepository,
     private readonly _resultsInvestmentDiscontinuedOptionRepository: ResultsInvestmentDiscontinuedOptionRepository,
+    private readonly _resultDeletionAuditService: ResultDeletionAuditService,
     @Optional()
     @Inject(AdUserService)
     private readonly _adUserService?: AdUserService,
@@ -1016,7 +1019,7 @@ export class ResultInnovationPackageService {
     }
   }
 
-  async delete(resultId: number, user: TokenDto) {
+  async delete(resultId: number, user: TokenDto, justification?: string) {
     const resultToUpdate = await this._resultRepository.find({
       where: { id: resultId },
     });
@@ -1063,6 +1066,13 @@ export class ResultInnovationPackageService {
         };
       }
     }
+
+    await this._resultDeletionAuditService.recordDeletion({
+      resultId: currentResult.id,
+      userId: user.id,
+      deletionSource: ResultDeletionAuditSource.IpsrInnovationPackage,
+      justification,
+    });
 
     const resultByInnovationPackageToUpdate =
       await this._innovationByResultRepository.find({

--- a/onecgiar-pr-server/src/api/results/result-deletion-audit/entities/result-deletion-audit.entity.ts
+++ b/onecgiar-pr-server/src/api/results/result-deletion-audit/entities/result-deletion-audit.entity.ts
@@ -1,0 +1,83 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Result } from '../../entities/result.entity';
+import { User } from '../../../../auth/modules/user/entities/user.entity';
+import { ResultDeletionAuditSource } from '../result-deletion-audit-source.enum';
+
+@Entity('result_deletion_audit')
+export class ResultDeletionAudit {
+  @PrimaryGeneratedColumn({
+    name: 'id',
+    type: 'bigint',
+  })
+  id: number;
+
+  @Column({
+    name: 'result_id',
+    type: 'bigint',
+  })
+  result_id: number;
+
+  @Column({
+    name: 'deleted_by_user_id',
+    type: 'int',
+  })
+  deleted_by_user_id: number;
+
+  @CreateDateColumn({
+    name: 'created_date',
+    type: 'timestamp',
+    nullable: false,
+  })
+  created_date: Date;
+
+  @UpdateDateColumn({
+    name: 'last_updated_date',
+    type: 'timestamp',
+    nullable: true,
+  })
+  last_updated_date: Date;
+
+  @Column({
+    name: 'created_by',
+    type: 'bigint',
+    nullable: true,
+  })
+  created_by: number;
+
+  @Column({
+    name: 'last_updated_by',
+    type: 'bigint',
+    nullable: true,
+  })
+  last_updated_by: number;
+
+  @Column({
+    name: 'justification',
+    type: 'text',
+    nullable: true,
+  })
+  justification: string | null;
+
+  @Column({
+    name: 'deletion_source',
+    type: 'varchar',
+    length: 64,
+  })
+  deletion_source: ResultDeletionAuditSource;
+
+  @ManyToOne(() => Result, { nullable: false })
+  @JoinColumn({ name: 'result_id' })
+  obj_result: Result;
+
+  @ManyToOne(() => User, { nullable: false })
+  @JoinColumn({ name: 'deleted_by_user_id' })
+  obj_deleted_by: User;
+}

--- a/onecgiar-pr-server/src/api/results/result-deletion-audit/result-deletion-audit-source.enum.ts
+++ b/onecgiar-pr-server/src/api/results/result-deletion-audit/result-deletion-audit-source.enum.ts
@@ -1,0 +1,5 @@
+export enum ResultDeletionAuditSource {
+  ManageData = 'MANAGE_DATA',
+  IpsrInnovationPackage = 'IPSR_INNOVATION_PACKAGE',
+  ResultsModule = 'RESULTS_MODULE',
+}

--- a/onecgiar-pr-server/src/api/results/result-deletion-audit/result-deletion-audit.module.ts
+++ b/onecgiar-pr-server/src/api/results/result-deletion-audit/result-deletion-audit.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ResultDeletionAudit } from './entities/result-deletion-audit.entity';
+import { ResultDeletionAuditService } from './result-deletion-audit.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ResultDeletionAudit])],
+  providers: [ResultDeletionAuditService],
+  exports: [ResultDeletionAuditService],
+})
+export class ResultDeletionAuditModule {}

--- a/onecgiar-pr-server/src/api/results/result-deletion-audit/result-deletion-audit.service.ts
+++ b/onecgiar-pr-server/src/api/results/result-deletion-audit/result-deletion-audit.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ResultDeletionAudit } from './entities/result-deletion-audit.entity';
+import { ResultDeletionAuditSource } from './result-deletion-audit-source.enum';
+
+@Injectable()
+export class ResultDeletionAuditService {
+  constructor(
+    @InjectRepository(ResultDeletionAudit)
+    private readonly repository: Repository<ResultDeletionAudit>,
+  ) {}
+
+  async recordDeletion(params: {
+    resultId: number;
+    userId: number;
+    deletionSource: ResultDeletionAuditSource;
+    justification?: string | null;
+  }): Promise<void> {
+    const justification =
+      params.justification?.trim().length > 0
+        ? params.justification.trim()
+        : null;
+
+    const row = this.repository.create({
+      result_id: params.resultId,
+      deleted_by_user_id: params.userId,
+      created_by: params.userId,
+      last_updated_by: params.userId,
+      justification,
+      deletion_source: params.deletionSource,
+    });
+
+    await this.repository.save(row);
+  }
+}

--- a/onecgiar-pr-server/src/api/results/result.spec.ts
+++ b/onecgiar-pr-server/src/api/results/result.spec.ts
@@ -75,6 +75,7 @@ import { ReviewUpdateDto } from './dto/review-update.dto';
 import { ResultsTocResultsService } from './results-toc-results/results-toc-results.service';
 import { ShareResultRequestService } from './share-result-request/share-result-request.service';
 import { ShareResultRequestRepository } from './share-result-request/share-result-request.repository';
+import { ResultDeletionAuditService } from './result-deletion-audit/result-deletion-audit.service';
 
 describe('ResultsService (unit, pure mocks)', () => {
   let module: TestingModule;
@@ -521,6 +522,10 @@ describe('ResultsService (unit, pure mocks)', () => {
     }),
   } as any;
 
+  const mockResultDeletionAuditService = {
+    recordDeletion: jest.fn().mockResolvedValue(undefined),
+  };
+
   const mockResultImpactAreaScoresService = {
     validateImpactAreaScores: jest
       .fn()
@@ -672,6 +677,10 @@ describe('ResultsService (unit, pure mocks)', () => {
         {
           provide: AoWBilateralRepository,
           useValue: mockAoWBilateralRepository,
+        },
+        {
+          provide: ResultDeletionAuditService,
+          useValue: mockResultDeletionAuditService,
         },
         {
           provide: ResultReviewHistoryRepository,

--- a/onecgiar-pr-server/src/api/results/results-knowledge-products/results-knowledge-products.module.ts
+++ b/onecgiar-pr-server/src/api/results/results-knowledge-products/results-knowledge-products.module.ts
@@ -58,12 +58,14 @@ import { AoWBilateralRepository } from '../results-toc-results/repositories/aow-
 import { ResultImpactAreaScoresModule } from '../../result-impact-area-scores/result-impact-area-scores.module';
 import { ResultsTocResultsModule } from '../results-toc-results/results-toc-results.module';
 import { ResultsByInstitutionsModule } from '../results_by_institutions/results_by_institutions.module';
+import { ResultDeletionAuditModule } from '../result-deletion-audit/result-deletion-audit.module';
 
 @Module({
   imports: [
     HttpModule,
     VersioningModule,
     DeleteRecoverDataModule,
+    ResultDeletionAuditModule,
     //resultsservice imports :(
     ResultTypesModule,
     ResultsByInititiativesModule,

--- a/onecgiar-pr-server/src/api/results/results.controller.spec.ts
+++ b/onecgiar-pr-server/src/api/results/results.controller.spec.ts
@@ -178,7 +178,7 @@ describe('ResultsController', () => {
 
   it('update calls deleteResult with id and user', async () => {
     await controller.update(10, user);
-    expect(mockService.deleteResult).toHaveBeenCalledWith(10, user);
+    expect(mockService.deleteResult).toHaveBeenCalledWith(10, user, undefined);
   });
 
   it('saveGeographic sets result_id and delegates', async () => {

--- a/onecgiar-pr-server/src/api/results/results.controller.ts
+++ b/onecgiar-pr-server/src/api/results/results.controller.ts
@@ -402,9 +402,19 @@ export class ResultsController {
       'Marks a result as deleted while keeping the historical record.',
   })
   @ApiParam({ name: 'id', type: Number, required: true })
+  @ApiQuery({
+    name: 'justification',
+    required: false,
+    description:
+      'Optional justification for the deletion (e.g. operational note).',
+  })
   @ApiOkResponse({ description: 'Result flagged as deleted.' })
-  update(@Param('id') id: number, @UserToken() user: TokenDto) {
-    return this.resultsService.deleteResult(id, user);
+  update(
+    @Param('id') id: number,
+    @UserToken() user: TokenDto,
+    @Query('justification') justification?: string,
+  ) {
+    return this.resultsService.deleteResult(id, user, justification);
   }
 
   @Patch('update/geographic/:resiltId')

--- a/onecgiar-pr-server/src/api/results/results.module.ts
+++ b/onecgiar-pr-server/src/api/results/results.module.ts
@@ -104,6 +104,7 @@ import { ResultImpactAreaScoresModule } from '../result-impact-area-scores/resul
 import { ContributorsPartnersModule } from '../results-framework-reporting/contributors-partners/contributors-partners.module';
 import { InnovationDevModule } from '../results-framework-reporting/innovation_dev/innovation_dev.module';
 import { InnovationUseModule } from '../results-framework-reporting/innovation-use/innovation-use.module';
+import { ResultDeletionAuditModule } from './result-deletion-audit/result-deletion-audit.module';
 
 @Module({
   controllers: [ResultsController],
@@ -168,6 +169,7 @@ import { InnovationUseModule } from '../results-framework-reporting/innovation-u
     forwardRef(() => ContributorsPartnersModule),
     forwardRef(() => InnovationDevModule),
     forwardRef(() => InnovationUseModule),
+    ResultDeletionAuditModule,
   ],
   providers: [
     ResultsService,

--- a/onecgiar-pr-server/src/api/results/results.service.ts
+++ b/onecgiar-pr-server/src/api/results/results.service.ts
@@ -130,6 +130,8 @@ import { ShareResultRequestRepository } from './share-result-request/share-resul
 import { ShareResultRequest } from './share-result-request/entities/share-result-request.entity';
 import { EvidencesService } from '../results/evidences/evidences.service';
 import { SavePartnersV2Dto } from './results_by_institutions/dto/save-partners-v2.dto';
+import { ResultDeletionAuditService } from './result-deletion-audit/result-deletion-audit.service';
+import { ResultDeletionAuditSource } from './result-deletion-audit/result-deletion-audit-source.enum';
 
 @Injectable()
 export class ResultsService {
@@ -176,6 +178,7 @@ export class ResultsService {
     private readonly _resultsCenterRepository: ResultsCenterRepository,
     private readonly _resultsTocResultRepository: ResultsTocResultRepository,
     private readonly _tocResultsRepository: AoWBilateralRepository,
+    private readonly _resultDeletionAuditService: ResultDeletionAuditService,
     private readonly _dataSource: DataSource,
     private readonly _resultImpactAreaScoresService: ResultImpactAreaScoresService,
     private readonly _initiativeEntityMapRepository?: InitiativeEntityMapRepository,
@@ -974,7 +977,7 @@ export class ResultsService {
    * @returns
    */
 
-  async deleteResult(resultId: number, user: TokenDto) {
+  async deleteResult(resultId: number, user: TokenDto, justification?: string) {
     try {
       const result: Result = await this._resultRepository.findOne({
         where: { id: resultId },
@@ -993,6 +996,13 @@ export class ResultsService {
           statusCode: HttpStatus.BAD_REQUEST,
           response: result,
         });
+
+      await this._resultDeletionAuditService.recordDeletion({
+        resultId: result.id,
+        userId: user.id,
+        deletionSource: ResultDeletionAuditSource.ResultsModule,
+        justification,
+      });
 
       result.is_active = false;
 

--- a/onecgiar-pr-server/src/migrations/1774000000000-CreateResultDeletionAuditTable.ts
+++ b/onecgiar-pr-server/src/migrations/1774000000000-CreateResultDeletionAuditTable.ts
@@ -1,0 +1,42 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateResultDeletionAuditTable1774000000000
+  implements MigrationInterface
+{
+  name = 'CreateResultDeletionAuditTable1774000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE \`result_deletion_audit\` (
+        \`id\` bigint NOT NULL AUTO_INCREMENT,
+        \`result_id\` bigint NOT NULL,
+        \`deleted_by_user_id\` int NOT NULL,
+        \`created_date\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        \`last_updated_date\` timestamp NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+        \`created_by\` bigint NULL,
+        \`last_updated_by\` bigint NULL,
+        \`justification\` text NULL,
+        \`deletion_source\` varchar(64) NOT NULL,
+        PRIMARY KEY (\`id\`),
+        INDEX \`IDX_result_deletion_audit_result_id\` (\`result_id\`),
+        INDEX \`IDX_result_deletion_audit_created_date\` (\`created_date\`)
+      ) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`result_deletion_audit\` ADD CONSTRAINT \`FK_rda_result_id\` FOREIGN KEY (\`result_id\`) REFERENCES \`result\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`result_deletion_audit\` ADD CONSTRAINT \`FK_rda_deleted_by_user\` FOREIGN KEY (\`deleted_by_user_id\`) REFERENCES \`users\`(\`id\`) ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`result_deletion_audit\` DROP FOREIGN KEY \`FK_rda_deleted_by_user\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`result_deletion_audit\` DROP FOREIGN KEY \`FK_rda_result_id\``,
+    );
+    await queryRunner.query(`DROP TABLE \`result_deletion_audit\``);
+  }
+}


### PR DESCRIPTION
## Summary
Implements **P2-2611** — when a result is deleted through the reporting-related APIs, the backend now writes an **append-only audit row** so the organization can see **who** deleted the result, **when**, **from which flow**, and optionally **why**.

## What was implemented

### Database
- New table `result_deletion_audit` (migration `1774000000000-CreateResultDeletionAuditTable`).
- Columns: `result_id`, `deleted_by_user_id`, audit-style timestamps and user fields (`created_date`, `last_updated_date`, `created_by`, `last_updated_by`), optional `justification`, and `deletion_source`.
- **No** `is_active` on the audit table (log-only).
- Foreign keys to `result` and `users`; indexes on `result_id` and `created_date`.

### Application (NestJS / TypeORM)
- New entity `ResultDeletionAudit`, enum `ResultDeletionAuditSource`, `ResultDeletionAuditService`, and `ResultDeletionAuditModule`.
- `recordDeletion()` is invoked **after** permission / phase / QA checks and **before** logical delete in:
  - `DeleteRecoverDataService.deleteResult` → `MANAGE_DATA`
  - `ResultInnovationPackageService.delete` → `IPSR_INNOVATION_PACKAGE`
  - `ResultsService.deleteResult` → `RESULTS_MODULE`
- `ResultDeletionAuditModule` is imported wherever those services are constructed (including `InnovationPathwayModule` and `ResultsKnowledgeProductsModule` due to duplicate provider graphs).

### API
- Optional query parameter `justification` on:
  - `DELETE /api/manage-data/result/:id/delete`
  - `DELETE /api/ipsr/results-innovation-package/:resultId`
  - `PATCH /api/results/delete/:id`

### Scope / out of scope
- **Out of scope (as agreed):** legacy bilateral delete path.
- Manual SQL deletes are not instrumented by the app; `justification` remains available for exceptional operational use.

### Tests
- Controller specs updated for the new optional argument where applicable.

## Jira
[P2-2611](https://cgiarmel.atlassian.net/browse/P2-2611)

## Checklist for reviewers
- [x] Migration applied / reviewed in target environments.
- [ ] Smoke: delete via manage-data, IPSR innovation package, and results soft-delete; verify rows in `result_deletion_audit`.
- [x] Optional: confirm `justification` query param from client or API client.

Made with [Cursor](https://cursor.com)

[P2-2611]: https://cgiarmel.atlassian.net/browse/P2-2611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ