### PR TITLE
* Feat Enhance Innovation Dev InfoComponent and Innovation Dev Service

### DIFF
--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/evidence-item/evidence-item.component.html
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/evidence-item/evidence-item.component.html
@@ -105,11 +105,11 @@
     <div class="checkboxes_container" *ngIf="!isSuppInfo">
       <app-pr-field-header [label]="getEvidenceRelatedTitle()" [required]="false"></app-pr-field-header>
       <div class="checkboxes">
-        <app-pr-checkbox label="Gender" [(ngModel)]="this.evidence.gender_related"> </app-pr-checkbox>
-        <app-pr-checkbox label="Climate change" [(ngModel)]="this.evidence.youth_related"> </app-pr-checkbox>
-        <app-pr-checkbox label="Nutrition" [(ngModel)]="this.evidence.nutrition_related"> </app-pr-checkbox>
-        <app-pr-checkbox label="Environment" [(ngModel)]="this.evidence.environmental_biodiversity_related"> </app-pr-checkbox>
-        <app-pr-checkbox label="Poverty" [(ngModel)]="this.evidence.poverty_related"> </app-pr-checkbox>
+        <app-pr-checkbox label="Gender equality, youth and social inclusion" [(ngModel)]="this.evidence.gender_related"> </app-pr-checkbox>
+        <app-pr-checkbox label="Climate adaptation and mitigation" [(ngModel)]="this.evidence.youth_related"> </app-pr-checkbox>
+        <app-pr-checkbox label="Nutrition, health and food security" [(ngModel)]="this.evidence.nutrition_related"> </app-pr-checkbox>
+        <app-pr-checkbox label="Environmental health and biodiversity" [(ngModel)]="this.evidence.environmental_biodiversity_related"> </app-pr-checkbox>
+        <app-pr-checkbox label="Poverty reduction, livelihoods and jobs" [(ngModel)]="this.evidence.poverty_related"> </app-pr-checkbox>
         <app-pr-checkbox label="Innovation Development" [(ngModel)]="this.evidence.innovation_readiness_related" *ngIf="this.dataControlSE.isInnoDev">
         </app-pr-checkbox>
         <app-pr-checkbox label="Innovation Use" [(ngModel)]="this.evidence.innovation_use_related" *ngIf="this.dataControlSE.isInnoUse">

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.html
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.html
@@ -98,7 +98,7 @@
   <div
     appFeedbackValidation
     labelText="Evidence"
