### PR TITLE
* Feat Add Jira and ToC skill documentation

### DIFF
--- a/.cursor/skills/jira-standard-documentation/SKILL.md
+++ b/.cursor/skills/jira-standard-documentation/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: jira-standard-documentation
+description: >-
+  Standardizes creating and validating Jira issues as full engineering specs for
+  development teams via Atlassian MCP: schema discovery, strict section order
+  (summary, context, technical requirements, AC, DoD, QA), duplicate search,
+  ADF or Markdown body, preview then create. Use when drafting or rewriting
+  Jira tickets, technical issues, user stories, or MCP-driven Jira workflows.
+---
+
+# Jira Engineering Standard Documentation
+
+## Purpose
+
+Standardize how Jira issues are **created** and **validated** so each ticket reads as a **complete technical specification**, not only an administrative task. Optimized for the **Model Context Protocol (MCP)** against the Atlassian Jira MCP server.
+
+## MCP context
+
+- **Target:** Atlassian Jira MCP server (read tool descriptors for exact tool names).
+- **Output:** Issue body in **ADF** (Atlassian Document Format) or enriched **Markdown**, depending on what the connected Jira API / tool accepts.
+- **Workflow:** **Discovery (schema)** → **Draft (structure)** → **Search (duplicates)** → **Preview** → **Create** (or update).
+
+## Mandatory structure (strict order)
+
+All body content (description / primary rich-text field) must follow **exactly** this order and headings. Do not merge or reorder sections.
+
+### 1. Summary (Jira `summary` field)
+
+Format: `[TYPE] Concise name`.
+
+Suggested types: `[FEAT]`, `[FIX]`, `[REFACTOR]`, `[CHORE]`, `[INFRA]`, `[PERF]`, `[DOCS]`.
+
+### 2. Context
+
+Technical description of the problem or requirement. It must answer: **Why does this ticket exist?** and **What value** does it deliver for the **system**, an **integration flow**, or the **end user**?
+
+### 3. Technical Requirements
+
+Engineering detail, grouped as bullets:
+
+- **Architecture:** Services, modules, backend logic, or system integrations (e.g. internal platforms, API layers, message buses—use what fits the codebase).
+- **Database / data model:** SQL or ORM changes, migrations, indexing, schema impact, or data consistency rules.
+- **Implementation points:** Concrete endpoints, triggers, functions, jobs, config files, or feature flags affected.
+
+**Optimization rule:** If the ticket concerns **performance** or **resource management** (CPU, memory, I/O, quotas, batch sizes, caching, etc.), you **must** add a **Performance / cost impact** subsection (hypothesis, what improves, and how it will be measured or estimated).
+
+### 4. Acceptance criteria (AC)
+
+Binary, **verifiable** checklist (pass / fail). Each item must be **technically measurable** (e.g. status codes under stated conditions, migration safety, observable behavior).
+
+Use the format the API supports (e.g. Markdown ` - [ ] ` in preview; ADF lists per tool support).
+
+### 5. Definition of done (DoD)
+
+Minimum quality before closing:
+
+- **Unit tests:** Required coverage or a **short technical justification** if truly not applicable.
+- **Documentation:** Which **technical** artifact must change (wiki page, README section, OpenAPI/Swagger, ADR, etc.).
+- **FinOps / efficiency:** Resource or cost validation, or **N/A** with a **brief technical rationale**.
+
+### 6. QA / testing plan
+
+Numbered steps for integration or QA (environment, sample payloads or scripts, expected logs, DB or UI checks). Written so QA leads or integrators can execute without guessing.
+
+## Validation rules (“Guardian”)
+
+Before any MCP **write** (create/update issue):
+
+| Rule | Required action |
+| :--- | :--- |
+| **Issue type mapping** | Via MCP, confirm the `issueType` is valid for the **target Jira project** (key or ID the user gives). If unknown, resolve project + allowed types before creating. |
+| **Mandatory AC** | Block creation if there is not at least **one actionable, technical** acceptance criterion. |
+| **Duplicate search** | Run a **JQL** (or MCP search) on keywords from the summary/domain and **surface** likely duplicate or overlapping backlog items in the preview. |
+| **ADF / Markdown** | Detect from the tool / API whether the body must be **ADF** or **Markdown** (or wiki) and transform the draft accordingly. |
+| **Preview and confirm** | Always show a clear **preview** (Summary + full structured description). Do not run the final create until the user confirms, unless they explicitly asked to skip confirmation. |
+
+## Workflow (MCP)
+
+1. **Discovery:** Fetch project/issue metadata and **required fields** from the MCP (schema, create meta, or equivalent).
+2. **Draft:** Fill the **Mandatory structure** from the user’s input (vague input is OK—infer and label assumptions).
+3. **Search:** Optional but recommended—query for duplicates or related issues.
+4. **Preview:** Present formatted preview to the user.
+5. **Create:** After confirmation, call create/update with validated parameters and correct body encoding.
+
+## Preview template
+
+```markdown
+**Summary:** [TYPE] Technical task name
+
+**Description:**
+
+## Context
+...
+
+## Technical Requirements
+- Architecture: ...
+- Database / data model: ...
+- Implementation points: ...
+- **Performance / cost impact:** ... *(required when optimization rule applies)*
+
+## Acceptance Criteria (AC)
+- [ ] ...
+- [ ] ...
+
+## Definition of Done (DoD)
+- Unit tests: ...
+- Technical documentation: ...
+- FinOps / efficiency: ...
+
+## QA / Testing Plan
+1. ...
+2. ...
+```
+
+## Short best practices
+
+- **Summary:** Respect Jira length limits (~80 characters is a safe default); single line.
+- **AC:** One measurable outcome per bullet; avoid generic wording (“works well”) without a test.
+- **DoD:** Link or name the exact doc path or API spec section when possible.
+- On MCP permission or custom-field errors, report clearly and ask for missing fields or admin help.
+
+## Additional resources
+
+For ADF JSON patterns, see [reference.md](reference.md) only when the create tool requires hand-built ADF.

