### PR TITLE
* Feat Use apiKey instead of credentials for reports Microservice

### DIFF
--- a/onecgiar-pr-server/src/api/platform-report/platform-report-payloads.spec.ts
+++ b/onecgiar-pr-server/src/api/platform-report/platform-report-payloads.spec.ts
@@ -13,7 +13,7 @@ describe('platform-report-payloads (shape validation)', () => {
         templateName: 'results_p25',
         bucketName: 'my-bucket',
         fileName: 'report.pdf',
-        credentials: '{}',
+        apiKey: 'test-api-key',
       };
       expect(payload.data).toBeDefined();
       expect(payload.paperWidth).toBe('600px');
@@ -21,7 +21,7 @@ describe('platform-report-payloads (shape validation)', () => {
       expect(payload.templateName).toBe('results_p25');
       expect(payload.bucketName).toBe('my-bucket');
       expect(payload.fileName).toBe('report.pdf');
-      expect(payload.credentials).toBeDefined();
+      expect(payload.apiKey).toBeDefined();
     });
 
     it('should require all payload fields', () => {
@@ -32,7 +32,7 @@ describe('platform-report-payloads (shape validation)', () => {
         'templateName',
         'bucketName',
         'fileName',
-        'credentials',
+        'apiKey',
       ];
       const payload: PdfGenerateUrlPayload = {
         data: {},
@@ -41,7 +41,7 @@ describe('platform-report-payloads (shape validation)', () => {
         templateName: '',
         bucketName: '',
         fileName: '',
-        credentials: '',
+        apiKey: '',
       };
       requiredKeys.forEach((key) => {
         expect(payload).toHaveProperty(key);

--- a/onecgiar-pr-server/src/api/platform-report/platform-report-payloads.ts
+++ b/onecgiar-pr-server/src/api/platform-report/platform-report-payloads.ts
@@ -9,8 +9,8 @@ export interface PdfGenerateUrlPayload {
   templateName: string;
   bucketName: string;
   fileName: string;
-  /** Auth header for the Reports microservice (e.g. JSON string with username/password). */
-  credentials: string;
+  /** API key for the Reports microservice (`MICROSERVICE_API_KEY`). */
+  apiKey: string;
 }
 
 /**

--- a/onecgiar-pr-server/src/api/platform-report/platform-report.service.ts
+++ b/onecgiar-pr-server/src/api/platform-report/platform-report.service.ts
@@ -5,7 +5,7 @@ import {
   HandlersError,
   returnErrorDto,
 } from '../../shared/handlers/error.utils';
-import { env } from 'process';
+import { env } from 'node:process';
 import { ResultRepository } from '../results/result.repository';
 import { Result, SourceEnum } from '../results/entities/result.entity';
 import axios from 'axios';
@@ -27,11 +27,8 @@ import type {
 @Injectable()
 export class PlatformReportService implements OnModuleInit {
   private readonly _logger: Logger = new Logger(PlatformReportService.name);
-  private authHeaderMs2 = JSON.stringify({
-    username: env.MS_REPORTS_USER,
-    password: env.MS_REPORTS_PASSWORD,
-  });
-  private authHeaderMs4 = JSON.stringify({
+  private readonly microserviceApiKey = env.MICROSERVICE_API_KEY;
+  private readonly authHeaderMs4 = JSON.stringify({
     username: env.MS_FILE_MANAGEMENT_USER,
     password: env.MS_FILE_MANAGEMENT_PASSWORD,
   });
@@ -42,7 +39,7 @@ export class PlatformReportService implements OnModuleInit {
     private readonly _resultRepository: ResultRepository,
     @InjectRepository(Version)
     private readonly _versionRepository: Repository<Version>,
-    @Inject('REPORT_SERVICE') private client: ClientProxy,
+    @Inject('REPORT_SERVICE') private readonly client: ClientProxy,
   ) {}
 
   async onModuleInit() {
@@ -294,13 +291,16 @@ export class PlatformReportService implements OnModuleInit {
       const bucketName = env.AWS_BUCKET_NAME;
 
       if (this.isP25Portfolio(portfolioAcronym)) {
-        const p25Payload = this.buildP25Payload(
-          data,
-          resultToCheck.source,
-          fileName,
-          bucketName,
-          resultToCheck?.result_type_id,
-        );
+        const p25Payload: PdfGenerateUrlPayload = {
+          ...this.buildP25Payload(
+            data,
+            resultToCheck.source,
+            fileName,
+            bucketName,
+            resultToCheck?.result_type_id,
+          ),
+          apiKey: this.microserviceApiKey,
+        };
         const response = await firstValueFrom(
           this.client.send<PdfGenerateUrlResponse>(
             PLATFORM_REPORT_CONSTANTS.REPORT_EVENT_PATTERNS.PDF_GENERATE_URL,
@@ -329,7 +329,7 @@ export class PlatformReportService implements OnModuleInit {
         options: Number(report.id) === 1 ? optionsReporting : optionsIPSR,
         fileName,
         bucketName,
-        credentials: this.authHeaderMs2,
+        apiKey: this.microserviceApiKey,
       };
       this.client.emit(
         PLATFORM_REPORT_CONSTANTS.REPORT_EVENT_PATTERNS.PDF_GENERATE,
@@ -425,7 +425,7 @@ export class PlatformReportService implements OnModuleInit {
     fileName: string,
     bucketName: string,
     resultTypeId?: number | null,
-  ): PdfGenerateUrlPayload {
+  ): Omit<PdfGenerateUrlPayload, 'apiKey'> {
     const { RESULT_P25, RESULT_P25_BILATERAL, IPSR_2025 } =
       PLATFORM_REPORT_CONSTANTS;
 
@@ -446,7 +446,6 @@ export class PlatformReportService implements OnModuleInit {
       templateName: platformReportConstants.TEMPLATE_NAME,
       bucketName,
       fileName,
-      credentials: this.authHeaderMs2,
     };
   }
 }


### PR DESCRIPTION
Replace the legacy `credentials` auth field with an `apiKey` for platform report payloads. Add a `microserviceApiKey` from env (MICROSERVICE_API_KEY), include it when sending/building PDF payloads, and update the PdfGenerateUrlPayload type and buildP25Payload return shape (now omits apiKey). Also: update tests to assert `apiKey`, import `env` from `node:process`, remove the old authHeaderMs2 JSON, and mark the injected REPORT_SERVICE client as readonly.