### PR TITLE
* Feat IPSR pathway summaries on list API and unified budget payloads

### DIFF
--- a/onecgiar-pr-server/docs/bilateral-result-summaries.en.md
+++ b/onecgiar-pr-server/docs/bilateral-result-summaries.en.md
@@ -18,7 +18,7 @@ Each item in a list response typically looks like:
 
 | Property       | Meaning |
 |----------------|---------|
-| `type`         | String discriminator, e.g. `knowledge_product`, `capacity_sharing`, `innovation_development`, `innovation_use`, `policy_change`. |
+| `type`         | String discriminator, e.g. `knowledge_product`, `capacity_sharing`, `innovation_development`, `innovation_use`, `innovation_package`, `policy_change`. |
 | `result_id`    | Numeric id of the result row. |
 | `data`         | Full enriched result document: common PRMS fields **plus** the summary for that type (when applicable). |
 
@@ -247,11 +247,13 @@ Structured demand **without** internal ids:
 
 ### Budgets and evidence (shared pattern with Innovation use budgets)
 
+The three budget arrays use the **same row shape** everywhere in bilateral summaries (Innovation development, Innovation use, and IPSR `step_four`): Clarisa-facing ids and amounts only — no PRMS join PKs, audit columns, or role flags on the row.
+
 | Field | Meaning |
 |-------|---------|
-| `initiative_budget[]` | Per contributing initiative: codes, names, year amounts, `kind_cash`, `is_determined`. |
-| `bilateral_project_budget[]` | Per bilateral project: short name, cash/in-kind splits, `is_determined`. |
-| `partner_budget[]` | Per partner institution budget line. |
+| `initiative_budget[]` | Each row: `current_year`, `next_year`, `kind_cash`, `is_determined`, **`initiative`** `{ id, official_code, name }` — `id` is the Clarisa initiative id. |
+| `bilateral_project_budget[]` | Each row: `in_cash`, `in_kind`, `kind_cash`, `is_determined`, **`project`** `{ id, short_name, full_name }` — `id` is the Clarisa project id. |
+| `partner_budget[]` | Each row: `kind_cash`, `in_cash`, `in_kind`, `is_determined`, **`institutions_id`** (Clarisa institution id), **`institution`** `{ id, name, acronym, institution_type_name }` (`id` matches Clarisa). |
 | `reference_materials[]` | `{ link }` from evidence type “materials”. |
 | `evidence_of_user_need_user_demand[]` | `{ link }` from evidence type user need / demand. |
 | `scaling_study_urls[]` | URLs when readiness is high enough to require scaling studies. |
@@ -343,6 +345,72 @@ Portfolio **P25** uses the **V2** question set; otherwise legacy P22. On load fa
 
 ---
 
+## 6. Innovation package (IPSR) — `ipsr_pathway_summary`
+
+**When:** `type === "innovation_package"` (PRMS result type id 10 — Innovation Package / IPSR).
+
+**Purpose:** Exposes the **four IPSR pathway steps** in one object for bilateral list consumers. **Steps one–four** use **bilateral-specific** shapes below (steps one–three aligned with PRMS IPSR UI; step four is a slim investments/materials/scaling slice).
+
+| Field | Meaning |
+|-------|---------|
+| `step_one` | See **Step one shape** below, or `null` if step one could not be loaded. |
+| `step_two` | Array of complementary innovations — see **Step two shape**; or `null` if not loaded. |
+| `step_three` | See **Step three shape**; or `null` if not loaded. |
+| `step_four` | See **Step four shape**; or `null` if not loaded. |
+
+### Step one shape (`ipsr_pathway_summary.step_one`)
+
+| Field | Meaning |
+|-------|---------|
+| `result_id` | Package result id. |
+| `coreResult` | Core innovation row from step-one SQL **plus** `year`: reporting year from the result’s `reported_year_id`. |
+| `specify_aspired_outcomes_impact` | Former `eoiOutcomes` list from pathway step one. |
+| `target_innovation_use` | Same structure as innovation use bilateral **`current_section`**: `actors[]`, `organizations[]`, `other_quantitative[]` (mapped with the same rules as innovation use). |
+| `scalig_ambition` | Scaling ambition object from pathway step one (unchanged key spelling). |
+| `result_ip_expert_workshop_organized` | Workshop participants; each item only `result_id`, `first_name`, `last_name`, `email`, `workshop_role`. |
+
+### Step two shape (`ipsr_pathway_summary.step_two`)
+
+Array of complementary innovation rows (same base data as `getStepTwoOne`), with these bilateral adjustments on **each** item:
+
+| Change | Meaning |
+|--------|---------|
+| `official_code` | Clarisa initiative **official_code** (from the step-two query join, or resolved from `initiative_id` when the join code is missing). **`initiative_id` is not returned.** |
+| (removed) | **`result_by_innovation_package_id`** is omitted. |
+| `result_type_name` | Human-readable **`result_type.name`** from PRMS. **`result_type_id` is not returned.** |
+| Other fields | Unchanged from the pathway response when present (e.g. `result_id`, `result_code`, `title`, `description`, `version_id`, `is_active`, …). |
+
+### Step three shape (`ipsr_pathway_summary.step_three`)
+
+Structured like PRMS **Step 3: Scaling readiness assessment** (not the raw `getStepThree` ORM dump).
+
+| Field | Meaning |
+|-------|---------|
+| `result_core_innovation` | `{ core_result_code, core_title, core_result_current_phase }` (unchanged from pathway). |
+| `result_innovation_package` | `is_expert_workshop_organized` only. Evidence-based readiness/use levels are on **`evidence_based_assessment`** (core + complementary rows), matching how PRMS step 3 saves data — not on the package row. |
+| `expert_workshop` | `null` if no expert workshop was organized. Otherwise: `is_expert_workshop_organized`, `what_was_assessed_during_expert_workshop` `{ id, name }` from catalog `assessed_during_expert_workshop`, `assessment_mode` (`none_of_above` \| `current_only` \| `current_and_potential` \| `null`), and `workshop_level_assignments` — see below. |
+| `evidence_based_assessment` | `core_innovation` and `complementary_innovations[]`: each row has **Innovation Readiness level evidence-based** and **Innovation use level evidence-based** as Clarisa slim objects, plus **`readinees_evidence_link`**, **`readiness_details_of_evidence`**, **`use_evidence_link`**, **`use_details_of_evidence`** (same concepts as step 3 in PRMS and as innovation use bilateral level blocks). |
+| `target_innovation_use` | Current use block: `actors[]`, `organizations[]`, `other_quantitative[]` (same mappers as innovation use bilateral / step one `target_innovation_use`). |
+
+**Expert workshop `workshop_level_assignments`:** `null` when `assessment_mode` is `none_of_above`, unknown, or not organized (equivalent to hiding the readiness/use table in PRMS for “None of the above”). When `current_only` (id **1** in catalog): `core_innovation` and `complementary_innovations[]` each include **`current`** only — `innovation_readiness_level` and `innovation_use_level` as Clarisa slim objects (workshop self-assessed **current** levels). When `current_and_potential` (id **2**): each row also includes **`potential`** with the same two Clarisa slim fields (12‑month potential levels).
+
+### Step four shape (`ipsr_pathway_summary.step_four`)
+
+Only these keys appear, in this order (same data sources as `getStepFour`, without pictures, PDF, unit times, publish flags, etc.):
+
+| Field | Meaning |
+|-------|---------|
+| `initiative_budget` | Initiative budget lines from step 4, **same row shape** as Innovation development / Innovation use `initiative_budget[]` (see §2 budgets table). |
+| `bilateral_project_budget` | Bilateral / Clarisa project budget lines — same shape as Inno Dev / Inno Use `bilateral_project_budget[]`. |
+| `partner_budget` | Partner institution budget lines — same shape as Inno Dev / Inno Use `partner_budget[]`. |
+| `ipsr_materials` | Evidence rows with type **materials** (source `evidence_type_id` 4 in PRMS); each item omits audit/typing flags (`creation_date`, `last_updated_date`, `description`, cross-cutting booleans, `is_supplementary`, `is_sharepoint`, `evidence_type_id`, etc.). |
+| `has_scaling_studies` | Boolean from the innovation package record. |
+| `scaling_studies_urls` | URLs linked to scaling studies for the package. |
+
+**Note:** Steps one–four are tailored for bilateral consumers.
+
+---
+
 ## Types without a dedicated summary in this flow
 
 Other bilateral-supported types (e.g. other output / other outcome) may **not** add a `*_summary` object; they still receive the **shared** enrichment on `data`.
@@ -357,6 +425,12 @@ Other bilateral-supported types (e.g. other output / other outcome) may **not** 
 | 2026 | Policy change: `result_related_to` from `ResultQuestionsService`; removed duplicate engagement-only field from bilateral JSON. |
 | 2026 | Policy change & capacity sharing summaries: omit `created_date` / `last_updated_date` on the **type summary** object only (core `data` still carries result-level dates). |
 | 2026 | `leading_result` reflects `is_lead_by_partner` (partner vs centre); `last_submission` for status QA/Submitted; Clarisa `id` on policy type/stage, implementing orgs, innovation typology; KP summary = `handle` only; cap sharing `institutions` renamed to `on_behalf_organizations`; policy change implementing orgs as `policy_implementing_organizations`. |