--- a/.cursor/skills/jira-standard-documentation/reference.md
+++ b/.cursor/skills/jira-standard-documentation/reference.md
@@ -1,0 +1,26 @@
+# ADF — minimal reference
+
+Use only when the Jira tool **requires** Atlassian Document Format (JSON) and does not accept Markdown.
+
+## Root document
+
+```json
+{
+  "version": 1,
+  "type": "doc",
+  "content": []
+}
+```
+
+## Useful patterns
+
+- **Paragraph:** `type: "paragraph"`, `content: [{ "type": "text", "text": "..." }]`.
+- **Heading:** `type: "heading"`, `attrs: { "level": 2 }`, `content: [ ... ]`.
+- **Bullet list:** `type: "bulletList"`, `content: [ { "type": "listItem", "content": [ { "type": "paragraph", ... } ] } ]`.
+- **Task / checkbox list:** depends on Jira version; if the MCP does not support `taskList`, use a **bulletList** with a plain-text `[ ]` prefix inside the paragraph.
+
+## Links
+
+`type: "text"`, `marks: [{ "type": "link", "attrs": { "href": "https://..." } }]`.
+
+Priority: **follow the tool descriptor example** or the official API docs used by the MCP, because the supported ADF subset can vary.

--- a/.cursor/skills/toc/SKILL.md
+++ b/.cursor/skills/toc/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: toc
+description: >-
+  Guides Theory of Change (ToC) work in onecgiar_pr—prdb link tables, external
+  Integration_information / env.DB_TOC schema, per-result and per-initiative ToC
+  mapping, indicators, planned vs actual, work packages, and P22/P25 reporting
+  SQL. Use when implementing or changing ToC mapping, indicators, IPSR pathway
+  ToC references, or reports that join results to toc_results.
+---
+
+# Theory of Change (ToC) — Agent Guide
+
+Use this skill when implementing or changing **ToC** logic: result–ToC node mapping, indicators, planned vs actual, work packages, or reports that consume ToC (for example P22 / P25 patterns in `result.repository.ts`).
+
+## Two data sources for ToC
+
+1. **Project database (prdb):** tables that link **results** to ToC nodes and selected indicators (`results_toc_result`, `results_toc_result_indicators`, related target tables).
+2. **External schema:** `Integration_information` and/or `${env.DB_TOC}` (naming varies by query). ToC tree nodes and metadata live there: `toc_results`, work-package tables, `toc_results_indicators`, etc. These are **not** assumed to be TypeORM entities in this repo; code often uses **raw SQL** or repositories that interpolate the schema name.
+
+Always align table and column names with **existing queries and repositories**, not assumptions.
+
+## Prdb tables — Result ↔ ToC
+
+| Table | Role | Main FKs |
+|-------|------|-----------|
+| `results_toc_result` | One row = one **result** mapped to one **ToC node** for one **initiative**. | `results_id` → result, `toc_result_id` → external `toc_results.id`, `initiative_id` → initiative |
+| `results_toc_result_indicators` | ToC indicators selected for that result–ToC row. | `results_toc_results_id` → `results_toc_result.result_toc_result_id`, `toc_results_indicator_id` → external indicator id |
+| `result_indicators_targets` | Targets / values per indicator (`number_target`, `contributing_indicator`, etc.). | Links via result–ToC indicator row (see entity / repo) |
+| `result_toc_impact_area_target` | Impact area (Clarisa) linkage. | `result_toc_result_id` |
+| `result_toc_sdg_targets` | SDG target linkage (`clarisa_sdgs_targets`). | `result_toc_result_id` |
+| `result_toc_action_area` | Action area outcome linkage. | `result_toc_result_id` |
+
+**PK** of `results_toc_result`: `result_toc_result_id`. Useful columns include `toc_result_id`, `results_id`, `initiative_id`, `planned_result`, `toc_progressive_narrative`, `toc_level_id`, `action_area_id`, `is_active`.
+
+## Initiative relationship
+
+- Each `results_toc_result` row is: result **R** mapped to ToC node **N** for initiative **I**.
+- For lead vs contributing initiative roles, join initiative linkage tables used in reporting (often `results_by_inititiative` — **note the schema spelling** — with `initiative_role_id` such as 1 = lead, 2 = contributing) and `clarisa_initiatives` / equivalents as in existing SQL.
+- **P22-style** reporting often groups by initiative (primary / secondary), surfacing work package, title, description, indicators, impact area, SDG, action area, narrative.
+
+## External schema (`Integration_information` / `DB_TOC`)
+
+Referenced in SQL as `Integration_information.toc_results`, `Integration_information.work_packages`, `${env.DB_TOC}.toc_results`, `${env.DB_TOC}.toc_work_packages`, etc., depending on report or environment.
+
+- **`toc_results`:** ToC tree nodes; ids match `results_toc_result.toc_result_id`. Typical fields include titles, descriptions, and work-package foreign keys (exact column names vary—follow live queries).
+- **Work packages:** joined from `toc_results` (patterns include `work_packages`, `toc_work_packages`, and `wp_id` vs `work_packages_id` depending on query—**verify the specific JOIN** in the file you are editing).
+- **`toc_results_indicators`:** indicators for a node; joined by `toc_results_id` (and sometimes `related_node_id` / indicator id columns). Prdb `results_toc_result_indicators.toc_results_indicator_id` points into this layer.
+- Other satellite tables may appear: country/region/target breakdowns for indicators—only add joins when an existing report or requirement uses them.
+
+Do **not** assume TypeORM entities exist for external-schema tables unless you find them.
+
+## Indicators: planned vs actual
+
+- **Planned:** `results_toc_result.planned_result` (boolean); reports often label this as “Is planned: Yes/No”.
+- **Indicators in use:** via `results_toc_result_indicators` plus external `toc_results_indicators` for labels and metadata.
+- **Actual / achieved:** `result_indicators_targets.contributing_indicator` (and related narrative fields where present).
+
+For “indicator_used” and “actual_achieved” style outputs, chain `results_toc_result` → `results_toc_result_indicators` → external `toc_results_indicators` and `result_indicators_targets` as in existing report SQL.
+
+## Innovation packages (pathway)
+
+- Innovation packages (**IP**, `result_type_id = 10`) can store a **pathway** (EOI, action area, impact, SDG) at **result-by-innovation-package** level (`result_ip_eoi_outcomes`, `result_ip_action_area_outcome`, etc.), referencing `Integration_information.toc_results` via `toc_result_id`. That is **IP pathway**, distinct from the classic **per-initiative** `results_toc_result` mapping.
+- **Result-level “toc mapping”** for a result (IP or not) still flows through `results_toc_result` + external `toc_results` + work packages **by initiative** where applicable.
+
+## Reports and SQL
+
+- **P25 / P22 patterns:** large ToC joins and CTE-style logic for reporting live primarily in `onecgiar-pr-server/src/api/results/result.repository.ts` (search for `Integration_information`, `DB_TOC`, `toc_results`, P22/P25-related methods).
+- Prefer **filtering** `results_toc_result.is_active = 1` and, when relevant, `results_toc_result_indicators.is_active = 1`, consistent with existing queries.
+
+## Where the code lives
+
+- **TypeORM entities (prdb ToC):** `onecgiar-pr-server/src/api/results/results-toc-results/entities/` — e.g. `results-toc-result.entity.ts`, `results-toc-results-indicators.entity.ts`, `result-toc-result-target-indicators.entity.ts`, `result-toc-impact-area-target.entity.ts`, `result-toc-sdg-target.entity.ts`, `result-toc-action-area.entity.ts`.
+- **Repositories / raw queries:** `onecgiar-pr-server/src/api/results/results-toc-results/repositories/`, plus `onecgiar-pr-server/src/api/results/result.repository.ts` for cross-cutting report SQL.
+- **IP pathway (ToC ids on pathway tables):** `onecgiar-pr-server/src/api/ipsr/innovation-pathway/` (entities under `entities/`, data access under `repository/`).
+
+## Additional reference
+
+For deeper table-by-table notes or examples copied from internal docs, extend [reference.md](reference.md) in this folder and link new sections from here (keep links **one level deep** from `SKILL.md`).

--- a/.cursor/skills/toc/reference.md
+++ b/.cursor/skills/toc/reference.md
@@ -1,0 +1,8 @@
+# ToC — extended notes
+
+Add long-form SQL excerpts, ER sketches, or initiative-role conventions here as the team documents them.
+
+**Practical starting points in the repo:**
+
+- `rg "Integration_information\\.toc_results" onecgiar-pr-server/src`
+- `rg "DB_TOC" onecgiar-pr-server/src/api/results`


### PR DESCRIPTION
Introduce two new skill folders under .cursor/skills: jira-standard-documentation and toc, each with a SKILL.md and a reference.md. jira-standard-documentation defines an MCP-driven workflow, a strict Jira issue structure (summary, context, technical requirements, AC, DoD, QA), preview/duplicate checks, and an ADF reference template. toc documents Theory of Change data sources, prdb/external schema mappings, key tables and reporting patterns (P22/P25), and pointers to repo locations and SQL starting points.