-    [isComplete]="this.evidencesBody.evidences.length > 0 || this.dataControlSE.currentResult?.result_type_id == 5"></div>
+    [isComplete]="this.evidenceSectionComplete"></div>
   <div appFeedbackValidation labelText="Empty, repeated or invalid link" [isComplete]="!this.validateButtonDisabled"></div>
 </div>
 

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.spec.ts
@@ -364,7 +364,7 @@ describe('RdEvidencesComponent', () => {
 
     it('getSelectedImpactTags returns labels of marked fields', () => {
       const tags = component.getSelectedImpactTags({ gender_related: true, youth_related: true });
-      expect(tags).toEqual(['Gender', 'Climate change']);
+      expect(tags).toEqual(['Gender equality, youth and social inclusion', 'Climate adaptation and mitigation']);
     });
 
     it('evidenceDisplayName prefers file name then link', () => {
@@ -560,6 +560,77 @@ describe('RdEvidencesComponent', () => {
       component.evidencesBody.evidences = [];
       const result = component.validateHasInnoReadinessLevelEvidence();
       expect(result).toBe(false);
+    });
+  });
+
+  describe('evidenceSectionComplete (P2-3056 green check)', () => {
+    // No Principal markers, no readiness requirement, no evidence → builds a baseline body.
+    const cleanBody = (evidences: any[] = []) => ({
+      result_id: 1,
+      gender_tag_level: null,
+      climate_change_tag_level: null,
+      nutrition_tag_level: null,
+      environmental_biodiversity_tag_level: null,
+      poverty_tag_level: null,
+      evidences
+    });
+    const setType = (id: number) => (mockApiService.dataControlSE.currentResult = { result_type_id: id });
+
+    it('is NOT complete for a non-exempt result with no evidence', () => {
+      setType(7);
+      component.isOptionalReadinessLevel = true;
+      component.evidencesBody = cleanBody([]);
+      expect(component.evidenceSectionComplete).toBe(false);
+    });
+
+    it('is complete for Capacity Sharing (type 5) with no evidence', () => {
+      setType(5);
+      component.evidencesBody = cleanBody([]);
+      expect(component.evidenceSectionComplete).toBe(true);
+    });
+
+    it('is NOT complete when a Principal marker (level 3) has no tagged evidence', () => {
+      setType(1);
+      const body = cleanBody([{ link: 'x', poverty_related: false }]);
+      body.poverty_tag_level = '3';
+      component.evidencesBody = body;
+      expect(component.evidenceSectionComplete).toBe(false);
+    });
+
+    it('is complete when every Principal marker has tagged evidence (non-Innovation-Development)', () => {
+      setType(1);
+      const body = cleanBody([{ link: 'x', poverty_related: true }]);
+      body.poverty_tag_level = '3';
+      component.evidencesBody = body;
+      expect(component.evidenceSectionComplete).toBe(true);
+    });
+
+    it('is NOT complete for Innovation Development (type 7) with readiness 1-9 and no readiness evidence', () => {
+      setType(7);
+      component.isOptionalReadinessLevel = false;
+      component.evidencesBody = cleanBody([{ link: 'x', innovation_readiness_related: false }]);
+      expect(component.evidenceSectionComplete).toBe(false);
+    });
+
+    it('is complete for Innovation Development with readiness 0 (exempt) and base evidence', () => {
+      setType(7);
+      component.isOptionalReadinessLevel = true;
+      component.evidencesBody = cleanBody([{ link: 'x' }]);
+      expect(component.evidenceSectionComplete).toBe(true);
+    });
+
+    it('is complete for Innovation Development when all rules are satisfied', () => {
+      setType(7);
+      component.isOptionalReadinessLevel = false;
+      component.evidencesBody = cleanBody([{ link: 'x', innovation_readiness_related: true }]);
+      expect(component.evidenceSectionComplete).toBe(true);
+    });
+
+    it('does not apply the readiness rule to non-Innovation-Development results', () => {
+      setType(1);
+      component.isOptionalReadinessLevel = false; // would block if it applied
+      component.evidencesBody = cleanBody([{ link: 'x' }]);
+      expect(component.evidenceSectionComplete).toBe(true);
     });
   });
 });

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.ts
@@ -27,11 +27,11 @@ export class RdEvidencesComponent implements OnInit {
   // Impact-area + typology fields surfaced as tags in the collapsed accordion header.
   // (Note: the "Climate change" checkbox is bound to youth_related, matching the existing form.)
   private readonly tagFields: { field: keyof EvidencesCreateInterface; label: string }[] = [
-    { field: 'gender_related', label: 'Gender' },
-    { field: 'youth_related', label: 'Climate change' },
-    { field: 'nutrition_related', label: 'Nutrition' },
-    { field: 'environmental_biodiversity_related', label: 'Environment' },
-    { field: 'poverty_related', label: 'Poverty' },
+    { field: 'gender_related', label: 'Gender equality, youth and social inclusion' },
+    { field: 'youth_related', label: 'Climate adaptation and mitigation' },
+    { field: 'nutrition_related', label: 'Nutrition, health and food security' },
+    { field: 'environmental_biodiversity_related', label: 'Environmental health and biodiversity' },
+    { field: 'poverty_related', label: 'Poverty reduction, livelihoods and jobs' },
     { field: 'innovation_readiness_related', label: 'Innovation Development' },
     { field: 'innovation_use_related', label: 'Innovation Use' },
     { field: 'policy_change_related', label: 'Policy Change' },
@@ -295,6 +295,19 @@ export class RdEvidencesComponent implements OnInit {
     if (this.isOptionalReadinessLevel) return true;
 
     return this.evidencesBody.evidences.some(evidence => evidence.innovation_readiness_related);
+  }
+
+  // P2-3056: the Evidence green check must stay red until ALL mandatory evidence is present:
+  // (1) at least one piece of evidence (type 5 is exempt),
+  // (2) evidence for every Impact-Area marker set to Principal (validateCheckBoxes() returns '' when covered),
+  // (3) Innovation-Readiness evidence when the readiness level is 1-9 (Innovation Development, type 7, only).
+  // Reuses the same helpers that drive the yellow warnings so the check and the alerts never disagree.
+  get evidenceSectionComplete(): boolean {
+    const resultTypeId = this.api.dataControlSE.currentResult?.result_type_id;
+    const hasBaseEvidence = this.evidencesBody.evidences.length > 0 || resultTypeId == 5;
+    const markersCovered = !this.validateCheckBoxes();
+    const readinessCovered = resultTypeId !== 7 || this.validateHasInnoReadinessLevelEvidence();
+    return hasBaseEvidence && markersCovered && readinessCovered;
   }
 
   get validateButtonDisabled() {

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-result-types-pages/innovation-dev-info/components/user-evidence/user-evidence.component.html
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-result-types-pages/innovation-dev-info/components/user-evidence/user-evidence.component.html
@@ -105,11 +105,11 @@
 
     <app-pr-field-header [label]="getEvidenceRelatedTitle()" [required]="false" *ngIf="!isSuppInfo"></app-pr-field-header>
     <div class="checkboxes" *ngIf="!isSuppInfo">
-      <app-pr-checkbox label="Gender" [(ngModel)]="this.evidence.gender_related"> </app-pr-checkbox>
-      <app-pr-checkbox label="Climate change" [(ngModel)]="this.evidence.youth_related"> </app-pr-checkbox>
-      <app-pr-checkbox label="Nutrition" [(ngModel)]="this.evidence.nutrition_related"> </app-pr-checkbox>
-      <app-pr-checkbox label="Environment" [(ngModel)]="this.evidence.environmental_biodiversity_related"> </app-pr-checkbox>
-      <app-pr-checkbox label="Poverty" [(ngModel)]="this.evidence.poverty_related"> </app-pr-checkbox>
+      <app-pr-checkbox label="Gender equality, youth and social inclusion" [(ngModel)]="this.evidence.gender_related"> </app-pr-checkbox>
+      <app-pr-checkbox label="Climate adaptation and mitigation" [(ngModel)]="this.evidence.youth_related"> </app-pr-checkbox>
+      <app-pr-checkbox label="Nutrition, health and food security" [(ngModel)]="this.evidence.nutrition_related"> </app-pr-checkbox>
+      <app-pr-checkbox label="Environmental health and biodiversity" [(ngModel)]="this.evidence.environmental_biodiversity_related"> </app-pr-checkbox>
+      <app-pr-checkbox label="Poverty reduction, livelihoods and jobs" [(ngModel)]="this.evidence.poverty_related"> </app-pr-checkbox>
       <app-pr-checkbox label="Innovation Development" [(ngModel)]="this.evidence.innovation_readiness_related" *ngIf="this.dataControlSE.isInnoDev">
       </app-pr-checkbox>
       <app-pr-checkbox label="Innovation Use" [(ngModel)]="this.evidence.innovation_use_related" *ngIf="this.dataControlSE.isInnoUse">

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-result-types-pages/innovation-dev-info/innovation-dev-info.component.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-result-types-pages/innovation-dev-info/innovation-dev-info.component.ts
@@ -55,7 +55,7 @@ export class InnovationDevInfoComponent {
     this.api.resultsSE.GET_innovationDevP25().subscribe(({ response }) => {
       this.innovationDevInfoBody = response;
       this.convertOrganizations(response?.innovatonUse?.organization);
-      this.innovationDevInfoBody.innovation_user_to_be_determined = Boolean(this.innovationDevInfoBody.innovation_user_to_be_determined);
+      this.normalizeInnovationDevBooleans();
       this.savingSection = false;
     });
     this.api.resultsSE.GET_questionsInnovationDevelopmentP25().subscribe(({ response }) => {
@@ -95,7 +95,7 @@ export class InnovationDevInfoComponent {
       next: ({ response }) => {
         this.convertOrganizations(response?.innovatonUse?.organization);
         this.innovationDevInfoBody = response;
-        this.innovationDevInfoBody.innovation_user_to_be_determined = Boolean(this.innovationDevInfoBody.innovation_user_to_be_determined);
+        this.normalizeInnovationDevBooleans();
         this.savingSection = false;
       },
       error: err => {
@@ -118,6 +118,21 @@ export class InnovationDevInfoComponent {
         item.institution_types_id = item?.parent_institution_type_id;
       }
     });
+  }
+
+  private normalizeInnovationDevBooleans(): void {
+    this.innovationDevInfoBody.innovation_user_to_be_determined = Boolean(
+      this.innovationDevInfoBody.innovation_user_to_be_determined,
+    );
+    this.innovationDevInfoBody.is_new_variety =
+      this.innovationDevInfoBody.is_new_variety == null
+        ? null
+        : Boolean(this.innovationDevInfoBody.is_new_variety);
+    if (this.innovationDevInfoBody.innovation_nature_id != null) {
+      this.innovationDevInfoBody.innovation_nature_id = Number(
+        this.innovationDevInfoBody.innovation_nature_id,
+      );
+    }
   }
 
   convertOrganizationsTosave() {

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.controller.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.controller.ts
@@ -6,6 +6,7 @@ import {
   ParseIntPipe,
   Post,
   Query,
+  UseGuards,
   UseInterceptors,
   ValidationPipe,
 } from '@nestjs/common';
@@ -13,6 +14,7 @@ import { SkipThrottle } from '@nestjs/throttler';
 import { BilateralService } from './bilateral.service';
 import {
   ApiBody,
+  ApiHeader,
   ApiOperation,
   ApiParam,
   ApiQuery,
@@ -21,15 +23,24 @@ import {
 import { ResponseInterceptor } from '../../shared/Interceptors/Return-data.interceptor';
 import { RootResultsDto } from './dto/create-bilateral.dto';
 import { ListResultsQueryDto } from './dto/list-results-query.dto';
+import { ClarisaApiKeyGuard } from './guards/clarisa-api-key.guard';
+import { BilateralClarisaEndpoint } from './decorators/bilateral-clarisa-endpoint.decorator';
 
 @Controller()
 @ApiTags('Bilaterals')
+@ApiHeader({
+  name: 'X-API-Key',
+  required: true,
+  description: 'CLARISA API key for bilateral access',
+})
+@UseGuards(ClarisaApiKeyGuard)
 @SkipThrottle()
 @UseInterceptors(ResponseInterceptor)
 export class BilateralController {
   constructor(private readonly bilateralService: BilateralService) {}
 
   @Post('create')
+  @BilateralClarisaEndpoint('/api/bilateral/create')
   @ApiBody({ type: RootResultsDto })
   async create(
     @Body(
@@ -45,6 +56,7 @@ export class BilateralController {
   }
 
   @Get()
+  @BilateralClarisaEndpoint('/api/bilateral')
   @ApiOperation({
     summary: 'Get all bilateral results',
     description:
@@ -64,6 +76,7 @@ export class BilateralController {
   }
 
   @Get('list')
+  @BilateralClarisaEndpoint('/api/bilateral/list')
   @ApiOperation({
     summary: 'List all results with pagination and filters',
     description:
@@ -186,6 +199,7 @@ export class BilateralController {
   }
 
   @Get('results')
+  @BilateralClarisaEndpoint('/api/bilateral/results')
   @ApiOperation({
     summary: 'Get all bilateral results for synchronization',
     description:
@@ -214,6 +228,7 @@ export class BilateralController {
   }
 
   @Get(':id')
+  @BilateralClarisaEndpoint('/api/bilateral/:id')
   @ApiOperation({
     summary: 'Get bilateral result by ID',
     description:

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.module.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
 import { BilateralService } from './bilateral.service';
 import { BilateralController } from './bilateral.controller';
 import { ResultsModule } from '../results/results.module';
@@ -45,9 +46,12 @@ import { ResultsPolicyChangesRepository } from '../results/summary/repositories/
 import { NoopBilateralHandler } from './handlers/noop.handler';
 import { NonPooledProjectBudgetRepository } from '../results/result_budget/repositories/non_pooled_proyect_budget.repository';
 import { PathwayModule } from '../ipsr-framework/pathway/pathway.module';
+import { ClarisaApiKeyValidationService } from './services/clarisa-api-key-validation.service';
+import { ClarisaApiKeyGuard } from './guards/clarisa-api-key.guard';
 
 @Module({
   imports: [
+    HttpModule,
     ResultsModule,
     VersioningModule,
     UserModule,
@@ -84,6 +88,8 @@ import { PathwayModule } from '../ipsr-framework/pathway/pathway.module';
   ],
   controllers: [BilateralController],
   providers: [
+    ClarisaApiKeyValidationService,
+    ClarisaApiKeyGuard,
     BilateralService,
     KnowledgeProductBilateralHandler,
     CapacityChangeBilateralHandler,

--- a/onecgiar-pr-server/src/api/bilateral/constants/bilateral-auth.constants.ts
+++ b/onecgiar-pr-server/src/api/bilateral/constants/bilateral-auth.constants.ts
@@ -1,0 +1,3 @@
+export const BILATERAL_CLARISA_MICROSERVICE_NAME = 'Bilateral Service';
+
+export const BILATERAL_UNAUTHORIZED_MESSAGE = 'Unauthorized';

--- a/onecgiar-pr-server/src/api/bilateral/decorators/bilateral-clarisa-endpoint.decorator.ts
+++ b/onecgiar-pr-server/src/api/bilateral/decorators/bilateral-clarisa-endpoint.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const BILATERAL_CLARISA_ENDPOINT_KEY = 'bilateralClarisaEndpoint';
+
+export const BilateralClarisaEndpoint = (endpointAccessed: string) =>
+  SetMetadata(BILATERAL_CLARISA_ENDPOINT_KEY, endpointAccessed);

--- a/onecgiar-pr-server/src/api/bilateral/guards/clarisa-api-key.guard.spec.ts
+++ b/onecgiar-pr-server/src/api/bilateral/guards/clarisa-api-key.guard.spec.ts
@@ -1,0 +1,87 @@
+import { Reflector } from '@nestjs/core';
+import { UnauthorizedException } from '@nestjs/common';
+import { ClarisaApiKeyGuard } from './clarisa-api-key.guard';
+import { BILATERAL_CLARISA_ENDPOINT_KEY } from '../decorators/bilateral-clarisa-endpoint.decorator';
+import { BILATERAL_UNAUTHORIZED_MESSAGE } from '../constants/bilateral-auth.constants';
+
+describe('ClarisaApiKeyGuard', () => {
+  const validationService = {
+    validate: jest.fn(),
+  };
+
+  const reflector = {
+    get: jest.fn(),
+  };
+
+  const guard = new ClarisaApiKeyGuard(
+    validationService as any,
+    reflector as unknown as Reflector,
+  );
+
+  const makeContext = (headers: Record<string, string | string[]>) =>
+    ({
+      getHandler: () => function handler() {},
+      switchToHttp: () => ({
+        getRequest: () => ({
+          headers,
+          socket: { remoteAddress: '127.0.0.1' },
+        }),
+      }),
+    }) as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    reflector.get.mockReturnValue('/api/bilateral/create');
+  });
+
+  it('should reject requests without X-API-Key', async () => {
+    await expect(guard.canActivate(makeContext({}))).rejects.toThrow(
+      new UnauthorizedException(BILATERAL_UNAUTHORIZED_MESSAGE),
+    );
+    expect(validationService.validate).not.toHaveBeenCalled();
+  });
+
+  it('should reject requests when endpoint metadata is missing', async () => {
+    reflector.get.mockReturnValue(undefined);
+
+    await expect(
+      guard.canActivate(makeContext({ 'x-api-key': 'cl_prod_key' })),
+    ).rejects.toThrow(
+      new UnauthorizedException(BILATERAL_UNAUTHORIZED_MESSAGE),
+    );
+    expect(validationService.validate).not.toHaveBeenCalled();
+  });
+
+  it('should allow requests when CLARISA validates the API key', async () => {
+    validationService.validate.mockResolvedValue(true);
+
+    await expect(
+      guard.canActivate(
+        makeContext({
+          'x-api-key': 'cl_prod_key',
+          'x-forwarded-for': '203.0.113.42',
+        }),
+      ),
+    ).resolves.toBe(true);
+
+    expect(reflector.get).toHaveBeenCalledWith(
+      BILATERAL_CLARISA_ENDPOINT_KEY,
+      expect.any(Function),
+    );
+    expect(validationService.validate).toHaveBeenCalledWith(
+      'cl_prod_key',
+      '/api/bilateral/create',
+      '203.0.113.42',
+    );
+  });
+
+  it('should reject requests when CLARISA rejects the API key', async () => {
+    validationService.validate.mockResolvedValue(false);
+
+    await expect(
+      guard.canActivate(makeContext({ 'x-api-key': 'bad-key' })),
+    ).rejects.toThrow(
+      new UnauthorizedException(BILATERAL_UNAUTHORIZED_MESSAGE),
+    );
+  });
+});

--- a/onecgiar-pr-server/src/api/bilateral/guards/clarisa-api-key.guard.ts
+++ b/onecgiar-pr-server/src/api/bilateral/guards/clarisa-api-key.guard.ts
@@ -1,0 +1,69 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+import { BILATERAL_UNAUTHORIZED_MESSAGE } from '../constants/bilateral-auth.constants';
+import { BILATERAL_CLARISA_ENDPOINT_KEY } from '../decorators/bilateral-clarisa-endpoint.decorator';
+import { ClarisaApiKeyValidationService } from '../services/clarisa-api-key-validation.service';
+
+@Injectable()
+export class ClarisaApiKeyGuard implements CanActivate {
+  constructor(
+    private readonly clarisaApiKeyValidationService: ClarisaApiKeyValidationService,
+    private readonly reflector: Reflector,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const apiKey = this.extractApiKey(request);
+
+    if (!apiKey) {
+      throw new UnauthorizedException(BILATERAL_UNAUTHORIZED_MESSAGE);
+    }
+
+    const endpointAccessed = this.reflector.get<string>(
+      BILATERAL_CLARISA_ENDPOINT_KEY,
+      context.getHandler(),
+    );
+
+    if (!endpointAccessed) {
+      throw new UnauthorizedException(BILATERAL_UNAUTHORIZED_MESSAGE);
+    }
+
+    const isValid = await this.clarisaApiKeyValidationService.validate(
+      apiKey,
+      endpointAccessed,
+      this.extractClientIp(request),
+    );
+
+    if (!isValid) {
+      throw new UnauthorizedException(BILATERAL_UNAUTHORIZED_MESSAGE);
+    }
+
+    return true;
+  }
+
+  private extractApiKey(request: Request): string | undefined {
+    const headerValue = request.headers['x-api-key'];
+
+    if (Array.isArray(headerValue)) {
+      return headerValue[0]?.trim() || undefined;
+    }
+
+    const apiKey = headerValue?.trim();
+    return apiKey || undefined;
+  }
+
+  private extractClientIp(request: Request): string | undefined {
+    const forwardedFor = request.headers['x-forwarded-for'];
+    const ip = Array.isArray(forwardedFor)
+      ? forwardedFor[0]
+      : forwardedFor || request.socket?.remoteAddress;
+
+    return typeof ip === 'string' ? ip.trim() : undefined;
+  }
+}

--- a/onecgiar-pr-server/src/api/bilateral/interfaces/clarisa-api-key-validation.interface.ts
+++ b/onecgiar-pr-server/src/api/bilateral/interfaces/clarisa-api-key-validation.interface.ts
@@ -1,0 +1,28 @@
+export interface ClarisaApiKeyValidationRequest {
+  api_key: string;
+  microservice_name: string;
+  endpoint_accessed: string;
+  ip_address?: string;
+}
+
+export interface ClarisaApiKeyValidationMis {
+  id: number;
+  name: string;
+  acronym: string;
+}
+
+export interface ClarisaApiKeyValidationSuccess {
+  valid: true;
+  mis: ClarisaApiKeyValidationMis;
+  environment: string;
+  scopes: string[];
+}
+
+export interface ClarisaApiKeyValidationFailure {
+  valid: false;
+  error?: string;
+}
+
+export type ClarisaApiKeyValidationResponse =
+  | ClarisaApiKeyValidationSuccess
+  | ClarisaApiKeyValidationFailure;

--- a/onecgiar-pr-server/src/api/bilateral/services/clarisa-api-key-validation.service.spec.ts
+++ b/onecgiar-pr-server/src/api/bilateral/services/clarisa-api-key-validation.service.spec.ts
@@ -1,0 +1,120 @@
+import { HttpService } from '@nestjs/axios';
+import { Logger } from '@nestjs/common';
+import { of, throwError } from 'rxjs';
+import { AxiosError, AxiosHeaders } from 'axios';
+import { ClarisaApiKeyValidationService } from './clarisa-api-key-validation.service';
+import { BILATERAL_CLARISA_MICROSERVICE_NAME } from '../constants/bilateral-auth.constants';
+
+const originalEnv = { ...process.env };
+
+describe('ClarisaApiKeyValidationService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.CLA_URL = 'https://clarisa.example/';
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  const createService = (httpService: HttpService) =>
+    new ClarisaApiKeyValidationService(httpService);
+
+  it('should validate API key against CLARISA without Basic Auth', async () => {
+    const post = jest.fn().mockReturnValue(
+      of({
+        data: {
+          valid: true,
+          mis: { id: 12, name: 'Reporting Tool', acronym: 'PRMS' },
+          environment: 'PROD',
+          scopes: ['bilateral:read'],
+        },
+      }),
+    );
+    const httpService = { post } as unknown as HttpService;
+
+    const service = createService(httpService);
+    const isValid = await service.validate(
+      'cl_prod_key',
+      '/api/bilateral/list',
+      '203.0.113.42',
+    );
+
+    expect(isValid).toBe(true);
+    expect(post).toHaveBeenCalledWith(
+      'https://clarisa.example/api/auth/validate-api-key',
+      {
+        api_key: 'cl_prod_key',
+        microservice_name: BILATERAL_CLARISA_MICROSERVICE_NAME,
+        endpoint_accessed: '/api/bilateral/list',
+        ip_address: '203.0.113.42',
+      },
+      expect.objectContaining({
+        headers: { 'Content-Type': 'application/json' },
+        timeout: 5000,
+      }),
+    );
+    expect(post.mock.calls[0][2]).not.toHaveProperty('auth');
+  });
+
+  it('should return false when CLARISA responds with valid false', async () => {
+    const httpService = {
+      post: jest.fn().mockReturnValue(
+        of({
+          data: {
+            valid: false,
+            error: 'Invalid API key',
+          },
+        }),
+      ),
+    } as unknown as HttpService;
+
+    const service = createService(httpService);
+    await expect(
+      service.validate('bad-key', '/api/bilateral/create'),
+    ).resolves.toBe(false);
+  });
+
+  it('should return false when CLARISA responds with HTTP 401', async () => {
+    const axiosError = new AxiosError(
+      'Unauthorized',
+      '401',
+      undefined,
+      undefined,
+      {
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: {},
+        config: { headers: new AxiosHeaders() },
+        data: { valid: false, error: 'Missing required scope' },
+      },
+    );
+
+    const httpService = {
+      post: jest.fn().mockReturnValue(throwError(() => axiosError)),
+    } as unknown as HttpService;
+
+    const service = createService(httpService);
+    await expect(
+      service.validate('bad-key', '/api/bilateral/results'),
+    ).resolves.toBe(false);
+  });
+
+  it('should return false and log when CLARISA is unreachable', async () => {
+    const warnSpy = jest
+      .spyOn(Logger.prototype, 'warn')
+      .mockImplementation(() => undefined);
+
+    const httpService = {
+      post: jest
+        .fn()
+        .mockReturnValue(throwError(() => new Error('network error'))),
+    } as unknown as HttpService;
+
+    const service = createService(httpService);
+    await expect(
+      service.validate('some-key', '/api/bilateral'),
+    ).resolves.toBe(false);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/onecgiar-pr-server/src/api/bilateral/services/clarisa-api-key-validation.service.ts
+++ b/onecgiar-pr-server/src/api/bilateral/services/clarisa-api-key-validation.service.ts
@@ -1,0 +1,63 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable, Logger } from '@nestjs/common';
+import { AxiosError } from 'axios';
+import { env } from 'process';
+import { firstValueFrom } from 'rxjs';
+import { BILATERAL_CLARISA_MICROSERVICE_NAME } from '../constants/bilateral-auth.constants';
+import {
+  ClarisaApiKeyValidationRequest,
+  ClarisaApiKeyValidationResponse,
+} from '../interfaces/clarisa-api-key-validation.interface';
+
+@Injectable()
+export class ClarisaApiKeyValidationService {
+  private readonly logger = new Logger(ClarisaApiKeyValidationService.name);
+  private readonly validateUrl: string;
+
+  constructor(private readonly httpService: HttpService) {
+    const baseUrl = (env.CLA_URL ?? '').replace(/\/+$/, '');
+    this.validateUrl = `${baseUrl}/api/auth/validate-api-key`;
+  }
+
+  async validate(
+    apiKey: string,
+    endpointAccessed: string,
+    ipAddress?: string,
+  ): Promise<boolean> {
+    const payload: ClarisaApiKeyValidationRequest = {
+      api_key: apiKey,
+      microservice_name: BILATERAL_CLARISA_MICROSERVICE_NAME,
+      endpoint_accessed: endpointAccessed,
+    };
+
+    if (ipAddress) {
+      payload.ip_address = ipAddress;
+    }
+
+    try {
+      const response = await firstValueFrom(
+        this.httpService.post<ClarisaApiKeyValidationResponse>(
+          this.validateUrl,
+          payload,
+          {
+            headers: { 'Content-Type': 'application/json' },
+            timeout: 5000,
+          },
+        ),
+      );
+
+      return response.data?.valid === true;
+    } catch (error) {
+      const axiosError = error as AxiosError<ClarisaApiKeyValidationResponse>;
+
+      if (axiosError.response?.data?.valid === false) {
+        return false;
+      }
+
+      this.logger.warn(
+        `CLARISA API key validation failed for endpoint ${endpointAccessed}`,
+      );
+      return false;
+    }
+  }
+}

--- a/onecgiar-pr-server/src/api/results-framework-reporting/innovation_dev/innovation_dev.service.spec.ts
+++ b/onecgiar-pr-server/src/api/results-framework-reporting/innovation_dev/innovation_dev.service.spec.ts
@@ -27,6 +27,15 @@ describe('InnovationDevService', () => {
   let service: InnovationDevService;
   let mockResultsInnovationsDevRepository: jest.Mocked<ResultsInnovationsDevRepository>;
   let mockHandlersError: jest.Mocked<HandlersError>;
+  let mockInnoDevService: {
+    saveEvidence: jest.Mock;
+    saveInitiativeInvestment: jest.Mock;
+    savePartnerInvestment: jest.Mock;
+  };
+  let mockInnovationUseService: { saveAnticipatedInnoUser: jest.Mock };
+  let mockResultRepository: { update: jest.Mock };
+  let mockResultAnswerRepository: { find: jest.Mock; save: jest.Mock };
+  let mockResultsByProjectsRepository: { find: jest.Mock };
 
   const userTest: TokenDto = {
     id: 1,
@@ -65,11 +74,29 @@ describe('InnovationDevService', () => {
     ).mockResolvedValueOnce(updatedMock);
   };
 
+  const buildInnovationDevQuestions = () => ({
+    responsible_innovation_and_scaling: {
+      q1: { radioButtonValue: null, options: [] },
+      q2: { radioButtonValue: null, options: [] },
+      q3: { radioButtonValue: null, options: [] },
+      q4: { radioButtonValue: null, options: [] },
+    },
+    intellectual_property_rights: {
+      q1: { radioButtonValue: null, options: [] },
+      q2: { radioButtonValue: null, options: [] },
+      q3: { radioButtonValue: null, options: [] },
+      q4: { radioButtonValue: null, options: [] },
+    },
+    innovation_team_diversity: { radioButtonValue: null, options: [] },
+    megatrends: { radioButtonValue: null, options: [] },
+  });
+
   beforeEach(async () => {
     const mockResultsInnovationsDevRepo = {
       InnovationDevExists: jest.fn(),
       findOne: jest.fn(),
       save: jest.fn(),
+      update: jest.fn().mockResolvedValue(undefined),
     };
 
     const mockHandlersErrorService = {
@@ -78,6 +105,24 @@ describe('InnovationDevService', () => {
         message: error?.message || 'Error occurred',
         status: error?.status || HttpStatus.INTERNAL_SERVER_ERROR,
       })),
+    };
+    mockInnoDevService = {
+      saveEvidence: jest.fn().mockResolvedValue(undefined),
+      saveInitiativeInvestment: jest.fn().mockResolvedValue(undefined),
+      savePartnerInvestment: jest.fn().mockResolvedValue(undefined),
+    };
+    mockInnovationUseService = {
+      saveAnticipatedInnoUser: jest.fn().mockResolvedValue(undefined),
+    };
+    mockResultRepository = {
+      update: jest.fn().mockResolvedValue(undefined),
+    };
+    mockResultAnswerRepository = {
+      find: jest.fn().mockResolvedValue([]),
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+    mockResultsByProjectsRepository = {
+      find: jest.fn().mockResolvedValue([]),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -97,7 +142,7 @@ describe('InnovationDevService', () => {
         },
         {
           provide: ResultRepository,
-          useValue: {},
+          useValue: mockResultRepository,
         },
         {
           provide: EvidencesRepository,
@@ -133,11 +178,11 @@ describe('InnovationDevService', () => {
         },
         {
           provide: InnoDevService,
-          useValue: {},
+          useValue: mockInnoDevService,
         },
         {
           provide: InnovationUseService,
-          useValue: {},
+          useValue: mockInnovationUseService,
         },
         {
           provide: getRepositoryToken(ResultScalingStudyUrl),
@@ -145,11 +190,11 @@ describe('InnovationDevService', () => {
         },
         {
           provide: ResultAnswerRepository,
-          useValue: {},
+          useValue: mockResultAnswerRepository,
         },
         {
           provide: ResultsByProjectsRepository,
-          useValue: {},
+          useValue: mockResultsByProjectsRepository,
         },
         {
           provide: ResultsCenterRepository,
@@ -260,8 +305,6 @@ describe('InnovationDevService', () => {
       expect(result.status).toBe(HttpStatus.OK);
       expect(mockResultsInnovationsDevRepository.save).toHaveBeenCalledWith(
         expect.objectContaining({
-          innovation_developers: 'Original Developer',
-          readiness_level: '0',
           last_updated_by: userTest.id,
           innovation_nature: { code: 20 },
         }),
@@ -295,7 +338,6 @@ describe('InnovationDevService', () => {
       expect(mockResultsInnovationsDevRepository.save).toHaveBeenCalledWith(
         expect.objectContaining({
           innovation_developers: 'New Developer Name',
-          innovation_nature_id: 13,
           last_updated_by: userTest.id,
         }),
       );
@@ -367,6 +409,7 @@ describe('InnovationDevService', () => {
       expect(result.message).toBe('Innovation development record not found');
       expect(result.response).toEqual({});
       expect(mockResultsInnovationsDevRepository.save).not.toHaveBeenCalled();
+      expect(mockResultsInnovationsDevRepository.update).not.toHaveBeenCalled();
     });
 
     it('should handle undefined fields correctly (only update defined fields)', async () => {
@@ -399,8 +442,6 @@ describe('InnovationDevService', () => {
       expect(result.status).toBe(HttpStatus.OK);
       expect(mockResultsInnovationsDevRepository.save).toHaveBeenCalledWith(
         expect.objectContaining({
-          innovation_developers: 'Original Developer',
-          readiness_level: '0',
           last_updated_by: userTest.id,
           innovation_nature: { code: 15 },
           innovation_readiness_level: { id: 12 },
@@ -464,6 +505,79 @@ describe('InnovationDevService', () => {
       expect(mockResultsInnovationsDevRepository.save).toHaveBeenCalledWith(
         expect.objectContaining({
           last_updated_by: userTest.id,
+        }),
+      );
+    });
+  });
+
+  describe('saveInnovationDev', () => {
+    it('should persist typology and readiness relations when creating a new record', async () => {
+      const savedRecord = { result_innovation_dev_id: 5001 };
+
+      (
+        mockResultsInnovationsDevRepository.InnovationDevExists as jest.Mock
+      ).mockResolvedValueOnce(undefined);
+      (
+        mockResultsInnovationsDevRepository.save as jest.Mock
+      ).mockResolvedValueOnce(savedRecord);
+
+      await service.saveInnovationDev(
+        {
+          innovation_nature_id: 12,
+          innovation_readiness_level_id: 11,
+          innovation_characterization_id: 3,
+          is_new_variety: true,
+          number_of_varieties: 2,
+          innovatonUse: { actors: [], organization: [], measures: [] },
+          reference_materials: [],
+          bilateral_expected_investment: [],
+          ...buildInnovationDevQuestions(),
+        } as any,
+        8563,
+        userTest,
+      );
+
+      expect(mockResultsInnovationsDevRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          is_new_variety: true,
+          number_of_varieties: 2,
+          innovation_nature: { code: 12 },
+          innovation_readiness_level: { id: 11 },
+          innovation_characterization: { id: 3 },
+        }),
+      );
+    });
+
+    it('should persist typology relation when updating an existing record', async () => {
+      const mockCopy = createMockCopy();
+      const updatedMock = {
+        ...mockCopy,
+        innovation_nature_id: 12,
+        is_new_variety: true,
+        number_of_varieties: 2,
+      };
+
+      setupPersistMocks(mockCopy, updatedMock);
+
+      await service.saveInnovationDev(
+        {
+          innovation_nature_id: 12,
+          is_new_variety: true,
+          number_of_varieties: 2,
+          innovatonUse: { actors: [], organization: [], measures: [] },
+          reference_materials: [],
+          bilateral_expected_investment: [],
+          ...buildInnovationDevQuestions(),
+        } as any,
+        8563,
+        userTest,
+      );
+
+      expect(mockResultsInnovationsDevRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          is_new_variety: true,
+          number_of_varieties: 2,
+          innovation_nature: { code: 12 },
         }),
       );
     });

--- a/onecgiar-pr-server/src/api/results-framework-reporting/innovation_dev/innovation_dev.service.spec.ts
+++ b/onecgiar-pr-server/src/api/results-framework-reporting/innovation_dev/innovation_dev.service.spec.ts
@@ -50,9 +50,25 @@ describe('InnovationDevService', () => {
   // Helper function to create fresh mock copies
   const createMockCopy = () => JSON.parse(JSON.stringify(mockInnovationDev));
 
+  const setupPersistMocks = (
+    mockCopy: typeof mockInnovationDev,
+    updatedMock: typeof mockInnovationDev,
+  ) => {
+    (
+      mockResultsInnovationsDevRepository.InnovationDevExists as jest.Mock
+    ).mockResolvedValueOnce(mockCopy);
+    (
+      mockResultsInnovationsDevRepository.findOne as jest.Mock
+    ).mockResolvedValueOnce({ ...mockCopy });
+    (
+      mockResultsInnovationsDevRepository.save as jest.Mock
+    ).mockResolvedValueOnce(updatedMock);
+  };
+
   beforeEach(async () => {
     const mockResultsInnovationsDevRepo = {
       InnovationDevExists: jest.fn(),
+      findOne: jest.fn(),
       save: jest.fn(),
     };
 
@@ -182,12 +198,7 @@ describe('InnovationDevService', () => {
         last_updated_by: userTest.id,
       };
 
-      (
-        mockResultsInnovationsDevRepository.InnovationDevExists as jest.Mock
-      ).mockResolvedValueOnce(mockCopy);
-      (
-        mockResultsInnovationsDevRepository.save as jest.Mock
-      ).mockResolvedValueOnce(updatedMock);
+      setupPersistMocks(mockCopy, updatedMock);
 
       const result = await service.updateInnovationDevPartial(
         resultId,
@@ -203,13 +214,19 @@ describe('InnovationDevService', () => {
       expect(
         mockResultsInnovationsDevRepository.InnovationDevExists,
       ).toHaveBeenCalledWith(resultId);
+      expect(mockResultsInnovationsDevRepository.findOne).toHaveBeenCalledWith({
+        where: {
+          result_innovation_dev_id: mockCopy.result_innovation_dev_id,
+          is_active: true,
+        },
+      });
       expect(mockResultsInnovationsDevRepository.save).toHaveBeenCalledWith(
         expect.objectContaining({
-          innovation_nature_id: 15,
           innovation_developers: 'Ms. Yodalieva Markhabo',
-          innovation_readiness_level_id: 12,
           readiness_level: '1',
           last_updated_by: userTest.id,
+          innovation_nature: { code: 15 },
+          innovation_readiness_level: { id: 12 },
         }),
       );
     });
@@ -232,12 +249,7 @@ describe('InnovationDevService', () => {
         last_updated_by: userTest.id,
       };
 
-      (
-        mockResultsInnovationsDevRepository.InnovationDevExists as jest.Mock
-      ).mockResolvedValueOnce(mockCopy);
-      (
-        mockResultsInnovationsDevRepository.save as jest.Mock
-      ).mockResolvedValueOnce(updatedMock);
+      setupPersistMocks(mockCopy, updatedMock);
 
       const result = await service.updateInnovationDevPartial(
         resultId,
@@ -248,11 +260,10 @@ describe('InnovationDevService', () => {
       expect(result.status).toBe(HttpStatus.OK);
       expect(mockResultsInnovationsDevRepository.save).toHaveBeenCalledWith(
         expect.objectContaining({
-          innovation_nature_id: 20,
           innovation_developers: 'Original Developer',
-          innovation_readiness_level_id: 11,
           readiness_level: '0',
           last_updated_by: userTest.id,
+          innovation_nature: { code: 20 },
         }),
       );
     });
@@ -272,12 +283,7 @@ describe('InnovationDevService', () => {
         last_updated_by: userTest.id,
       };
 
-      (
-        mockResultsInnovationsDevRepository.InnovationDevExists as jest.Mock
-      ).mockResolvedValueOnce(mockCopy);
-      (
-        mockResultsInnovationsDevRepository.save as jest.Mock
-      ).mockResolvedValueOnce(updatedMock);
+      setupPersistMocks(mockCopy, updatedMock);
 
       const result = await service.updateInnovationDevPartial(
         resultId,
@@ -289,7 +295,7 @@ describe('InnovationDevService', () => {
       expect(mockResultsInnovationsDevRepository.save).toHaveBeenCalledWith(
         expect.objectContaining({
           innovation_developers: 'New Developer Name',
-          innovation_nature_id: 13, // No cambió
+          innovation_nature_id: 13,
           last_updated_by: userTest.id,
         }),
       );
@@ -312,12 +318,7 @@ describe('InnovationDevService', () => {
         last_updated_by: userTest.id,
       };
 
-      (
-        mockResultsInnovationsDevRepository.InnovationDevExists as jest.Mock
-      ).mockResolvedValueOnce(mockCopy);
-      (
-        mockResultsInnovationsDevRepository.save as jest.Mock
-      ).mockResolvedValueOnce(updatedMock);
+      setupPersistMocks(mockCopy, updatedMock);
 
       const result = await service.updateInnovationDevPartial(
         resultId,
@@ -328,9 +329,9 @@ describe('InnovationDevService', () => {
       expect(result.status).toBe(HttpStatus.OK);
       expect(mockResultsInnovationsDevRepository.save).toHaveBeenCalledWith(
         expect.objectContaining({
-          innovation_readiness_level_id: 15,
           readiness_level: '2',
           last_updated_by: userTest.id,
+          innovation_readiness_level: { id: 15 },
         }),
       );
     });
@@ -387,12 +388,7 @@ describe('InnovationDevService', () => {
         last_updated_by: userTest.id,
       };
 
-      (
-        mockResultsInnovationsDevRepository.InnovationDevExists as jest.Mock
-      ).mockResolvedValueOnce(mockCopy);
-      (
-        mockResultsInnovationsDevRepository.save as jest.Mock
-      ).mockResolvedValueOnce(updatedMock);
+      setupPersistMocks(mockCopy, updatedMock);
 
       const result = await service.updateInnovationDevPartial(
         resultId,
@@ -403,11 +399,11 @@ describe('InnovationDevService', () => {
       expect(result.status).toBe(HttpStatus.OK);
       expect(mockResultsInnovationsDevRepository.save).toHaveBeenCalledWith(
         expect.objectContaining({
-          innovation_nature_id: 15,
-          innovation_readiness_level_id: 12,
           innovation_developers: 'Original Developer',
           readiness_level: '0',
           last_updated_by: userTest.id,
+          innovation_nature: { code: 15 },
+          innovation_readiness_level: { id: 12 },
         }),
       );
     });
@@ -454,13 +450,7 @@ describe('InnovationDevService', () => {
       };
 
       const mockCopy = createMockCopy();
-
-      (
-        mockResultsInnovationsDevRepository.InnovationDevExists as jest.Mock
-      ).mockResolvedValueOnce(mockCopy);
-      (
-        mockResultsInnovationsDevRepository.save as jest.Mock
-      ).mockResolvedValueOnce({
+      setupPersistMocks(mockCopy, {
         ...mockCopy,
         last_updated_by: userTest.id,
       });

--- a/onecgiar-pr-server/src/api/results-framework-reporting/innovation_dev/innovation_dev.service.ts
+++ b/onecgiar-pr-server/src/api/results-framework-reporting/innovation_dev/innovation_dev.service.ts
@@ -92,26 +92,14 @@ export class InnovationDevService {
       } = createInnovationDevDto;
 
       let InnDevRes: ResultsInnovationsDev = undefined;
+      const innovationDevFields = this._buildInnovationDevFieldsFromDto(
+        createInnovationDevDto,
+      );
+
       if (innDevExists) {
         InnDevRes = await this._persistInnovationDevEntity(
           innDevExists.result_innovation_dev_id,
-          {
-            short_title,
-            is_new_variety,
-            readiness_level,
-            number_of_varieties,
-            innovation_nature_id,
-            innovation_developers,
-            evidences_justification,
-            innovation_collaborators,
-            innovation_readiness_level_id,
-            innovation_characterization_id,
-            innovation_acknowledgement,
-            innovation_pdf,
-            innovation_user_to_be_determined,
-            has_scaling_studies,
-            ip_support_center_id,
-          },
+          innovationDevFields,
           user.id,
         );
       } else {
@@ -124,17 +112,21 @@ export class InnovationDevService {
         newInnDev.is_new_variety = is_new_variety;
         newInnDev.readiness_level = readiness_level;
         newInnDev.number_of_varieties = number_of_varieties;
-        newInnDev.innovation_nature_id = innovation_nature_id;
         newInnDev.innovation_developers = innovation_developers;
         newInnDev.evidences_justification = evidences_justification;
         newInnDev.innovation_collaborators = innovation_collaborators;
         newInnDev.result_innovation_dev_id = result_innovation_dev_id;
-        newInnDev.innovation_readiness_level_id = innovation_readiness_level_id;
-        newInnDev.innovation_characterization_id =
-          innovation_characterization_id;
+        newInnDev.innovation_acknowledgement = innovation_acknowledgement;
+        newInnDev.innovation_pdf = innovation_pdf;
         newInnDev.innovation_user_to_be_determined =
           innovation_user_to_be_determined;
         newInnDev.has_scaling_studies = has_scaling_studies;
+        newInnDev.ip_support_center_id = ip_support_center_id;
+        this._applyInnovationDevRelations(newInnDev, {
+          innovation_readiness_level_id,
+          innovation_nature_id,
+          innovation_characterization_id,
+        });
         InnDevRes = await this._resultsInnovationsDevRepository.save(newInnDev);
       }
       // * SAVING INNOVATION AND SCALING
@@ -430,7 +422,7 @@ export class InnovationDevService {
 
       return {
         response: {
-          ...innDevExists,
+          ...this._normalizeInnovationDevRecord(innDevExists),
           pictures,
           innovatonUse,
           initiative_expected_investment,
@@ -788,7 +780,11 @@ export class InnovationDevService {
 
   private async _persistInnovationDevEntity(
     resultInnovationDevId: number,
-    fields: Partial<ResultsInnovationsDev>,
+    fields: Partial<ResultsInnovationsDev> & {
+      innovation_readiness_level_id?: number | null;
+      innovation_nature_id?: number | null;
+      innovation_characterization_id?: number | null;
+    },
     userId: number,
   ): Promise<ResultsInnovationsDev> {
     const entity = await this._resultsInnovationsDevRepository.findOne({
@@ -811,7 +807,95 @@ export class InnovationDevService {
       ...scalarFields
     } = fields;
 
-    Object.assign(entity, scalarFields, { last_updated_by: userId });
+    const scalarUpdate = this._pickDefinedFields({
+      ...scalarFields,
+      last_updated_by: userId,
+    });
+
+    Object.assign(entity, scalarUpdate);
+
+    this._applyInnovationDevRelations(entity, {
+      innovation_readiness_level_id,
+      innovation_nature_id,
+      innovation_characterization_id,
+    });
+
+    return this._resultsInnovationsDevRepository.save(entity);
+  }
+
+  private _buildInnovationDevFieldsFromDto(
+    dto: CreateInnovationDevDtoV2,
+  ): Partial<ResultsInnovationsDev> & {
+    innovation_readiness_level_id?: number | null;
+    innovation_nature_id?: number | null;
+    innovation_characterization_id?: number | null;
+  } {
+    const fieldNames = [
+      'short_title',
+      'is_new_variety',
+      'readiness_level',
+      'number_of_varieties',
+      'innovation_nature_id',
+      'innovation_developers',
+      'evidences_justification',
+      'innovation_collaborators',
+      'innovation_readiness_level_id',
+      'innovation_characterization_id',
+      'innovation_acknowledgement',
+      'innovation_pdf',
+      'innovation_user_to_be_determined',
+      'has_scaling_studies',
+      'ip_support_center_id',
+    ] as const;
+
+    const fields: Partial<ResultsInnovationsDev> & {
+      innovation_readiness_level_id?: number | null;
+      innovation_nature_id?: number | null;
+      innovation_characterization_id?: number | null;
+    } = {};
+
+    for (const fieldName of fieldNames) {
+      if (dto[fieldName] !== undefined) {
+        fields[fieldName] = dto[fieldName] as never;
+      }
+    }
+
+    return fields;
+  }
+
+  private _pickDefinedFields<T extends Record<string, unknown>>(
+    fields: T,
+  ): Partial<T> {
+    return Object.fromEntries(
+      Object.entries(fields).filter(([, value]) => value !== undefined),
+    ) as Partial<T>;
+  }
+
+  private _normalizeInnovationDevRecord<T extends { is_new_variety?: unknown }>(
+    record: T,
+  ): T {
+    return {
+      ...record,
+      is_new_variety:
+        record?.is_new_variety == null
+          ? null
+          : Boolean(Number(record.is_new_variety)),
+    };
+  }
+
+  private _applyInnovationDevRelations(
+    entity: ResultsInnovationsDev,
+    relations: {
+      innovation_readiness_level_id?: number | null;
+      innovation_nature_id?: number | null;
+      innovation_characterization_id?: number | null;
+    },
+  ): void {
+    const {
+      innovation_readiness_level_id,
+      innovation_nature_id,
+      innovation_characterization_id,
+    } = relations;
 
     if (innovation_readiness_level_id !== undefined) {
       entity.innovation_readiness_level =
@@ -833,8 +917,6 @@ export class InnovationDevService {
           ? null
           : ({ id: innovation_characterization_id } as any);
     }
-
-    return this._resultsInnovationsDevRepository.save(entity);
   }
 
   private _hasBudgetFields(

--- a/onecgiar-pr-server/src/api/results-framework-reporting/innovation_dev/innovation_dev.service.ts
+++ b/onecgiar-pr-server/src/api/results-framework-reporting/innovation_dev/innovation_dev.service.ts
@@ -93,27 +93,26 @@ export class InnovationDevService {
 
       let InnDevRes: ResultsInnovationsDev = undefined;
       if (innDevExists) {
-        innDevExists.short_title = short_title;
-        innDevExists.last_updated_by = user.id;
-        innDevExists.is_new_variety = is_new_variety;
-        innDevExists.readiness_level = readiness_level;
-        innDevExists.number_of_varieties = number_of_varieties;
-        innDevExists.innovation_nature_id = innovation_nature_id;
-        innDevExists.innovation_developers = innovation_developers;
-        innDevExists.evidences_justification = evidences_justification;
-        innDevExists.innovation_collaborators = innovation_collaborators;
-        innDevExists.innovation_readiness_level_id =
-          innovation_readiness_level_id;
-        innDevExists.innovation_characterization_id =
-          innovation_characterization_id;
-        innDevExists.innovation_acknowledgement = innovation_acknowledgement;
-        innDevExists.innovation_pdf = innovation_pdf;
-        innDevExists.innovation_user_to_be_determined =
-          innovation_user_to_be_determined;
-        innDevExists.has_scaling_studies = has_scaling_studies;
-        innDevExists.ip_support_center_id = ip_support_center_id;
-        InnDevRes = await this._resultsInnovationsDevRepository.save(
-          innDevExists as any,
+        InnDevRes = await this._persistInnovationDevEntity(
+          innDevExists.result_innovation_dev_id,
+          {
+            short_title,
+            is_new_variety,
+            readiness_level,
+            number_of_varieties,
+            innovation_nature_id,
+            innovation_developers,
+            evidences_justification,
+            innovation_collaborators,
+            innovation_readiness_level_id,
+            innovation_characterization_id,
+            innovation_acknowledgement,
+            innovation_pdf,
+            innovation_user_to_be_determined,
+            has_scaling_studies,
+            ip_support_center_id,
+          },
+          user.id,
         );
       } else {
         const newInnDev = new ResultsInnovationsDev();
@@ -745,29 +744,31 @@ export class InnovationDevService {
         };
       }
 
+      const partialUpdate: Partial<ResultsInnovationsDev> = {};
+
       if (innovationDevDto.innovation_nature_id !== undefined) {
-        innDevExists.innovation_nature_id =
+        partialUpdate.innovation_nature_id =
           innovationDevDto.innovation_nature_id;
       }
 
       if (innovationDevDto.innovation_developers !== undefined) {
-        innDevExists.innovation_developers =
+        partialUpdate.innovation_developers =
           innovationDevDto.innovation_developers;
       }
 
       if (innovationDevDto.innovation_readiness_level_id !== undefined) {
-        innDevExists.innovation_readiness_level_id =
+        partialUpdate.innovation_readiness_level_id =
           innovationDevDto.innovation_readiness_level_id;
       }
 
       if (innovationDevDto.level !== undefined) {
-        innDevExists.readiness_level = innovationDevDto.level;
+        partialUpdate.readiness_level = innovationDevDto.level;
       }
 
-      innDevExists.last_updated_by = user.id;
-
-      const updatedInnDev = await this._resultsInnovationsDevRepository.save(
-        innDevExists as any,
+      const updatedInnDev = await this._persistInnovationDevEntity(
+        innDevExists.result_innovation_dev_id,
+        partialUpdate,
+        user.id,
       );
 
       // Update or delete project budgets only if budget-related fields are present
@@ -783,6 +784,57 @@ export class InnovationDevService {
     } catch (error) {
       return this._handlersError.returnErrorRes({ error, debug: true });
     }
+  }
+
+  private async _persistInnovationDevEntity(
+    resultInnovationDevId: number,
+    fields: Partial<ResultsInnovationsDev>,
+    userId: number,
+  ): Promise<ResultsInnovationsDev> {
+    const entity = await this._resultsInnovationsDevRepository.findOne({
+      where: {
+        result_innovation_dev_id: resultInnovationDevId,
+        is_active: true,
+      },
+    });
+
+    if (!entity) {
+      throw new NotFoundException({
+        message: `Innovation development record ${resultInnovationDevId} not found`,
+      });
+    }
+
+    const {
+      innovation_readiness_level_id,
+      innovation_nature_id,
+      innovation_characterization_id,
+      ...scalarFields
+    } = fields;
+
+    Object.assign(entity, scalarFields, { last_updated_by: userId });
+
+    if (innovation_readiness_level_id !== undefined) {
+      entity.innovation_readiness_level =
+        innovation_readiness_level_id == null
+          ? null
+          : ({ id: innovation_readiness_level_id } as any);
+    }
+
+    if (innovation_nature_id !== undefined) {
+      entity.innovation_nature =
+        innovation_nature_id == null
+          ? null
+          : ({ code: innovation_nature_id } as any);
+    }
+
+    if (innovation_characterization_id !== undefined) {
+      entity.innovation_characterization =
+        innovation_characterization_id == null
+          ? null
+          : ({ id: innovation_characterization_id } as any);
+    }
+
+    return this._resultsInnovationsDevRepository.save(entity);
   }
 
   private _hasBudgetFields(

--- a/openspec/changes/p2-3056-evidence-green-check/.openspec.yaml
+++ b/openspec/changes/p2-3056-evidence-green-check/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-18

--- a/openspec/changes/p2-3056-evidence-green-check/design.md
+++ b/openspec/changes/p2-3056-evidence-green-check/design.md
@@ -1,0 +1,56 @@
+## Context
+
+The Evidence section (`rd-evidences.component`) shows a local completeness flag via the `appFeedbackValidation` directive. Today the gate is:
+
+```html
+[isComplete]="this.evidencesBody.evidences.length > 0 || this.dataControlSE.currentResult?.result_type_id == 5"
+```
+
+So the green check flips as soon as one evidence exists, regardless of mandatory marker/readiness evidence. Meanwhile the component already computes the missing-evidence conditions, but only to render yellow warnings:
+
+- `validateCheckBoxes()` returns a non-empty HTML string when any Impact-Area marker at Principal level (`*_tag_level === '3'`) lacks tagged evidence; empty string means all Principal markers are covered.
+- `validateHasInnoReadinessLevelEvidence()` returns `true` when readiness is optional (level 0 / `isOptionalReadinessLevel`) or there is at least one `innovation_readiness_related` evidence; `false` when readiness is mandatory but missing.
+
+The backend green-check (`onecgiar-pr-server/.../results-validation-module.repository.ts` → `evidenceValidation()`) already enforces the same three rules in raw SQL (markers `tag_level_id = 3`; readiness for `result_type_id = 7`, level ≠ 0; type 5 exempt). The bug is purely the client's local flag being more permissive than the rules.
+
+Requirements confirmed with reporter Santiago Sánchez via Slack on 2026-06-18.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the client Evidence green check honor: base evidence presence + Principal-marker evidence (all types) + Innovation-Readiness evidence (Innovation Development, readiness 1–9).
+- Rename the five Impact-Area checkbox labels to canonical names, without changing field bindings.
+- Reuse the existing validation helpers so the gate and the warnings stay in sync.
+
+**Non-Goals:**
+- No backend changes — the server validation already implements these rules.
+- No change to the warning messages (already correct), to evidence creation/deletion, or to other evidence labels (those belong to `p2-2981`).
+- No change to the `youth_related` ↔ Climate mapping.
+
+## Decisions
+
+**Decision 1 — Reuse existing helpers in `isComplete` instead of new logic.**
+Extend the Evidence `isComplete` to:
+`evidences.length > 0 (or type 5)` **AND** `validateCheckBoxes()` is empty **AND** `validateHasInnoReadinessLevelEvidence()` is true.
+Rationale: the helpers already encode the exact rules and already drive the warnings; reusing them guarantees the green check and the yellow alerts never disagree. Alternative (re-deriving the conditions inline) was rejected as duplicate, drift-prone logic.
+To keep the template readable, expose a single getter (e.g. `get evidenceSectionComplete()`) on the component that combines the three conditions, and bind `[isComplete]` to it.
+
+**Decision 2 — Labels changed only in the two display spots.**
+Update the `tagFields` label strings (`rd-evidences.component.ts`) and the five `app-pr-checkbox` labels (`evidence-item.component.html`). `getSelectedImpactTags()` derives the read-only chips from `tagFields`, so the chips update automatically. Bindings/`field` keys are untouched.
+
+**Decision 3 — Verify where the user-visible check is sourced before claiming the fix.**
+The side-menu check is painted from the backend green-check; the in-section flag is the client `isComplete`. During verification, confirm which one the user saw turning green prematurely, so the fix demonstrably closes the reported bug. If the backend value already blocks correctly, the client fix removes the visual inconsistency; if the side menu also relied on the client flag, the same fix covers it.
+
+## Risks / Trade-offs
+
+- [Calling `validateCheckBoxes()` from a getter bound in the template runs it on each change detection] → It is a light array scan over ≤6 evidences and a 5-element list; negligible. Avoid heavier work in the getter.
+- [`isOptionalReadinessLevel` must be correctly populated for non-Innovation-Development types so readiness never blocks them] → The readiness rule is already guarded by `result_type_id === 7` in the template alert; mirror that guard in the getter so non-Innovation-Development results are never blocked by readiness.
+- [Client gate could diverge from backend SQL if rules change later] → Both now reflect the same rules; document the coupling in the spec so future edits update both.
+
+## Migration Plan
+
+Pure frontend change, no migrations. Deploy with the client build. Rollback = revert the commit; no data impact.
+
+## Open Questions
+
+- Confirm during verification whether the reported premature green check is the in-section flag, the side-menu (backend) check, or both. (To be answered by manual testing on prtest/local before closing.)

--- a/openspec/changes/p2-3056-evidence-green-check/proposal.md
+++ b/openspec/changes/p2-3056-evidence-green-check/proposal.md
@@ -33,6 +33,7 @@ In the Evidence section the green check turns valid as soon as **any** single pi
   - `pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.html` — line 101 `[isComplete]` of the Evidence `appFeedbackValidation` block: extend the condition with the existing validation helpers.
   - `pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.ts` — `tagFields` array labels (5 Impact-Area entries); possibly expose a small getter to keep the template condition readable.
   - `pages/results/pages/result-detail/pages/rd-evidences/evidence-item/evidence-item.component.html` — the five `app-pr-checkbox` labels.
+  - `pages/results/pages/result-detail/pages/rd-result-types-pages/innovation-dev-info/components/user-evidence/user-evidence.component.html` — the same five `app-pr-checkbox` labels (separate copy used by Innovation Development results).
   - Specs: `rd-evidences.component.spec.ts` (green-check gate), `evidence-item.component.spec.ts` (labels).
 - **No backend changes**: server green-check (`onecgiar-pr-server/.../results-validation-module.repository.ts`, `evidenceValidation()`) already enforces these rules in SQL (markers `tag_level_id = 3`; readiness for result_type 7, level ≠ 0). Server is read-only for this change.
 - No API contract changes, no migrations.

--- a/openspec/changes/p2-3056-evidence-green-check/proposal.md
+++ b/openspec/changes/p2-3056-evidence-green-check/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+In the Evidence section the green check turns valid as soon as **any** single piece of evidence is uploaded, even when mandatory marker- or readiness-specific evidence is still missing. This lets users mark a result as "done" without the evidence the reporting rules actually require, which is the bug reported in **P2-3056** (child of P2-3012, *Open Phase Step 1 — open PRMS 2026 phase*). Requirements were confirmed with the reporter, Santiago Sánchez, over Slack on 2026-06-18. Separately, the five Impact-Area checkbox labels still show the old short names while the rest of the section (alerts) already uses the new canonical Impact-Area names.
+
+**Scope: frontend-only.** The backend green-check (`results-validation-module.repository.ts`, raw SQL) already enforces all three completeness rules below; the defect is that the client's local `isComplete` flag for the Evidence section does not. No server change is required.
+
+## What Changes
+
+- **Block the Evidence green check** in the client so the section is only complete when ALL of these hold (today only the first is checked):
+  - at least one piece of evidence is uploaded;
+  - **AND** every Impact-Area marker set to **Principal (score 2 / `tag_level` 3)** in General Information has at least one piece of evidence tagged to it — applies to **all result types**;
+  - **AND** when the Innovation Development readiness field ("How would you assess the current readiness of this innovation?") is **1–9**, at least one Innovation-Readiness-tagged evidence exists — applies **only to Innovation Development** (readiness 0 = exempt).
+  - The blocking reuses the already-present `validateCheckBoxes()` and `validateHasInnoReadinessLevelEvidence()` helpers (today they only render yellow warnings without affecting `isComplete`).
+- **Rename the five Impact-Area checkbox labels** in the Evidence section to the canonical names (matching the alert text that already uses them):
+  - Gender → **Gender equality, youth and social inclusion**
+  - Climate change → **Climate adaptation and mitigation**
+  - Nutrition → **Nutrition, health and food security**
+  - Environment → **Environmental health and biodiversity**
+  - Poverty → **Poverty reduction, livelihoods and jobs**
+  - Label text only. The "Climate adaptation and mitigation" checkbox stays bound to the existing `youth_related` field (intentional historical column reuse) — **no binding change**.
+
+## Capabilities
+
+### New Capabilities
+- `evidence-green-check`: Defines when the Evidence section's local completeness flag (green check) is satisfied — base evidence presence plus mandatory marker-Principal evidence (all result types) and Innovation-Readiness evidence (Innovation Development, readiness 1–9). Also fixes the five Impact-Area checkbox labels to the canonical Impact-Area names.
+
+### Modified Capabilities
+- (none) — `evidence-alert-messaging` already standardized the alert wording on the new Impact-Area names; this change only aligns the checkbox labels and the local green-check gate with that behavior.
+
+## Impact
+
+- **Client only** (`onecgiar-pr-client`):
+  - `pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.html` — line 101 `[isComplete]` of the Evidence `appFeedbackValidation` block: extend the condition with the existing validation helpers.
+  - `pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.ts` — `tagFields` array labels (5 Impact-Area entries); possibly expose a small getter to keep the template condition readable.
+  - `pages/results/pages/result-detail/pages/rd-evidences/evidence-item/evidence-item.component.html` — the five `app-pr-checkbox` labels.
+  - Specs: `rd-evidences.component.spec.ts` (green-check gate), `evidence-item.component.spec.ts` (labels).
+- **No backend changes**: server green-check (`onecgiar-pr-server/.../results-validation-module.repository.ts`, `evidenceValidation()`) already enforces these rules in SQL (markers `tag_level_id = 3`; readiness for result_type 7, level ≠ 0). Server is read-only for this change.
+- No API contract changes, no migrations.
+- Verification must confirm whether the user-visible side-menu check is driven by the backend green-check, the client `isComplete`, or both, so the fix lands where the user actually sees the bug.
+- SDD baseline: behavior fits `docs/system-design/design.md` (Evidence section) and `docs/detailed-design/detailed-design.md` (results validation). Related changes: `p2-2981-evidence-labels-frontend` (other evidence labels, no overlap), spec `evidence-alert-messaging` (alert names).

--- a/openspec/changes/p2-3056-evidence-green-check/specs/evidence-green-check/spec.md
+++ b/openspec/changes/p2-3056-evidence-green-check/specs/evidence-green-check/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Evidence green check requires base evidence
+
+The Evidence section's local completeness flag (green check) SHALL NOT be satisfied unless at least one piece of evidence has been uploaded, except for result types that are exempt from evidence (Capacity Sharing for Development, result type 5), which remain complete with no evidence.
+
+#### Scenario: No evidence uploaded
+
+- **WHEN** a result that is not exempt has zero pieces of evidence
+- **THEN** the Evidence section green check is not satisfied (stays red)
+
+#### Scenario: Exempt result type with no evidence
+
+- **WHEN** the result type is Capacity Sharing for Development (type 5) and has zero pieces of evidence
+- **THEN** the Evidence section green check is satisfied
+
+### Requirement: Green check requires evidence for each Principal marker
+
+When an Impact-Area marker is set to Principal (score 2, `tag_level` value 3) in General Information, the Evidence section green check SHALL NOT be satisfied until at least one piece of evidence is tagged to that Impact Area. This rule applies to all result types.
+
+#### Scenario: Principal marker without tagged evidence
+
+- **WHEN** an Impact Area (e.g. Poverty reduction, livelihoods and jobs) is set to Principal score 2 and no uploaded evidence is tagged to that Impact Area
+- **THEN** the Evidence section green check is not satisfied (stays red)
+
+#### Scenario: Principal marker with tagged evidence
+
+- **WHEN** every Impact Area set to Principal score 2 has at least one piece of evidence tagged to it
+- **THEN** that marker rule no longer blocks the green check
+
+#### Scenario: Marker not at Principal level
+
+- **WHEN** an Impact Area is set to a level other than Principal (none, or significant) 
+- **THEN** that Impact Area does not require tagged evidence for the green check
+
+### Requirement: Green check requires Innovation Readiness evidence when applicable
+
+For Innovation Development results, when the readiness field ("How would you assess the current readiness of this innovation?") is set to a value between 1 and 9, the Evidence section green check SHALL NOT be satisfied until at least one piece of Innovation-Readiness-tagged evidence exists. When readiness is 0 (idea), no Innovation-Readiness evidence is required. This rule applies only to Innovation Development.
+
+#### Scenario: Readiness 1-9 without readiness evidence
+
+- **WHEN** an Innovation Development result has readiness level between 1 and 9 and no Innovation-Readiness-tagged evidence
+- **THEN** the Evidence section green check is not satisfied (stays red)
+
+#### Scenario: Readiness 0 exempts readiness evidence
+
+- **WHEN** an Innovation Development result has readiness level 0
+- **THEN** the Innovation-Readiness rule does not block the green check
+
+#### Scenario: Non-Innovation-Development result
+
+- **WHEN** the result is not an Innovation Development result
+- **THEN** the Innovation-Readiness rule does not apply to its green check
+
+### Requirement: Impact-Area checkbox labels use canonical names
+
+The five Impact-Area checkboxes in the Evidence section SHALL display the canonical Impact-Area names, matching the wording already used in the Evidence alerts.
+
+#### Scenario: Canonical labels shown
+
+- **WHEN** the Evidence section renders the Impact-Area checkboxes
+- **THEN** the labels read "Gender equality, youth and social inclusion", "Climate adaptation and mitigation", "Nutrition, health and food security", "Environmental health and biodiversity", and "Poverty reduction, livelihoods and jobs"
+
+#### Scenario: Climate checkbox binding unchanged
+
+- **WHEN** the user checks "Climate adaptation and mitigation"
+- **THEN** the value is stored against the existing `youth_related` evidence field (binding unchanged; only the label text changed)

--- a/openspec/changes/p2-3056-evidence-green-check/tasks.md
+++ b/openspec/changes/p2-3056-evidence-green-check/tasks.md
@@ -3,6 +3,7 @@
 - [x] 1.1 Update the five Impact-Area `label` strings in the `tagFields` array in `rd-evidences.component.ts` (Gender equality, youth and social inclusion / Climate adaptation and mitigation / Nutrition, health and food security / Environmental health and biodiversity / Poverty reduction, livelihoods and jobs) — keep `field` keys unchanged
 - [x] 1.2 Update the five `app-pr-checkbox` labels in `evidence-item.component.html` to the same canonical names — keep the `[(ngModel)]` bindings (incl. Climate → `youth_related`) unchanged
 - [x] 1.3 Confirm the read-only impact-tag chips (`getSelectedImpactTags()`) now render the canonical names automatically
+- [x] 1.4 Rename the same five labels in the Innovation Development evidence component `user-evidence.component.html` (separate checkbox copy used by Innovation Development results) — bindings unchanged
 
 ## 2. Block the Evidence green check
 

--- a/openspec/changes/p2-3056-evidence-green-check/tasks.md
+++ b/openspec/changes/p2-3056-evidence-green-check/tasks.md
@@ -1,0 +1,24 @@
+## 1. Rename Impact-Area checkbox labels
+
+- [x] 1.1 Update the five Impact-Area `label` strings in the `tagFields` array in `rd-evidences.component.ts` (Gender equality, youth and social inclusion / Climate adaptation and mitigation / Nutrition, health and food security / Environmental health and biodiversity / Poverty reduction, livelihoods and jobs) — keep `field` keys unchanged
+- [x] 1.2 Update the five `app-pr-checkbox` labels in `evidence-item.component.html` to the same canonical names — keep the `[(ngModel)]` bindings (incl. Climate → `youth_related`) unchanged
+- [x] 1.3 Confirm the read-only impact-tag chips (`getSelectedImpactTags()`) now render the canonical names automatically
+
+## 2. Block the Evidence green check
+
+- [x] 2.1 Add a getter on `rd-evidences.component.ts` (e.g. `evidenceSectionComplete`) combining: base evidence present (or result type 5) AND `validateCheckBoxes()` returns empty AND `validateHasInnoReadinessLevelEvidence()` is true; guard the readiness condition so it only applies to Innovation Development (result_type_id 7)
+- [x] 2.2 Bind `[isComplete]` of the Evidence `appFeedbackValidation` block (`rd-evidences.component.html:101`) to the new getter
+- [x] 2.3 Sanity-check that the yellow warnings and the green check now agree in all branches (no evidence, Principal marker missing, readiness 1–9 missing, readiness 0, type 5)
+
+## 3. Tests
+
+- [x] 3.1 Add/extend `rd-evidences.component.spec.ts`: green check blocked with no evidence; blocked when a Principal marker lacks tagged evidence; blocked when Innovation Development readiness is 1–9 without readiness evidence; satisfied when readiness is 0; satisfied for type 5 with no evidence; satisfied when all rules met
+- [x] 3.2 Add/extend `evidence-item.component.spec.ts` (or rd-evidences spec): the five checkboxes render the canonical labels (covered via `getSelectedImpactTags` test in rd-evidences spec)
+- [x] 3.3 Run `npm run test src/.../rd-evidences.component.spec.ts` and the evidence-item spec; ensure green — 46 + 29 passing
+
+## 4. Manual verification
+
+- [ ] 4.1 Run the client locally; on an Innovation Development result, confirm the Evidence green check stays red until base + Principal-marker + readiness evidence are provided, and turns green once all are met
+- [ ] 4.2 On a non-Innovation-Development result with a Principal marker, confirm the green check requires the marker evidence and is NOT blocked by readiness
+- [ ] 4.3 Confirm where the user-visible check (in-section flag vs side-menu/backend) was turning green prematurely, and that the fix closes the reported P2-3056 case; capture before/after screenshots into `onecgiar_pr/.local-screenshots/`
+- [ ] 4.4 Report results to reporter Santiago Sánchez (Slack) with the panorama and verification status


### PR DESCRIPTION
Refactor the InnovationDevInfoComponent to introduce a new method, normalizeInnovationDevBooleans, which standardizes the handling of boolean fields and ensures proper type conversion for innovation_nature_id. Additionally, update the InnovationDevService to streamline the persistence of innovation development records by consolidating field assignments into a dedicated method, _buildInnovationDevFieldsFromDto. This change improves code clarity and maintainability while ensuring consistent handling of innovation development data.

Introduce a centralized _persistInnovationDevEntity method that consolidates finding the active InnovationDev entity, mapping *_id fields to nested relation objects (innovation_nature, innovation_readiness_level, innovation_characterization), assigning scalar fields and last_updated_by, and saving the entity. Replace duplicated direct entity mutations in saveInnovationDev and updateInnovationDevPartial with calls to this helper. Update unit tests to DRY mock setup via setupPersistMocks, assert that findOne is called, and adjust expectations to the new nested relation shapes. Also include a minor formatting change to the constructor spacing.