+| 2026 | Innovation package (IPSR): list `type` `innovation_package`; `ipsr_pathway_summary` with `step_one`–`step_four` from pathway services. |
+| 2026 | IPSR bilateral `step_two`: `official_code`, `result_type_name`; drop `result_by_innovation_package_id`, `initiative_id`, `result_type_id`, `initiative_official_code`. |
+| 2026 | IPSR bilateral `step_three`: expert workshop selection + conditional workshop levels; evidence-based readiness/use + links + details; `target_innovation_use`. |
+| 2026 | IPSR bilateral `step_three`: `result_innovation_package` flags only (evidence-based levels under `evidence_based_assessment`); no `result_ip_expert_workshop_organized` on step 3. |
+| 2026 | IPSR bilateral `step_four`: only initiative/bilateral/institution investments, `ipsr_materials`, `has_scaling_studies`, `scaling_studies_urls`. |
+| 2026 | Bilateral budget rows unified: `initiative_budget` / `bilateral_project_budget` / `partner_budget` share one slim shape (Clarisa `initiative` / `project` / `institution` objects + amounts); IPSR `step_four` uses these **same keys and row shape** (replacing raw `initiative_expected_investment` / `bilateral_expected_investment` / `institutions_expected_investment` on the bilateral payload only). |
 
 ---
 

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.module.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.module.ts
@@ -44,6 +44,7 @@ import { ResultsCapacityDevelopmentsRepository } from '../results/summary/reposi
 import { ResultsPolicyChangesRepository } from '../results/summary/repositories/results-policy-changes.repository';
 import { NoopBilateralHandler } from './handlers/noop.handler';
 import { NonPooledProjectBudgetRepository } from '../results/result_budget/repositories/non_pooled_proyect_budget.repository';
+import { PathwayModule } from '../ipsr-framework/pathway/pathway.module';
 
 @Module({
   imports: [
@@ -79,6 +80,7 @@ import { NonPooledProjectBudgetRepository } from '../results/result_budget/repos
     InnovationUseModule,
     ResultsByInititiativesModule,
     ShareResultRequestModule,
+    PathwayModule,
   ],
   controllers: [BilateralController],
   providers: [

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.service.spec.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.service.spec.ts
@@ -82,6 +82,15 @@ describe('BilateralService (unit)', () => {
       }),
     };
 
+    const pathwayService = {
+      getPathwayMetadataForBilateral: jest.fn().mockResolvedValue({
+        step_one: null,
+        step_two: null,
+        step_three: null,
+        step_four: null,
+      }),
+    };
+
     const makeHandler = (resultType: number) => ({
       resultType,
       afterCreate: jest.fn(),
@@ -137,6 +146,7 @@ describe('BilateralService (unit)', () => {
       resultsCapacityDevelopmentsRepository as any,
       resultsPolicyChangesRepository as any,
       resultQuestionsService as any,
+      pathwayService as any,
       knowledgeProductHandler as any,
       capacityChangeHandler as any,
       innovationDevelopmentHandler as any,

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
@@ -90,6 +90,10 @@ import { ClarisaPolicyType } from '../../clarisa/clarisa-policy-types/entities/c
 import { ClarisaPolicyStage } from '../../clarisa/clarisa-policy-stages/entities/clarisa-policy-stage.entity';
 import { ResultsPolicyChangesRepository } from '../results/summary/repositories/results-policy-changes.repository';
 import { ResultQuestionsService } from '../results/result-questions/result-questions.service';
+import { PathwayService } from '../ipsr-framework/pathway/pathway.service';
+import { ResultType } from '../results/result_types/entities/result_type.entity';
+import { ClarisaInitiative } from '../../clarisa/clarisa-initiatives/entities/clarisa-initiative.entity';
+import { AssessedDuringExpertWorkshop } from '../ipsr/assessed-during-expert-workshop/entities/assessed-during-expert-workshop.entity';
 
 /** Anticipated innovation user — organization-type rows (same role as PRMS Innovation Dev). */
 const INNOVATION_DEV_ANTICIPATED_USER_ORG_ROLE_ID = 5;
@@ -105,6 +109,24 @@ const CAPACITY_SHARING_IMPLEMENTING_ORG_ROLE_ID = 3;
 
 /** Policy change — implementing organizations (`summary.service` / PRMS role 4). */
 const POLICY_CHANGE_IMPLEMENTING_ORG_ROLE_ID = 4;
+
+/** Fields stripped from each `ipsr_materials` evidence row in bilateral step 4. */
+const IPSR_BILATERAL_STEP_FOUR_MATERIAL_OMIT_KEYS = new Set([
+  'creation_date',
+  'last_updated_date',
+  'description',
+  'gender_related',
+  'youth_related',
+  'nutrition_related',
+  'environmental_biodiversity_related',
+  'poverty_related',
+  'is_supplementary',
+  'is_sharepoint',
+  'innovation_readiness_related',
+  'innovation_use_related',
+  'innov_dev_user_demand',
+  'evidence_type_id',
+]);
 
 /** Map result_type name (ListResultsResultTypeEnum) to result_type.id */
 const RESULT_TYPE_NAME_TO_ID: Partial<
@@ -194,6 +216,7 @@ export class BilateralService {
     private readonly _resultsCapacityDevelopmentsRepository: ResultsCapacityDevelopmentsRepository,
     private readonly _resultsPolicyChangesRepository: ResultsPolicyChangesRepository,
     private readonly _resultQuestionsService: ResultQuestionsService,
+    private readonly _pathwayService: PathwayService,
     private readonly _knowledgeProductHandler: KnowledgeProductBilateralHandler,
     private readonly _capacityChangeHandler: CapacityChangeBilateralHandler,
     private readonly _innovationDevelopmentHandler: InnovationDevelopmentBilateralHandler,
@@ -785,6 +808,7 @@ export class BilateralService {
           [ResultTypeEnum.CAPACITY_SHARING_FOR_DEVELOPMENT]: 'capacity_sharing',
           [ResultTypeEnum.INNOVATION_DEVELOPMENT]: 'innovation_development',
           [ResultTypeEnum.INNOVATION_USE]: 'innovation_use',
+          [ResultTypeEnum.INNOVATION_USE_IPSR]: 'innovation_package',
           [ResultTypeEnum.OTHER_OUTPUT]: 'other_output',
           [ResultTypeEnum.OTHER_OUTCOME]: 'other_outcome',
           [ResultTypeEnum.POLICY_CHANGE]: 'policy_change',
@@ -1905,6 +1929,132 @@ export class BilateralService {
     return out;
   }
 
+  /** Numeric budget field for bilateral summaries (null when missing / non-finite). */
+  private bilateralBudgetAmountOrNull(value: unknown): number | null {
+    if (value === null || value === undefined) return null;
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  }
+
+  /**
+   * Slim initiative budget row — shared by Innovation Dev / Innovation Use summaries
+   * and IPSR bilateral `step_four` (same inner shape; no PRMS join PKs or audit fields).
+   */
+  private slimBilateralInitiativeBudgetRow(
+    row: unknown,
+  ): Record<string, unknown> | null {
+    if (!row || typeof row !== 'object' || Array.isArray(row)) return null;
+    const b = row as Record<string, unknown>;
+    const ri = b['obj_result_initiative'] as Record<string, unknown> | undefined;
+    const ini = ri?.['obj_initiative'] as Record<string, unknown> | undefined;
+    const idRaw = ini?.['id'];
+    const initiative =
+      ini == null
+        ? null
+        : {
+            id:
+              idRaw == null || !Number.isFinite(Number(idRaw))
+                ? null
+                : Number(idRaw),
+            official_code: (ini['official_code'] as string | null) ?? null,
+            name: (ini['name'] as string | null) ?? null,
+          };
+    return {
+      current_year: this.bilateralBudgetAmountOrNull(b['current_year']),
+      next_year: this.bilateralBudgetAmountOrNull(b['next_year']),
+      kind_cash: this.bilateralBudgetAmountOrNull(b['kind_cash']),
+      is_determined: b['is_determined'] ?? null,
+      initiative,
+    };
+  }
+
+  private slimBilateralProjectBudgetRow(
+    row: unknown,
+  ): Record<string, unknown> | null {
+    if (!row || typeof row !== 'object' || Array.isArray(row)) return null;
+    const b = row as Record<string, unknown>;
+    const rp = b['obj_result_project'] as Record<string, unknown> | undefined;
+    const proj = rp?.['obj_clarisa_project'] as
+      | Record<string, unknown>
+      | undefined;
+    const idRaw = proj?.['id'];
+    const project =
+      proj == null
+        ? null
+        : {
+            id:
+              idRaw == null || !Number.isFinite(Number(idRaw))
+                ? null
+                : Number(idRaw),
+            short_name: (proj['shortName'] as string | null) ?? null,
+            full_name: (proj['fullName'] as string | null) ?? null,
+          };
+    return {
+      in_cash: this.bilateralBudgetAmountOrNull(b['in_cash']),
+      in_kind: this.bilateralBudgetAmountOrNull(b['in_kind']),
+      kind_cash: this.bilateralBudgetAmountOrNull(b['kind_cash']),
+      is_determined: b['is_determined'] ?? null,
+      project,
+    };
+  }
+
+  private slimBilateralPartnerBudgetRow(
+    row: unknown,
+  ): Record<string, unknown> | null {
+    if (!row || typeof row !== 'object' || Array.isArray(row)) return null;
+    const b = row as Record<string, unknown>;
+    const rbi = b['obj_result_institution'] as
+      | Record<string, unknown>
+      | undefined;
+    const inst = rbi?.['obj_institutions'] as Record<string, unknown> | undefined;
+    const typeObj = inst?.['obj_institution_type_code'] as
+      | Record<string, unknown>
+      | undefined;
+    const linkId = rbi?.['institutions_id'];
+    const instIdRaw = inst?.['id'];
+    let clarisaInstId: number | null = null;
+    if (linkId != null && Number.isFinite(Number(linkId))) {
+      clarisaInstId = Number(linkId);
+    } else if (instIdRaw != null && Number.isFinite(Number(instIdRaw))) {
+      clarisaInstId = Number(instIdRaw);
+    }
+    const institution =
+      inst == null
+        ? null
+        : {
+            id:
+              instIdRaw == null || !Number.isFinite(Number(instIdRaw))
+                ? null
+                : Number(instIdRaw),
+            name: (inst['name'] as string | null) ?? null,
+            acronym: (inst['acronym'] as string | null) ?? null,
+            institution_type_name:
+              (typeObj?.['name'] as string | null) ?? null,
+          };
+    return {
+      kind_cash: this.bilateralBudgetAmountOrNull(b['kind_cash']),
+      in_cash: this.bilateralBudgetAmountOrNull(b['in_cash']),
+      in_kind: this.bilateralBudgetAmountOrNull(b['in_kind']),
+      is_determined: b['is_determined'] ?? null,
+      institutions_id: clarisaInstId,
+      institution,
+    };
+  }
+
+  private mapBilateralBudgetArray(
+    raw: unknown,
+    mapper: (row: unknown) => Record<string, unknown> | null,
+  ): Record<string, unknown>[] {
+    if (raw == null) return [];
+    if (!Array.isArray(raw)) return [];
+    const out: Record<string, unknown>[] = [];
+    for (const row of raw) {
+      const mapped = mapper(row);
+      if (mapped) out.push(mapped);
+    }
+    return out;
+  }
+
   /**
    * Initiative / bilateral / partner budgets; optionally reference materials &
    * user-need evidence (Inno Dev only — Inno Use bilateral omits the latter two).
@@ -1985,39 +2135,23 @@ export class BilateralService {
           is_active: true,
         },
         relations: {
-          obj_result_institution: { obj_institutions: true },
+          obj_result_institution: {
+            obj_institutions: { obj_institution_type_code: true },
+          },
         },
       });
     }
 
     return {
-      initiative_budget: initiativeBudgetRows.map((b) => ({
-        initiative_official_code:
-          b.obj_result_initiative?.obj_initiative?.official_code ?? null,
-        initiative_name: b.obj_result_initiative?.obj_initiative?.name ?? null,
-        current_year: b.current_year == null ? null : Number(b.current_year),
-        next_year: b.next_year == null ? null : Number(b.next_year),
-        kind_cash: b.kind_cash == null ? null : Number(b.kind_cash),
-        is_determined: b.is_determined ?? null,
-      })),
-      bilateral_project_budget: bilateralBudgetRows.map((b) => ({
-        project_short_name:
-          b.obj_result_project?.obj_clarisa_project?.shortName ?? null,
-        in_cash: b.in_cash == null ? null : Number(b.in_cash),
-        in_kind: b.in_kind == null ? null : Number(b.in_kind),
-        kind_cash: b.kind_cash == null ? null : Number(b.kind_cash),
-        is_determined: b.is_determined ?? null,
-      })),
-      partner_budget: partnerBudgetRows.map((b) => ({
-        institution_name:
-          b.obj_result_institution?.obj_institutions?.name ?? null,
-        institution_acronym:
-          b.obj_result_institution?.obj_institutions?.acronym ?? null,
-        in_cash: b.in_cash == null ? null : Number(b.in_cash),
-        in_kind: b.in_kind == null ? null : Number(b.in_kind),
-        kind_cash: b.kind_cash == null ? null : Number(b.kind_cash),
-        is_determined: b.is_determined ?? null,
-      })),
+      initiative_budget: initiativeBudgetRows
+        .map((b) => this.slimBilateralInitiativeBudgetRow(b))
+        .filter((x): x is Record<string, unknown> => x != null),
+      bilateral_project_budget: bilateralBudgetRows
+        .map((b) => this.slimBilateralProjectBudgetRow(b))
+        .filter((x): x is Record<string, unknown> => x != null),
+      partner_budget: partnerBudgetRows
+        .map((b) => this.slimBilateralPartnerBudgetRow(b))
+        .filter((x): x is Record<string, unknown> => x != null),
       ...(includeEvidence
         ? {
             reference_materials: refs.map((e) => ({ link: e.link })),
@@ -2334,6 +2468,535 @@ export class BilateralService {
       quantity: m.quantity == null ? null : Number(m.quantity),
       addressing_demands: m.addressing_demands ?? null,
     };
+  }
+
+  /** IPSR `innovatonUse` → same shape as innovation use bilateral `current_section` inner payload. */
+  private mapIpsrInnovatonUseToTargetInnovationUseShape(innovatonUse: unknown): {
+    actors: unknown[];
+    organizations: unknown[];
+    other_quantitative: unknown[];
+  } {
+    const raw = innovatonUse as
+      | {
+          actors?: ResultActor[];
+          organization?: ResultsByInstitutionType[];
+          measures?: ResultIpMeasure[];
+        }
+      | undefined;
+    const actors = Array.isArray(raw?.actors)
+      ? raw!.actors!.map((a) => this.mapInnovationUseBilateralActor(a))
+      : [];
+    const organizations = Array.isArray(raw?.organization)
+      ? raw!.organization!.map((o) =>
+          this.mapInnovationUseBilateralOrganization(o),
+        )
+      : [];
+    const other_quantitative = Array.isArray(raw?.measures)
+      ? raw!.measures!.map((m) => this.mapInnovationUseBilateralMeasure(m))
+      : [];
+    return { actors, organizations, other_quantitative };
+  }
+
+  private clarisaInnovationReadinessLevelBilateralSlim(
+    e: ClarisaInnovationReadinessLevel | null | undefined,
+  ): {
+    id: number;
+    level: number | null;
+    name: string | null;
+    definition: string | null;
+  } | null {
+    if (!e) return null;
+    return {
+      id: Number(e.id),
+      level: e.level == null ? null : Number(e.level),
+      name: e.name ?? null,
+      definition: e.definition ?? null,
+    };
+  }
+
+  private clarisaInnovationUseLevelBilateralSlim(
+    e: ClarisaInnovationUseLevel | null | undefined,
+  ): {
+    id: number;
+    level: number | null;
+    name: string | null;
+    definition: string | null;
+  } | null {
+    if (!e) return null;
+    return {
+      id: Number(e.id),
+      level: e.level == null ? null : Number(e.level),
+      name: e.name ?? null,
+      definition: e.definition ?? null,
+    };
+  }
+
+  private resolveClarisaReadinessSlimForIpsrStep3(
+    fk: unknown,
+    obj: ClarisaInnovationReadinessLevel | undefined | null,
+    byId: Map<number, ClarisaInnovationReadinessLevel>,
+  ) {
+    if (obj) return this.clarisaInnovationReadinessLevelBilateralSlim(obj);
+    const n = Number(fk);
+    if (!Number.isFinite(n) || n <= 0) return null;
+    return this.clarisaInnovationReadinessLevelBilateralSlim(byId.get(n));
+  }
+
+  private resolveClarisaUseSlimForIpsrStep3(
+    fk: unknown,
+    obj: ClarisaInnovationUseLevel | undefined | null,
+    byId: Map<number, ClarisaInnovationUseLevel>,
+  ) {
+    if (obj) return this.clarisaInnovationUseLevelBilateralSlim(obj);
+    const n = Number(fk);
+    if (!Number.isFinite(n) || n <= 0) return null;
+    return this.clarisaInnovationUseLevelBilateralSlim(byId.get(n));
+  }
+
+  private collectIpsrStep3ClarisaLevelIds(
+    rows: any[],
+    packageRow?: any,
+  ): { readiness: Set<number>; use: Set<number> } {
+    const readiness = new Set<number>();
+    const use = new Set<number>();
+    const addRead = (v: unknown) => {
+      const n = Number(v);
+      if (Number.isFinite(n) && n > 0) readiness.add(n);
+    };
+    const addUse = (v: unknown) => {
+      const n = Number(v);
+      if (Number.isFinite(n) && n > 0) use.add(n);
+    };
+    const scan = (row: any) => {
+      if (!row || typeof row !== 'object') return;
+      addRead(row.readiness_level_evidence_based);
+      addUse(row.use_level_evidence_based);
+      addRead(row.current_innovation_readiness_level);
+      addUse(row.current_innovation_use_level);
+      addRead(row.potential_innovation_readiness_level);
+      addUse(row.potential_innovation_use_level);
+    };
+    for (const row of rows) scan(row);
+    if (packageRow) scan(packageRow);
+    return { readiness, use };
+  }
+
+  private mapIpsrStepThreeEvidenceBasedRow(
+    row: any,
+    readinessById: Map<number, ClarisaInnovationReadinessLevel>,
+    useById: Map<number, ClarisaInnovationUseLevel>,
+  ): Record<string, unknown> {
+    return {
+      result_title: row?.obj_result?.title ?? null,
+      result_code:
+        row?.obj_result?.result_code == null
+          ? null
+          : Number(row.obj_result.result_code),
+      innovation_readiness_level_evidence_based:
+        this.resolveClarisaReadinessSlimForIpsrStep3(
+          row?.readiness_level_evidence_based,
+          row?.obj_readiness_level_evidence_based,
+          readinessById,
+        ),
+      readinees_evidence_link: row?.readinees_evidence_link ?? null,
+      readiness_details_of_evidence: row?.readiness_details_of_evidence ?? null,
+      innovation_use_level_evidence_based:
+        this.resolveClarisaUseSlimForIpsrStep3(
+          row?.use_level_evidence_based,
+          row?.obj_use_level_evidence_based,
+          useById,
+        ),
+      use_evidence_link: row?.use_evidence_link ?? null,
+      use_details_of_evidence: row?.use_details_of_evidence ?? null,
+    };
+  }
+
+  private mapIpsrPathwayStepThreeWorkshopLevelRow(
+    row: any,
+    packageElement: string,
+    complementaryIndex: number | null,
+    mode: 'current_only' | 'current_and_potential',
+    readinessById: Map<number, ClarisaInnovationReadinessLevel>,
+    useById: Map<number, ClarisaInnovationUseLevel>,
+  ): Record<string, unknown> {
+    const current = {
+      innovation_readiness_level: this.resolveClarisaReadinessSlimForIpsrStep3(
+        row?.current_innovation_readiness_level,
+        undefined,
+        readinessById,
+      ),
+      innovation_use_level: this.resolveClarisaUseSlimForIpsrStep3(
+        row?.current_innovation_use_level,
+        undefined,
+        useById,
+      ),
+    };
+    const base: Record<string, unknown> = {
+      package_element: packageElement,
+      complementary_index: complementaryIndex,
+      result_title: row?.obj_result?.title ?? null,
+      result_code:
+        row?.obj_result?.result_code == null
+          ? null
+          : Number(row.obj_result.result_code),
+      current,
+    };
+    if (mode === 'current_and_potential') {
+      base.potential = {
+        innovation_readiness_level: this.resolveClarisaReadinessSlimForIpsrStep3(
+          row?.potential_innovation_readiness_level,
+          undefined,
+          readinessById,
+        ),
+        innovation_use_level: this.resolveClarisaUseSlimForIpsrStep3(
+          row?.potential_innovation_use_level,
+          undefined,
+          useById,
+        ),
+      };
+    }
+    return base;
+  }
+
+  /**
+   * IPSR pathway step 3 for bilateral: mirror PRMS step 3 (expert workshop selection + conditional
+   * readiness/use self-assessment table, evidence-based levels + links + details, current use).
+   */
+  private async mapIpsrPathwayStepThreeForBilateral(
+    stepThreeRaw: unknown,
+  ): Promise<unknown> {
+    if (!stepThreeRaw || typeof stepThreeRaw !== 'object') {
+      return stepThreeRaw;
+    }
+    const body = stepThreeRaw as Record<string, unknown>;
+    const rip = body['result_innovation_package'] as any;
+    const rawCore = body['result_ip_result_core'] as any;
+    const rawComp = Array.isArray(body['result_ip_result_complementary'])
+      ? (body['result_ip_result_complementary'] as any[])
+      : [];
+
+    const assessedRows = await this.dataSource
+      .getRepository(AssessedDuringExpertWorkshop)
+      .find({ select: ['id', 'name'] });
+    const assessedNameById = new Map(
+      assessedRows.map((a) => [Number(a.id), a.name ?? null]),
+    );
+
+    const rowsForIds = [rawCore, ...rawComp].filter(Boolean);
+    const { readiness: readinessIds, use: useIds } =
+      this.collectIpsrStep3ClarisaLevelIds(rowsForIds, rip);
+
+    const [readinessEntities, useEntities] = await Promise.all([
+      readinessIds.size > 0
+        ? this.dataSource.getRepository(ClarisaInnovationReadinessLevel).find({
+            where: { id: In([...readinessIds]) },
+          })
+        : Promise.resolve([] as ClarisaInnovationReadinessLevel[]),
+      useIds.size > 0
+        ? this.dataSource.getRepository(ClarisaInnovationUseLevel).find({
+            where: { id: In([...useIds]) },
+          })
+        : Promise.resolve([] as ClarisaInnovationUseLevel[]),
+    ]);
+    const readinessById = new Map(
+      readinessEntities.map((e) => [Number(e.id), e]),
+    );
+    const useById = new Map(useEntities.map((e) => [Number(e.id), e]));
+
+    const assessedId = Number(rip?.assessed_during_expert_workshop_id);
+    const assessedSelection =
+      Number.isFinite(assessedId) && assessedId > 0
+        ? {
+            id: assessedId,
+            name: assessedNameById.get(assessedId) ?? null,
+          }
+        : null;
+
+    const organized = !!rip?.is_expert_workshop_organized;
+    let expert_workshop: Record<string, unknown> | null = null;
+    if (organized) {
+      const noneOfAbove = assessedId === 3;
+      const modeCurrentAndPotential = assessedId === 2;
+      const modeCurrentOnly = assessedId === 1;
+      const mode: 'none_of_above' | 'current_only' | 'current_and_potential' | null =
+        noneOfAbove
+          ? 'none_of_above'
+          : modeCurrentAndPotential
+            ? 'current_and_potential'
+            : modeCurrentOnly
+              ? 'current_only'
+              : null;
+
+      let workshop_level_assignments: unknown = null;
+      if (mode === 'current_only' || mode === 'current_and_potential') {
+        const innerMode =
+          mode === 'current_and_potential'
+            ? 'current_and_potential'
+            : 'current_only';
+        workshop_level_assignments = {
+          core_innovation: this.mapIpsrPathwayStepThreeWorkshopLevelRow(
+            rawCore,
+            'core_innovation',
+            null,
+            innerMode,
+            readinessById,
+            useById,
+          ),
+          complementary_innovations: rawComp.map((row, i) =>
+            this.mapIpsrPathwayStepThreeWorkshopLevelRow(
+              row,
+              'complementary_innovation',
+              i + 1,
+              innerMode,
+              readinessById,
+              useById,
+            ),
+          ),
+        };
+      }
+
+      expert_workshop = {
+        is_expert_workshop_organized: true,
+        what_was_assessed_during_expert_workshop: assessedSelection,
+        assessment_mode: mode,
+        workshop_level_assignments,
+      };
+    }
+
+    // PRMS step 3 binds evidence-based readiness/use to core/complementary IPSR rows — not to
+    // `result_innovation_package` columns (often null). See `evidence_based_assessment`.
+    const result_innovation_package = rip
+      ? {
+          is_expert_workshop_organized: rip.is_expert_workshop_organized ?? null,
+        }
+      : null;
+
+    return {
+      result_core_innovation: body['result_core_innovation'] ?? null,
+      result_innovation_package,
+      expert_workshop,
+      evidence_based_assessment: {
+        core_innovation: rawCore
+          ? this.mapIpsrStepThreeEvidenceBasedRow(
+              rawCore,
+              readinessById,
+              useById,
+            )
+          : null,
+        complementary_innovations: rawComp.map((row) =>
+          this.mapIpsrStepThreeEvidenceBasedRow(row, readinessById, useById),
+        ),
+      },
+      target_innovation_use: this.mapIpsrInnovatonUseToTargetInnovationUseShape(
+        body['innovatonUse'],
+      ),
+    };
+  }
+
+  private slimIpsrStepFourMaterialRow(
+    row: unknown,
+  ): Record<string, unknown> {
+    if (!row || typeof row !== 'object' || Array.isArray(row)) {
+      return {};
+    }
+    const o = row as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(o)) {
+      if (IPSR_BILATERAL_STEP_FOUR_MATERIAL_OMIT_KEYS.has(k)) continue;
+      out[k] = v;
+    }
+    return out;
+  }
+
+  /** IPSR pathway step 4 for bilateral: investments, materials, scaling flags only. */
+  private mapIpsrPathwayStepFourForBilateral(
+    stepFourRaw: unknown,
+  ): Record<string, unknown> | null {
+    if (!stepFourRaw || typeof stepFourRaw !== 'object') return null;
+    const r = stepFourRaw as Record<string, unknown>;
+    const urls = r['scaling_studies_urls'];
+    const hasScaling = r['has_scaling_studies'];
+    const materialsRaw = r['ipsr_materials'];
+    const ipsr_materials =
+      materialsRaw == null
+        ? null
+        : Array.isArray(materialsRaw)
+          ? (materialsRaw as unknown[]).map((m) =>
+              this.slimIpsrStepFourMaterialRow(m),
+            )
+          : materialsRaw;
+    return {
+      initiative_budget: this.mapBilateralBudgetArray(
+        r['initiative_expected_investment'],
+        (row) => this.slimBilateralInitiativeBudgetRow(row),
+      ),
+      bilateral_project_budget: this.mapBilateralBudgetArray(
+        r['bilateral_expected_investment'],
+        (row) => this.slimBilateralProjectBudgetRow(row),
+      ),
+      partner_budget: this.mapBilateralBudgetArray(
+        r['institutions_expected_investment'],
+        (row) => this.slimBilateralPartnerBudgetRow(row),
+      ),
+      ipsr_materials,
+      has_scaling_studies:
+        hasScaling === true ||
+        hasScaling === 1 ||
+        hasScaling === '1' ||
+        hasScaling === 'true',
+      scaling_studies_urls: Array.isArray(urls) ? urls : [],
+    };
+  }
+
+  /**
+   * IPSR pathway step 1 for bilateral list: drop geo / partners (on common `data`),
+   * rename EOI block, align target innovation use with innovation-use summary actors/orgs/measures.
+   */
+  private mapIpsrPathwayStepOneForBilateral(
+    stepOneRaw: Record<string, unknown> | null,
+    filtered: { id?: number; reported_year_id?: number | null },
+  ): Record<string, unknown> | null {
+    if (!stepOneRaw || typeof stepOneRaw !== 'object') return null;
+
+    const resultIdRaw = filtered?.id ?? stepOneRaw['result_id'];
+    const result_id =
+      resultIdRaw == null || !Number.isFinite(Number(resultIdRaw))
+        ? null
+        : Number(resultIdRaw);
+
+    const reportedYear = filtered?.reported_year_id;
+    const year =
+      reportedYear == null || !Number.isFinite(Number(reportedYear))
+        ? null
+        : Number(reportedYear);
+
+    const coreRaw = stepOneRaw['coreResult'];
+    const coreResult =
+      coreRaw && typeof coreRaw === 'object' && !Array.isArray(coreRaw)
+        ? { ...(coreRaw as Record<string, unknown>), year }
+        : { year };
+
+    const workshopRaw = stepOneRaw['result_ip_expert_workshop_organized'];
+    const result_ip_expert_workshop_organized = Array.isArray(workshopRaw)
+      ? (workshopRaw as Array<Record<string, unknown>>).map((w) => ({
+          result_id:
+            w['result_id'] == null ? null : String(w['result_id']).trim(),
+          first_name:
+            w['first_name'] == null ? null : String(w['first_name']).trim(),
+          last_name:
+            w['last_name'] == null ? null : String(w['last_name']).trim(),
+          email: w['email'] == null ? null : String(w['email']).trim(),
+          workshop_role:
+            w['workshop_role'] == null
+              ? null
+              : String(w['workshop_role']).trim(),
+        }))
+      : [];
+
+    return {
+      result_id,
+      coreResult,
+      specify_aspired_outcomes_impact: stepOneRaw['eoiOutcomes'] ?? null,
+      target_innovation_use: this.mapIpsrInnovatonUseToTargetInnovationUseShape(
+        stepOneRaw['innovatonUse'],
+      ),
+      scalig_ambition: stepOneRaw['scalig_ambition'] ?? null,
+      result_ip_expert_workshop_organized,
+    };
+  }
+
+  /**
+   * IPSR pathway step 2 (complementary innovations) for bilateral: expose initiative
+   * `official_code`, drop linkage ids, expose result type `name` instead of id.
+   */
+  private async mapIpsrPathwayStepTwoForBilateral(
+    stepTwoRaw: unknown,
+  ): Promise<unknown> {
+    if (!Array.isArray(stepTwoRaw)) {
+      return stepTwoRaw;
+    }
+    if (stepTwoRaw.length === 0) {
+      return [];
+    }
+
+    const typeIds = new Set<number>();
+    const initiativeIdsMissingCode = new Set<number>();
+
+    for (const raw of stepTwoRaw) {
+      const r = raw as Record<string, unknown>;
+      const rt = Number(r['result_type_id']);
+      if (Number.isFinite(rt) && rt > 0) {
+        typeIds.add(rt);
+      }
+      const codeRaw = r['initiative_official_code'];
+      const codeStr =
+        codeRaw == null || String(codeRaw).trim() === ''
+          ? ''
+          : String(codeRaw).trim();
+      const iid = Number(r['initiative_id']);
+      if (codeStr === '' && Number.isFinite(iid) && iid > 0) {
+        initiativeIdsMissingCode.add(iid);
+      }
+    }
+
+    const [types, clarisaInits] = await Promise.all([
+      typeIds.size > 0
+        ? this.dataSource.getRepository(ResultType).find({
+            where: { id: In([...typeIds]) },
+            select: ['id', 'name'],
+          })
+        : Promise.resolve([] as ResultType[]),
+      initiativeIdsMissingCode.size > 0
+        ? this.dataSource.getRepository(ClarisaInitiative).find({
+            where: { id: In([...initiativeIdsMissingCode]) },
+            select: ['id', 'official_code'],
+          })
+        : Promise.resolve([] as ClarisaInitiative[]),
+    ]);
+
+    const resultTypeNameById = new Map(
+      types.map((t) => [Number(t.id), t.name ?? null]),
+    );
+    const officialCodeByInitiativeId = new Map(
+      clarisaInits.map((i) => [Number(i.id), i.official_code ?? null]),
+    );
+
+    const omitKeys = new Set([
+      'result_by_innovation_package_id',
+      'initiative_id',
+      'result_type_id',
+      'initiative_official_code',
+    ]);
+
+    return stepTwoRaw.map((raw) => {
+      const r = raw as Record<string, unknown>;
+      const rtid = Number(r['result_type_id']);
+      const result_type_name =
+        Number.isFinite(rtid) && rtid > 0
+          ? (resultTypeNameById.get(rtid) ?? null)
+          : null;
+
+      const fromJoin = r['initiative_official_code'];
+      const officialFromJoin =
+        fromJoin == null || String(fromJoin).trim() === ''
+          ? null
+          : String(fromJoin).trim();
+      const iid = Number(r['initiative_id']);
+      const official_code =
+        officialFromJoin ??
+        (Number.isFinite(iid) && iid > 0
+          ? (officialCodeByInitiativeId.get(iid) ?? null)
+          : null);
+
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(r)) {
+        if (omitKeys.has(k)) continue;
+        out[k] = v;
+      }
+      out.official_code = official_code;
+      out.result_type_name = result_type_name;
+      return out;
+    });
   }
 
   private async resolveInnovationUseLevelForSummary(
@@ -2852,6 +3515,43 @@ export class BilateralService {
       filtered.policy_change_summary =
         await this.buildPolicyChangeBilateralSummary(filtered.id);
       delete filtered.results_policy_changes_object;
+    }
+    if (filtered.result_type_id === ResultTypeEnum.INNOVATION_USE_IPSR) {
+      try {
+        const ipsrPathwaySummary =
+          await this._pathwayService.getPathwayMetadataForBilateral(
+            filtered.id,
+          );
+        if (ipsrPathwaySummary?.step_one != null) {
+          ipsrPathwaySummary.step_one = this.mapIpsrPathwayStepOneForBilateral(
+            ipsrPathwaySummary.step_one as Record<string, unknown>,
+            filtered,
+          );
+        }
+        if (ipsrPathwaySummary?.step_two != null) {
+          ipsrPathwaySummary.step_two =
+            await this.mapIpsrPathwayStepTwoForBilateral(
+              ipsrPathwaySummary.step_two,
+            );
+        }
+        if (ipsrPathwaySummary?.step_three != null) {
+          ipsrPathwaySummary.step_three =
+            await this.mapIpsrPathwayStepThreeForBilateral(
+              ipsrPathwaySummary.step_three,
+            );
+        }
+        if (ipsrPathwaySummary?.step_four != null) {
+          ipsrPathwaySummary.step_four = this.mapIpsrPathwayStepFourForBilateral(
+            ipsrPathwaySummary.step_four,
+          );
+        }
+        filtered.ipsr_pathway_summary = ipsrPathwaySummary;
+      } catch {
+        this.logger.warn(
+          `Bilateral enrich: could not load IPSR pathway summary for result ${filtered.id}`,
+        );
+        filtered.ipsr_pathway_summary = null;
+      }
     }
     delete filtered.obj_result_by_project;
   }

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.service.ts
@@ -1945,7 +1945,9 @@ export class BilateralService {
   ): Record<string, unknown> | null {
     if (!row || typeof row !== 'object' || Array.isArray(row)) return null;
     const b = row as Record<string, unknown>;
-    const ri = b['obj_result_initiative'] as Record<string, unknown> | undefined;
+    const ri = b['obj_result_initiative'] as
+      | Record<string, unknown>
+      | undefined;
     const ini = ri?.['obj_initiative'] as Record<string, unknown> | undefined;
     const idRaw = ini?.['id'];
     const initiative =
@@ -2006,7 +2008,9 @@ export class BilateralService {
     const rbi = b['obj_result_institution'] as
       | Record<string, unknown>
       | undefined;
-    const inst = rbi?.['obj_institutions'] as Record<string, unknown> | undefined;
+    const inst = rbi?.['obj_institutions'] as
+      | Record<string, unknown>
+      | undefined;
     const typeObj = inst?.['obj_institution_type_code'] as
       | Record<string, unknown>
       | undefined;
@@ -2028,8 +2032,7 @@ export class BilateralService {
                 : Number(instIdRaw),
             name: (inst['name'] as string | null) ?? null,
             acronym: (inst['acronym'] as string | null) ?? null,
-            institution_type_name:
-              (typeObj?.['name'] as string | null) ?? null,
+            institution_type_name: (typeObj?.['name'] as string | null) ?? null,
           };
     return {
       kind_cash: this.bilateralBudgetAmountOrNull(b['kind_cash']),
@@ -2471,7 +2474,9 @@ export class BilateralService {
   }
 
   /** IPSR `innovatonUse` → same shape as innovation use bilateral `current_section` inner payload. */
-  private mapIpsrInnovatonUseToTargetInnovationUseShape(innovatonUse: unknown): {
+  private mapIpsrInnovatonUseToTargetInnovationUseShape(
+    innovatonUse: unknown,
+  ): {
     actors: unknown[];
     organizations: unknown[];
     other_quantitative: unknown[];
@@ -2643,11 +2648,12 @@ export class BilateralService {
     };
     if (mode === 'current_and_potential') {
       base.potential = {
-        innovation_readiness_level: this.resolveClarisaReadinessSlimForIpsrStep3(
-          row?.potential_innovation_readiness_level,
-          undefined,
-          readinessById,
-        ),
+        innovation_readiness_level:
+          this.resolveClarisaReadinessSlimForIpsrStep3(
+            row?.potential_innovation_readiness_level,
+            undefined,
+            readinessById,
+          ),
         innovation_use_level: this.resolveClarisaUseSlimForIpsrStep3(
           row?.potential_innovation_use_level,
           undefined,
@@ -2718,14 +2724,17 @@ export class BilateralService {
       const noneOfAbove = assessedId === 3;
       const modeCurrentAndPotential = assessedId === 2;
       const modeCurrentOnly = assessedId === 1;
-      const mode: 'none_of_above' | 'current_only' | 'current_and_potential' | null =
-        noneOfAbove
-          ? 'none_of_above'
-          : modeCurrentAndPotential
-            ? 'current_and_potential'
-            : modeCurrentOnly
-              ? 'current_only'
-              : null;
+      const mode:
+        | 'none_of_above'
+        | 'current_only'
+        | 'current_and_potential'
+        | null = noneOfAbove
+        ? 'none_of_above'
+        : modeCurrentAndPotential
+          ? 'current_and_potential'
+          : modeCurrentOnly
+            ? 'current_only'
+            : null;
 
       let workshop_level_assignments: unknown = null;
       if (mode === 'current_only' || mode === 'current_and_potential') {
@@ -2767,7 +2776,8 @@ export class BilateralService {
     // `result_innovation_package` columns (often null). See `evidence_based_assessment`.
     const result_innovation_package = rip
       ? {
-          is_expert_workshop_organized: rip.is_expert_workshop_organized ?? null,
+          is_expert_workshop_organized:
+            rip.is_expert_workshop_organized ?? null,
         }
       : null;
 
@@ -2793,9 +2803,7 @@ export class BilateralService {
     };
   }
 
-  private slimIpsrStepFourMaterialRow(
-    row: unknown,
-  ): Record<string, unknown> {
+  private slimIpsrStepFourMaterialRow(row: unknown): Record<string, unknown> {
     if (!row || typeof row !== 'object' || Array.isArray(row)) {
       return {};
     }
@@ -3541,9 +3549,10 @@ export class BilateralService {
             );
         }
         if (ipsrPathwaySummary?.step_four != null) {
-          ipsrPathwaySummary.step_four = this.mapIpsrPathwayStepFourForBilateral(
-            ipsrPathwaySummary.step_four,
-          );
+          ipsrPathwaySummary.step_four =
+            this.mapIpsrPathwayStepFourForBilateral(
+              ipsrPathwaySummary.step_four,
+            );
         }
         filtered.ipsr_pathway_summary = ipsrPathwaySummary;
       } catch {

--- a/onecgiar-pr-server/src/api/ipsr-framework/pathway/ipsr-pathway-step-four.service.ts
+++ b/onecgiar-pr-server/src/api/ipsr-framework/pathway/ipsr-pathway-step-four.service.ts
@@ -564,11 +564,6 @@ export class IpsrPathwayStepFourService {
           },
         });
 
-      console.log(
-        'bilateral_expected_investment',
-        bilateral_expected_investment,
-      );
-
       const institutions = await this._resultByInstitutionsRepository.find({
         where: [
           {

--- a/onecgiar-pr-server/src/api/ipsr-framework/pathway/pathway.module.ts
+++ b/onecgiar-pr-server/src/api/ipsr-framework/pathway/pathway.module.ts
@@ -31,6 +31,7 @@ import { ResultIpMeasureRepository } from '../../ipsr/result-ip-measures/result-
 import { ResultIpImpactAreaRepository } from '../../ipsr/innovation-pathway/repository/result-ip-impact-area-targets.repository';
 import { ResultCountrySubnationalRepository } from '../../results/result-countries-sub-national/repositories/result-country-subnational.repository';
 import { ResultIpExpertWorkshopOrganizedRepostory } from '../../ipsr/innovation-pathway/repository/result-ip-expert-workshop-organized.repository';
+import { InnovationPathwayServicesModule } from '../../ipsr/innovation-pathway/innovation-pathway-services.module';
 
 @Module({
   controllers: [PathwayController],
@@ -66,7 +67,9 @@ import { ResultIpExpertWorkshopOrganizedRepostory } from '../../ipsr/innovation-
   ],
   imports: [
     forwardRef(() => VersioningModule),
+    InnovationPathwayServicesModule,
     TypeOrmModule.forFeature([ResultScalingStudyUrl]),
   ],
+  exports: [PathwayService],
 })
 export class PathwayModule {}

--- a/onecgiar-pr-server/src/api/ipsr-framework/pathway/pathway.service.spec.ts
+++ b/onecgiar-pr-server/src/api/ipsr-framework/pathway/pathway.service.spec.ts
@@ -1,12 +1,28 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus } from '@nestjs/common';
 import { PathwayService } from './pathway.service';
+import { IpsrPathwayStepOneService } from './ipsr-pathway-step-one.service';
+import { IpsrPathwayStepFourService } from './ipsr-pathway-step-four.service';
+import { InnovationPathwayStepTwoService } from '../../ipsr/innovation-pathway/innovation-pathway-step-two.service';
+import { InnovationPathwayStepThreeService } from '../../ipsr/innovation-pathway/innovation-pathway-step-three.service';
 
 describe('PathwayService', () => {
   let service: PathwayService;
+  const stepOne = { getStepOne: jest.fn() };
+  const stepTwo = { getStepTwoOne: jest.fn() };
+  const stepThree = { getStepThree: jest.fn() };
+  const stepFour = { getStepFour: jest.fn() };
 
   beforeEach(async () => {
+    jest.clearAllMocks();
     const module: TestingModule = await Test.createTestingModule({
-      providers: [PathwayService],
+      providers: [
+        PathwayService,
+        { provide: IpsrPathwayStepOneService, useValue: stepOne },
+        { provide: InnovationPathwayStepTwoService, useValue: stepTwo },
+        { provide: InnovationPathwayStepThreeService, useValue: stepThree },
+        { provide: IpsrPathwayStepFourService, useValue: stepFour },
+      ],
     }).compile();
 
     service = module.get<PathwayService>(PathwayService);
@@ -14,5 +30,36 @@ describe('PathwayService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('getPathwayMetadataForBilateral unwraps OK steps and nulls non-OK', async () => {
+    stepOne.getStepOne.mockResolvedValue({
+      status: HttpStatus.OK,
+      response: { a: 1 },
+    });
+    stepTwo.getStepTwoOne.mockResolvedValue({
+      status: HttpStatus.NOT_FOUND,
+      response: null,
+    });
+    stepThree.getStepThree.mockResolvedValue({
+      statusCode: HttpStatus.OK,
+      response: { c: 3 },
+    });
+    stepFour.getStepFour.mockResolvedValue({
+      status: HttpStatus.INTERNAL_SERVER_ERROR,
+    });
+
+    const out = await service.getPathwayMetadataForBilateral(42);
+
+    expect(stepOne.getStepOne).toHaveBeenCalledWith(42);
+    expect(stepTwo.getStepTwoOne).toHaveBeenCalledWith(42);
+    expect(stepThree.getStepThree).toHaveBeenCalledWith(42);
+    expect(stepFour.getStepFour).toHaveBeenCalledWith(42);
+    expect(out).toEqual({
+      step_one: { a: 1 },
+      step_two: null,
+      step_three: { c: 3 },
+      step_four: null,
+    });
   });
 });

--- a/onecgiar-pr-server/src/api/ipsr-framework/pathway/pathway.service.ts
+++ b/onecgiar-pr-server/src/api/ipsr-framework/pathway/pathway.service.ts
@@ -1,4 +1,51 @@
-import { Injectable } from '@nestjs/common';
+import { HttpStatus, Injectable } from '@nestjs/common';
+import { IpsrPathwayStepOneService } from './ipsr-pathway-step-one.service';
+import { IpsrPathwayStepFourService } from './ipsr-pathway-step-four.service';
+import { InnovationPathwayStepTwoService } from '../../ipsr/innovation-pathway/innovation-pathway-step-two.service';
+import { InnovationPathwayStepThreeService } from '../../ipsr/innovation-pathway/innovation-pathway-step-three.service';
+
+export type IpsrPathwayBilateralSummary = {
+  step_one: unknown;
+  step_two: unknown;
+  step_three: unknown;
+  step_four: unknown;
+};
+
+function unwrapIpsrStepResponse(res: unknown): unknown {
+  if (!res || typeof res !== 'object') return null;
+  const r = res as { status?: number; statusCode?: number; response?: unknown };
+  const status = r.status ?? r.statusCode;
+  if (status !== HttpStatus.OK) return null;
+  return r.response ?? null;
+}
 
 @Injectable()
-export class PathwayService {}
+export class PathwayService {
+  constructor(
+    private readonly _ipsrPathwayStepOne: IpsrPathwayStepOneService,
+    private readonly _innovationPathwayStepTwo: InnovationPathwayStepTwoService,
+    private readonly _innovationPathwayStepThree: InnovationPathwayStepThreeService,
+    private readonly _ipsrPathwayStepFour: IpsrPathwayStepFourService,
+  ) {}
+
+  /**
+   * IPSR pathway steps 1–4 for bilateral list enrichment (innovation package / IPSR results).
+   * Each step matches the corresponding pathway service response body on success; otherwise null.
+   */
+  async getPathwayMetadataForBilateral(
+    resultId: number,
+  ): Promise<IpsrPathwayBilateralSummary> {
+    const [one, two, three, four] = await Promise.all([
+      this._ipsrPathwayStepOne.getStepOne(resultId),
+      this._innovationPathwayStepTwo.getStepTwoOne(resultId),
+      this._innovationPathwayStepThree.getStepThree(resultId),
+      this._ipsrPathwayStepFour.getStepFour(resultId),
+    ]);
+    return {
+      step_one: unwrapIpsrStepResponse(one),
+      step_two: unwrapIpsrStepResponse(two),
+      step_three: unwrapIpsrStepResponse(three),
+      step_four: unwrapIpsrStepResponse(four),
+    };
+  }
+}

--- a/onecgiar-pr-server/src/api/ipsr/innovation-pathway/innovation-pathway-services.module.ts
+++ b/onecgiar-pr-server/src/api/ipsr/innovation-pathway/innovation-pathway-services.module.ts
@@ -1,0 +1,140 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { InnovationPathwayStepOneService } from './innovation-pathway-step-one.service';
+import { ResultRepository } from '../../../api/results/result.repository';
+import {
+  HandlersError,
+  ReturnResponse,
+} from '../../../shared/handlers/error.utils';
+import { ResultRegionRepository } from '../../../api/results/result-regions/result-regions.repository';
+import { ResultCountryRepository } from '../../../api/results/result-countries/result-countries.repository';
+import { ExpertisesRepository } from '../innovation-packaging-experts/repositories/expertises.repository';
+import { InnovationPackagingExpertRepository } from '../innovation-packaging-experts/repositories/innovation-packaging-expert.repository';
+import { ResultInnovationPackageRepository } from '../result-innovation-package/repositories/result-innovation-package.repository';
+import { VersionsService } from '../../results/versions/versions.service';
+import { VersionRepository } from 'src/api/versioning/versioning.repository';
+import { IpsrRepository } from '../ipsr.repository';
+import { ResultByIntitutionsRepository } from '../../results/results_by_institutions/result_by_intitutions.repository';
+import { ResultByInstitutionsByDeliveriesTypeRepository } from '../../results/result-by-institutions-by-deliveries-type/result-by-institutions-by-deliveries-type.repository';
+import { ResultIpSdgTargetRepository } from './repository/result-ip-sdg-targets.repository';
+import { ResultIpEoiOutcomeRepository } from './repository/result-ip-eoi-outcomes.repository';
+import { ResultIpAAOutcomeRepository } from './repository/result-ip-action-area-outcome.repository';
+import { ResultActorRepository } from '../../results/result-actors/repositories/result-actors.repository';
+import { ResultByIntitutionsTypeRepository } from '../../results/results_by_institution_types/result_by_intitutions_type.repository';
+import { ResultIpMeasureRepository } from '../result-ip-measures/result-ip-measures.repository';
+import { ResultIpImpactAreaRepository } from './repository/result-ip-impact-area-targets.repository';
+import { ClarisaInstitutionsTypeRepository } from '../../../clarisa/clarisa-institutions-type/ClariasaInstitutionsType.repository';
+import { InnovationPathwayStepTwoService } from './innovation-pathway-step-two.service';
+import { ResultsComplementaryInnovationRepository } from '../results-complementary-innovations/repositories/results-complementary-innovation.repository';
+import { ResultsComplementaryInnovationsFunctionRepository } from '../results-complementary-innovations-functions/repositories/results-complementary-innovations-function.repository';
+import { EvidencesRepository } from '../../../api/results/evidences/evidences.repository';
+import { InnovationPathwayStepThreeService } from './innovation-pathway-step-three.service';
+import { ResultsByIpInnovationUseMeasureRepository } from '../results-by-ip-innovation-use-measures/results-by-ip-innovation-use-measure.repository';
+import { ResultsIpActorRepository } from '../results-ip-actors/results-ip-actor.repository';
+import { ResultsIpInstitutionTypeRepository } from '../results-ip-institution-type/results-ip-institution-type.repository';
+import { YearRepository } from '../../../api/results/years/year.repository';
+import { ResultByInitiativesRepository } from '../../../api/results/results_by_inititiatives/resultByInitiatives.repository';
+import { ComplementaryInnovationFunctionsRepository } from '../results-complementary-innovations-functions/repositories/complementary-innovation-functions.repository';
+import { ClarisaInstitutionsRepository } from '../../../clarisa/clarisa-institutions/ClariasaInstitutions.repository';
+import { InnovationPathwayStepFourService } from './innovation-pathway-step-four.service';
+import { ResultInitiativeBudgetRepository } from '../../../api/results/result_budget/repositories/result_initiative_budget.repository';
+import { NonPooledProjectRepository } from '../../../api/results/non-pooled-projects/non-pooled-projects.repository';
+import { NonPooledProjectBudgetRepository } from '../../results/result_budget/repositories/non_pooled_proyect_budget.repository';
+import { ResultInstitutionsBudgetRepository } from '../../results/result_budget/repositories/result_institutions_budget.repository';
+import { ResultIpExpertisesRepository } from '../innovation-packaging-experts/repositories/result-ip-expertises.repository';
+import { ResultIpExpertWorkshopOrganizedRepostory } from './repository/result-ip-expert-workshop-organized.repository';
+import { VersioningModule } from '../../versioning/versioning.module';
+import { ResultCountrySubnationalRepository } from '../../results/result-countries-sub-national/repositories/result-country-subnational.repository';
+import { ResultInnovationPackageService } from '../result-innovation-package/result-innovation-package.service';
+import { ClarisaActionAreaOutcomeRepository } from '../../../clarisa/clarisa-action-area-outcome/clarisa-action-area-outcome.repository';
+import { ActiveBackstoppingRepository } from '../result-innovation-package/repositories/active-backstopping.repository';
+import { consensusInitiativeWorkPackageRepository } from '../result-innovation-package/repositories/consensus-initiative-work-package.repository';
+import { RegionalIntegratedRepository } from '../result-innovation-package/repositories/regional-integrated.repository';
+import { RegionalLeadershipRepository } from '../result-innovation-package/repositories/regional-leadership.repository';
+import { RelevantCountryRepository } from '../result-innovation-package/repositories/relevant-country.repository';
+import { ResultByEvidencesRepository } from '../../results/results_by_evidences/result_by_evidences.repository';
+import { resultValidationRepository } from '../../results/results-validation-module/results-validation-module.repository';
+import { UnitTimeRepository } from '../result-innovation-package/repositories/unit_time.repository';
+import { TocResultsRepository } from '../../../toc/toc-results/toc-results.repository';
+import { IpsrService } from '../ipsr.service';
+import { ResultsInvestmentDiscontinuedOptionRepository } from '../../results/results-investment-discontinued-options/results-investment-discontinued-options.repository';
+import { AdUsersModule } from '../../ad_users';
+import { InitiativeEntityMapRepository } from '../../initiative_entity_map/initiative_entity_map.repository';
+import { ResultDeletionAuditModule } from '../../results/result-deletion-audit/result-deletion-audit.module';
+
+/**
+ * Innovation pathway step services and dependencies without HTTP routes, so consumers
+ * (e.g. IPSR Framework Pathway, bilateral enrichment) can inject step logic without
+ * registering `InnovationPathwayController` twice.
+ */
+@Module({
+  imports: [
+    forwardRef(() => VersioningModule),
+    AdUsersModule,
+    ResultDeletionAuditModule,
+  ],
+  providers: [
+    InnovationPathwayStepOneService,
+    InnovationPathwayStepTwoService,
+    HandlersError,
+    ReturnResponse,
+    ResultRepository,
+    ResultRegionRepository,
+    ResultCountryRepository,
+    ExpertisesRepository,
+    InnovationPackagingExpertRepository,
+    ResultInnovationPackageRepository,
+    VersionsService,
+    VersionRepository,
+    IpsrRepository,
+    ResultByIntitutionsRepository,
+    ResultByInstitutionsByDeliveriesTypeRepository,
+    ResultIpSdgTargetRepository,
+    ResultIpEoiOutcomeRepository,
+    ResultIpAAOutcomeRepository,
+    ResultActorRepository,
+    ResultByIntitutionsTypeRepository,
+    ResultIpMeasureRepository,
+    ResultIpImpactAreaRepository,
+    ClarisaInstitutionsTypeRepository,
+    ResultsComplementaryInnovationRepository,
+    ResultsComplementaryInnovationsFunctionRepository,
+    EvidencesRepository,
+    InnovationPathwayStepThreeService,
+    ResultsByIpInnovationUseMeasureRepository,
+    ResultsIpActorRepository,
+    ResultsIpInstitutionTypeRepository,
+    YearRepository,
+    ResultByInitiativesRepository,
+    ComplementaryInnovationFunctionsRepository,
+    ClarisaInstitutionsRepository,
+    InnovationPathwayStepFourService,
+    ResultInitiativeBudgetRepository,
+    NonPooledProjectRepository,
+    NonPooledProjectBudgetRepository,
+    ResultInstitutionsBudgetRepository,
+    ResultIpExpertisesRepository,
+    ResultCountrySubnationalRepository,
+    ResultInnovationPackageService,
+    ClarisaActionAreaOutcomeRepository,
+    ActiveBackstoppingRepository,
+    ResultIpExpertWorkshopOrganizedRepostory,
+    consensusInitiativeWorkPackageRepository,
+    RegionalIntegratedRepository,
+    RegionalLeadershipRepository,
+    RelevantCountryRepository,
+    ResultByEvidencesRepository,
+    resultValidationRepository,
+    UnitTimeRepository,
+    TocResultsRepository,
+    IpsrService,
+    ResultsInvestmentDiscontinuedOptionRepository,
+    InitiativeEntityMapRepository,
+  ],
+  exports: [
+    InnovationPathwayStepOneService,
+    InnovationPathwayStepTwoService,
+    InnovationPathwayStepThreeService,
+    InnovationPathwayStepFourService,
+  ],
+})
+export class InnovationPathwayServicesModule {}

--- a/onecgiar-pr-server/src/api/ipsr/innovation-pathway/innovation-pathway.module.ts
+++ b/onecgiar-pr-server/src/api/ipsr/innovation-pathway/innovation-pathway.module.ts
@@ -1,66 +1,9 @@
 import { Module, forwardRef } from '@nestjs/common';
-import { InnovationPathwayStepOneService } from './innovation-pathway-step-one.service';
 import { InnovationPathwayController } from './innovation-pathway.controller';
-import { ResultRepository } from '../../../api/results/result.repository';
-import {
-  HandlersError,
-  ReturnResponse,
-} from '../../../shared/handlers/error.utils';
-import { ResultRegionRepository } from '../../../api/results/result-regions/result-regions.repository';
-import { ResultCountryRepository } from '../../../api/results/result-countries/result-countries.repository';
-import { ExpertisesRepository } from '../innovation-packaging-experts/repositories/expertises.repository';
-import { InnovationPackagingExpertRepository } from '../innovation-packaging-experts/repositories/innovation-packaging-expert.repository';
-import { ResultInnovationPackageRepository } from '../result-innovation-package/repositories/result-innovation-package.repository';
-import { VersionsService } from '../../results/versions/versions.service';
-import { VersionRepository } from 'src/api/versioning/versioning.repository';
-import { IpsrRepository } from '../ipsr.repository';
-import { ResultByIntitutionsRepository } from '../../results/results_by_institutions/result_by_intitutions.repository';
-import { ResultByInstitutionsByDeliveriesTypeRepository } from '../../results/result-by-institutions-by-deliveries-type/result-by-institutions-by-deliveries-type.repository';
-import { ResultIpSdgTargetRepository } from './repository/result-ip-sdg-targets.repository';
-import { ResultIpEoiOutcomeRepository } from './repository/result-ip-eoi-outcomes.repository';
-import { ResultIpAAOutcomeRepository } from './repository/result-ip-action-area-outcome.repository';
-import { ResultActorRepository } from '../../results/result-actors/repositories/result-actors.repository';
-import { ResultByIntitutionsTypeRepository } from '../../results/results_by_institution_types/result_by_intitutions_type.repository';
-import { ResultIpMeasureRepository } from '../result-ip-measures/result-ip-measures.repository';
-import { ResultIpImpactAreaRepository } from './repository/result-ip-impact-area-targets.repository';
-import { ClarisaInstitutionsTypeRepository } from '../../../clarisa/clarisa-institutions-type/ClariasaInstitutionsType.repository';
-import { InnovationPathwayStepTwoService } from './innovation-pathway-step-two.service';
-import { ResultsComplementaryInnovationRepository } from '../results-complementary-innovations/repositories/results-complementary-innovation.repository';
-import { ResultsComplementaryInnovationsFunctionRepository } from '../results-complementary-innovations-functions/repositories/results-complementary-innovations-function.repository';
-import { EvidencesRepository } from '../../../api/results/evidences/evidences.repository';
-import { InnovationPathwayStepThreeService } from './innovation-pathway-step-three.service';
-import { ResultsByIpInnovationUseMeasureRepository } from '../results-by-ip-innovation-use-measures/results-by-ip-innovation-use-measure.repository';
-import { ResultsIpActorRepository } from '../results-ip-actors/results-ip-actor.repository';
-import { ResultsIpInstitutionTypeRepository } from '../results-ip-institution-type/results-ip-institution-type.repository';
-import { YearRepository } from '../../../api/results/years/year.repository';
-import { ResultByInitiativesRepository } from '../../../api/results/results_by_inititiatives/resultByInitiatives.repository';
-import { ComplementaryInnovationFunctionsRepository } from '../results-complementary-innovations-functions/repositories/complementary-innovation-functions.repository';
-import { ClarisaInstitutionsRepository } from '../../../clarisa/clarisa-institutions/ClariasaInstitutions.repository';
-import { InnovationPathwayStepFourService } from './innovation-pathway-step-four.service';
-import { ResultInitiativeBudgetRepository } from '../../../api/results/result_budget/repositories/result_initiative_budget.repository';
-import { NonPooledProjectRepository } from '../../../api/results/non-pooled-projects/non-pooled-projects.repository';
-import { NonPooledProjectBudgetRepository } from '../../results/result_budget/repositories/non_pooled_proyect_budget.repository';
-import { ResultInstitutionsBudgetRepository } from '../../results/result_budget/repositories/result_institutions_budget.repository';
-import { ResultIpExpertisesRepository } from '../innovation-packaging-experts/repositories/result-ip-expertises.repository';
-import { ResultIpExpertWorkshopOrganizedRepostory } from './repository/result-ip-expert-workshop-organized.repository';
 import { VersioningModule } from '../../versioning/versioning.module';
-import { ResultCountrySubnationalRepository } from '../../results/result-countries-sub-national/repositories/result-country-subnational.repository';
-import { ResultInnovationPackageService } from '../result-innovation-package/result-innovation-package.service';
-import { ClarisaActionAreaOutcomeRepository } from '../../../clarisa/clarisa-action-area-outcome/clarisa-action-area-outcome.repository';
-import { ActiveBackstoppingRepository } from '../result-innovation-package/repositories/active-backstopping.repository';
-import { consensusInitiativeWorkPackageRepository } from '../result-innovation-package/repositories/consensus-initiative-work-package.repository';
-import { RegionalIntegratedRepository } from '../result-innovation-package/repositories/regional-integrated.repository';
-import { RegionalLeadershipRepository } from '../result-innovation-package/repositories/regional-leadership.repository';
-import { RelevantCountryRepository } from '../result-innovation-package/repositories/relevant-country.repository';
-import { ResultByEvidencesRepository } from '../../results/results_by_evidences/result_by_evidences.repository';
-import { resultValidationRepository } from '../../results/results-validation-module/results-validation-module.repository';
-import { UnitTimeRepository } from '../result-innovation-package/repositories/unit_time.repository';
-import { TocResultsRepository } from '../../../toc/toc-results/toc-results.repository';
-import { IpsrService } from '../ipsr.service';
-import { ResultsInvestmentDiscontinuedOptionRepository } from '../../results/results-investment-discontinued-options/results-investment-discontinued-options.repository';
 import { AdUsersModule } from '../../ad_users';
-import { InitiativeEntityMapRepository } from '../../initiative_entity_map/initiative_entity_map.repository';
 import { ResultDeletionAuditModule } from '../../results/result-deletion-audit/result-deletion-audit.module';
+import { InnovationPathwayServicesModule } from './innovation-pathway-services.module';
 
 @Module({
   controllers: [InnovationPathwayController],
@@ -68,64 +11,7 @@ import { ResultDeletionAuditModule } from '../../results/result-deletion-audit/r
     forwardRef(() => VersioningModule),
     AdUsersModule,
     ResultDeletionAuditModule,
-  ],
-  providers: [
-    InnovationPathwayStepOneService,
-    InnovationPathwayStepTwoService,
-    HandlersError,
-    ReturnResponse,
-    ResultRepository,
-    ResultRegionRepository,
-    ResultCountryRepository,
-    ExpertisesRepository,
-    InnovationPackagingExpertRepository,
-    ResultInnovationPackageRepository,
-    VersionsService,
-    VersionRepository,
-    IpsrRepository,
-    ResultByIntitutionsRepository,
-    ResultByInstitutionsByDeliveriesTypeRepository,
-    ResultIpSdgTargetRepository,
-    ResultIpEoiOutcomeRepository,
-    ResultIpAAOutcomeRepository,
-    ResultActorRepository,
-    ResultByIntitutionsTypeRepository,
-    ResultIpMeasureRepository,
-    ResultIpImpactAreaRepository,
-    ClarisaInstitutionsTypeRepository,
-    ResultsComplementaryInnovationRepository,
-    ResultsComplementaryInnovationsFunctionRepository,
-    EvidencesRepository,
-    InnovationPathwayStepThreeService,
-    ResultsByIpInnovationUseMeasureRepository,
-    ResultsIpActorRepository,
-    ResultsIpInstitutionTypeRepository,
-    YearRepository,
-    ResultByInitiativesRepository,
-    ComplementaryInnovationFunctionsRepository,
-    ClarisaInstitutionsRepository,
-    InnovationPathwayStepFourService,
-    ResultInitiativeBudgetRepository,
-    NonPooledProjectRepository,
-    NonPooledProjectBudgetRepository,
-    ResultInstitutionsBudgetRepository,
-    ResultIpExpertisesRepository,
-    ResultCountrySubnationalRepository,
-    ResultInnovationPackageService,
-    ClarisaActionAreaOutcomeRepository,
-    ActiveBackstoppingRepository,
-    ResultIpExpertWorkshopOrganizedRepostory,
-    consensusInitiativeWorkPackageRepository,
-    RegionalIntegratedRepository,
-    RegionalLeadershipRepository,
-    RelevantCountryRepository,
-    ResultByEvidencesRepository,
-    resultValidationRepository,
-    UnitTimeRepository,
-    TocResultsRepository,
-    IpsrService,
-    ResultsInvestmentDiscontinuedOptionRepository,
-    InitiativeEntityMapRepository,
+    InnovationPathwayServicesModule,
   ],
 })
 export class InnovationPathwayModule {}


### PR DESCRIPTION
## Summary

This release merges **staging** into **master** and delivers bilateral list enrichment for **Innovation Package (IPSR)** results, plus a **single contract** for initiative / bilateral / partner budget lines shared with Innovation Development and Innovation Use summaries.

## What was implemented

### IPSR pathway on bilateral results

- **`ipsr_pathway_summary`** on enriched bilateral list payloads for `innovation_package` (result type 10): `step_one` through `step_four` built from pathway services, then **mapped for bilateral consumers** (trimmed geo/partners where agreed, renamed blocks, Clarisa-oriented objects).
- **`PathwayService.getPathwayMetadataForBilateral`**: aggregates step 1–4 metadata for post-processing in `BilateralService`.
- **Module wiring**: `PathwayModule` exports pathway services; `InnovationPathwayServicesModule` consolidates IPSR pathway providers; `BilateralModule` imports `PathwayModule`.

### Step-level bilateral shaping (high level)

- **Step 1**: Core result + year, EOI / scaling / target innovation use alignment, slim expert workshop contacts (no full geo dump).
- **Step 2**: Complementary innovations with bilateral-specific field omissions and display fields (`official_code`, `result_type_name`).
- **Step 3**: Expert workshop catalog + assessment mode + conditional workshop levels; evidence-based readiness/use; `target_innovation_use`; package flags where appropriate.
- **Step 4**: Materials list slimmed (constant omit-keys); scaling flags and URLs; **budget arrays** mapped through shared slim helpers (see below).

### Unified budget rows (Inno Dev, Inno Use, IPSR step 4)

- Shared helpers in `bilateral.service.ts`: `slimBilateralInitiativeBudgetRow`, `slimBilateralProjectBudgetRow`, `slimBilateralPartnerBudgetRow`, `mapBilateralBudgetArray`, `bilateralBudgetAmountOrNull`.
- **`buildInnovationSharedBudgetAndEvidenceExtras`** now emits `initiative_budget`, `bilateral_project_budget`, and `partner_budget` using those mappers only; partner load includes institution type for `institution_type_name`.
- **IPSR bilateral step 4** uses the **same property names** as the other types (`initiative_budget`, `bilateral_project_budget`, `partner_budget`) instead of raw pathway keys (`initiative_expected_investment`, etc.) on the **bilateral** response only; pathway / PRMS `getStepFour` unchanged.
- Each row exposes **amounts**, `is_determined`, and nested **Clarisa** `initiative` / `project` / `institution` objects (plus `institutions_id` on partner lines). Internal PRMS join PKs and audit noise are dropped from these summaries.

### Other

- **`ipsr-pathway-step-four.service.ts`**: minor cleanup (e.g. stray logging removed).
- **Docs**: `onecgiar-pr-server/docs/bilateral-result-summaries.en.md` updated for IPSR steps and budget contract; changelog entry.
- **Tests**: pathway and bilateral specs updated; `tsc` / targeted Jest verified on the branch.

## Commits (staging not in master)

- `feat(bilateral.service, pathway.service): Integrate IPSR pathway steps into bilateral summaries`
- `refactor(bilateral.service): Improve code formatting and readability`

## Notes for reviewers / integrators

- **Breaking (bilateral API only)** for consumers that relied on flat budget fields (`initiative_official_code`, `project_short_name`, `institution_name`, …) or on IPSR bilateral `initiative_expected_investment` / `bilateral_expected_investment` / `institutions_expected_investment`: migrate to the nested objects and the three unified array names above.
- PRMS UI continues to use pathway DTO field names; only **bilateral enrichment** changes for IPSR budgets.

---

_Release PR: `staging` → `master`._
