### PR TITLE
🐛 fix(evidences) P2-3056: gate Evidence green check + rename impact-area labels

### DIFF
--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/evidence-item/evidence-item.component.html
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/evidence-item/evidence-item.component.html
@@ -105,11 +105,11 @@
     <div class="checkboxes_container" *ngIf="!isSuppInfo">
       <app-pr-field-header [label]="getEvidenceRelatedTitle()" [required]="false"></app-pr-field-header>
       <div class="checkboxes">
-        <app-pr-checkbox label="Gender" [(ngModel)]="this.evidence.gender_related"> </app-pr-checkbox>
-        <app-pr-checkbox label="Climate change" [(ngModel)]="this.evidence.youth_related"> </app-pr-checkbox>
-        <app-pr-checkbox label="Nutrition" [(ngModel)]="this.evidence.nutrition_related"> </app-pr-checkbox>
-        <app-pr-checkbox label="Environment" [(ngModel)]="this.evidence.environmental_biodiversity_related"> </app-pr-checkbox>
-        <app-pr-checkbox label="Poverty" [(ngModel)]="this.evidence.poverty_related"> </app-pr-checkbox>
+        <app-pr-checkbox label="Gender equality, youth and social inclusion" [(ngModel)]="this.evidence.gender_related"> </app-pr-checkbox>
+        <app-pr-checkbox label="Climate adaptation and mitigation" [(ngModel)]="this.evidence.youth_related"> </app-pr-checkbox>
+        <app-pr-checkbox label="Nutrition, health and food security" [(ngModel)]="this.evidence.nutrition_related"> </app-pr-checkbox>
+        <app-pr-checkbox label="Environmental health and biodiversity" [(ngModel)]="this.evidence.environmental_biodiversity_related"> </app-pr-checkbox>
+        <app-pr-checkbox label="Poverty reduction, livelihoods and jobs" [(ngModel)]="this.evidence.poverty_related"> </app-pr-checkbox>
         <app-pr-checkbox label="Innovation Development" [(ngModel)]="this.evidence.innovation_readiness_related" *ngIf="this.dataControlSE.isInnoDev">
         </app-pr-checkbox>
         <app-pr-checkbox label="Innovation Use" [(ngModel)]="this.evidence.innovation_use_related" *ngIf="this.dataControlSE.isInnoUse">

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.html
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.html
@@ -98,7 +98,7 @@
   <div
     appFeedbackValidation
     labelText="Evidence"
-    [isComplete]="this.evidencesBody.evidences.length > 0 || this.dataControlSE.currentResult?.result_type_id == 5"></div>
+    [isComplete]="this.evidenceSectionComplete"></div>
   <div appFeedbackValidation labelText="Empty, repeated or invalid link" [isComplete]="!this.validateButtonDisabled"></div>
 </div>
 

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.spec.ts
@@ -364,7 +364,7 @@ describe('RdEvidencesComponent', () => {
 
     it('getSelectedImpactTags returns labels of marked fields', () => {
       const tags = component.getSelectedImpactTags({ gender_related: true, youth_related: true });
-      expect(tags).toEqual(['Gender', 'Climate change']);
+      expect(tags).toEqual(['Gender equality, youth and social inclusion', 'Climate adaptation and mitigation']);
     });
 
     it('evidenceDisplayName prefers file name then link', () => {
@@ -560,6 +560,77 @@ describe('RdEvidencesComponent', () => {
       component.evidencesBody.evidences = [];
       const result = component.validateHasInnoReadinessLevelEvidence();
       expect(result).toBe(false);
+    });
+  });
+
+  describe('evidenceSectionComplete (P2-3056 green check)', () => {
+    // No Principal markers, no readiness requirement, no evidence → builds a baseline body.
+    const cleanBody = (evidences: any[] = []) => ({
+      result_id: 1,
+      gender_tag_level: null,
+      climate_change_tag_level: null,
+      nutrition_tag_level: null,
+      environmental_biodiversity_tag_level: null,
+      poverty_tag_level: null,
+      evidences
+    });
+    const setType = (id: number) => (mockApiService.dataControlSE.currentResult = { result_type_id: id });
+
+    it('is NOT complete for a non-exempt result with no evidence', () => {
+      setType(7);
+      component.isOptionalReadinessLevel = true;
+      component.evidencesBody = cleanBody([]);
+      expect(component.evidenceSectionComplete).toBe(false);
+    });
+
+    it('is complete for Capacity Sharing (type 5) with no evidence', () => {
+      setType(5);
+      component.evidencesBody = cleanBody([]);
+      expect(component.evidenceSectionComplete).toBe(true);
+    });
+
+    it('is NOT complete when a Principal marker (level 3) has no tagged evidence', () => {
+      setType(1);
+      const body = cleanBody([{ link: 'x', poverty_related: false }]);
+      body.poverty_tag_level = '3';
+      component.evidencesBody = body;
+      expect(component.evidenceSectionComplete).toBe(false);
+    });
+
+    it('is complete when every Principal marker has tagged evidence (non-Innovation-Development)', () => {
+      setType(1);
+      const body = cleanBody([{ link: 'x', poverty_related: true }]);
+      body.poverty_tag_level = '3';
+      component.evidencesBody = body;
+      expect(component.evidenceSectionComplete).toBe(true);
+    });
+
+    it('is NOT complete for Innovation Development (type 7) with readiness 1-9 and no readiness evidence', () => {
+      setType(7);
+      component.isOptionalReadinessLevel = false;
+      component.evidencesBody = cleanBody([{ link: 'x', innovation_readiness_related: false }]);
+      expect(component.evidenceSectionComplete).toBe(false);
+    });
+
+    it('is complete for Innovation Development with readiness 0 (exempt) and base evidence', () => {
+      setType(7);
+      component.isOptionalReadinessLevel = true;
+      component.evidencesBody = cleanBody([{ link: 'x' }]);
+      expect(component.evidenceSectionComplete).toBe(true);
+    });
+
+    it('is complete for Innovation Development when all rules are satisfied', () => {
+      setType(7);
+      component.isOptionalReadinessLevel = false;
+      component.evidencesBody = cleanBody([{ link: 'x', innovation_readiness_related: true }]);
+      expect(component.evidenceSectionComplete).toBe(true);
+    });
+
+    it('does not apply the readiness rule to non-Innovation-Development results', () => {
+      setType(1);
+      component.isOptionalReadinessLevel = false; // would block if it applied
+      component.evidencesBody = cleanBody([{ link: 'x' }]);
+      expect(component.evidenceSectionComplete).toBe(true);
     });
   });
 });

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.ts
@@ -27,11 +27,11 @@ export class RdEvidencesComponent implements OnInit {
   // Impact-area + typology fields surfaced as tags in the collapsed accordion header.
   // (Note: the "Climate change" checkbox is bound to youth_related, matching the existing form.)
   private readonly tagFields: { field: keyof EvidencesCreateInterface; label: string }[] = [
-    { field: 'gender_related', label: 'Gender' },
-    { field: 'youth_related', label: 'Climate change' },
-    { field: 'nutrition_related', label: 'Nutrition' },
-    { field: 'environmental_biodiversity_related', label: 'Environment' },
-    { field: 'poverty_related', label: 'Poverty' },
+    { field: 'gender_related', label: 'Gender equality, youth and social inclusion' },
+    { field: 'youth_related', label: 'Climate adaptation and mitigation' },
+    { field: 'nutrition_related', label: 'Nutrition, health and food security' },
+    { field: 'environmental_biodiversity_related', label: 'Environmental health and biodiversity' },
+    { field: 'poverty_related', label: 'Poverty reduction, livelihoods and jobs' },
     { field: 'innovation_readiness_related', label: 'Innovation Development' },
     { field: 'innovation_use_related', label: 'Innovation Use' },
     { field: 'policy_change_related', label: 'Policy Change' },
@@ -295,6 +295,19 @@ export class RdEvidencesComponent implements OnInit {
     if (this.isOptionalReadinessLevel) return true;
 
     return this.evidencesBody.evidences.some(evidence => evidence.innovation_readiness_related);
+  }
+
+  // P2-3056: the Evidence green check must stay red until ALL mandatory evidence is present:
+  // (1) at least one piece of evidence (type 5 is exempt),
+  // (2) evidence for every Impact-Area marker set to Principal (validateCheckBoxes() returns '' when covered),
+  // (3) Innovation-Readiness evidence when the readiness level is 1-9 (Innovation Development, type 7, only).
+  // Reuses the same helpers that drive the yellow warnings so the check and the alerts never disagree.
+  get evidenceSectionComplete(): boolean {
+    const resultTypeId = this.api.dataControlSE.currentResult?.result_type_id;
+    const hasBaseEvidence = this.evidencesBody.evidences.length > 0 || resultTypeId == 5;
+    const markersCovered = !this.validateCheckBoxes();
+    const readinessCovered = resultTypeId !== 7 || this.validateHasInnoReadinessLevelEvidence();
+    return hasBaseEvidence && markersCovered && readinessCovered;
   }
 
   get validateButtonDisabled() {

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-result-types-pages/innovation-dev-info/components/user-evidence/user-evidence.component.html
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-result-types-pages/innovation-dev-info/components/user-evidence/user-evidence.component.html
@@ -105,11 +105,11 @@
 
     <app-pr-field-header [label]="getEvidenceRelatedTitle()" [required]="false" *ngIf="!isSuppInfo"></app-pr-field-header>
     <div class="checkboxes" *ngIf="!isSuppInfo">
-      <app-pr-checkbox label="Gender" [(ngModel)]="this.evidence.gender_related"> </app-pr-checkbox>
-      <app-pr-checkbox label="Climate change" [(ngModel)]="this.evidence.youth_related"> </app-pr-checkbox>
-      <app-pr-checkbox label="Nutrition" [(ngModel)]="this.evidence.nutrition_related"> </app-pr-checkbox>
-      <app-pr-checkbox label="Environment" [(ngModel)]="this.evidence.environmental_biodiversity_related"> </app-pr-checkbox>
-      <app-pr-checkbox label="Poverty" [(ngModel)]="this.evidence.poverty_related"> </app-pr-checkbox>
+      <app-pr-checkbox label="Gender equality, youth and social inclusion" [(ngModel)]="this.evidence.gender_related"> </app-pr-checkbox>
+      <app-pr-checkbox label="Climate adaptation and mitigation" [(ngModel)]="this.evidence.youth_related"> </app-pr-checkbox>
+      <app-pr-checkbox label="Nutrition, health and food security" [(ngModel)]="this.evidence.nutrition_related"> </app-pr-checkbox>
+      <app-pr-checkbox label="Environmental health and biodiversity" [(ngModel)]="this.evidence.environmental_biodiversity_related"> </app-pr-checkbox>
+      <app-pr-checkbox label="Poverty reduction, livelihoods and jobs" [(ngModel)]="this.evidence.poverty_related"> </app-pr-checkbox>
       <app-pr-checkbox label="Innovation Development" [(ngModel)]="this.evidence.innovation_readiness_related" *ngIf="this.dataControlSE.isInnoDev">
       </app-pr-checkbox>
       <app-pr-checkbox label="Innovation Use" [(ngModel)]="this.evidence.innovation_use_related" *ngIf="this.dataControlSE.isInnoUse">

--- a/openspec/changes/p2-3056-evidence-green-check/.openspec.yaml
+++ b/openspec/changes/p2-3056-evidence-green-check/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-18

--- a/openspec/changes/p2-3056-evidence-green-check/design.md
+++ b/openspec/changes/p2-3056-evidence-green-check/design.md
@@ -1,0 +1,56 @@
+## Context
+
+The Evidence section (`rd-evidences.component`) shows a local completeness flag via the `appFeedbackValidation` directive. Today the gate is:
+
+```html
+[isComplete]="this.evidencesBody.evidences.length > 0 || this.dataControlSE.currentResult?.result_type_id == 5"
+```
+
+So the green check flips as soon as one evidence exists, regardless of mandatory marker/readiness evidence. Meanwhile the component already computes the missing-evidence conditions, but only to render yellow warnings:
+
+- `validateCheckBoxes()` returns a non-empty HTML string when any Impact-Area marker at Principal level (`*_tag_level === '3'`) lacks tagged evidence; empty string means all Principal markers are covered.
+- `validateHasInnoReadinessLevelEvidence()` returns `true` when readiness is optional (level 0 / `isOptionalReadinessLevel`) or there is at least one `innovation_readiness_related` evidence; `false` when readiness is mandatory but missing.
+
+The backend green-check (`onecgiar-pr-server/.../results-validation-module.repository.ts` → `evidenceValidation()`) already enforces the same three rules in raw SQL (markers `tag_level_id = 3`; readiness for `result_type_id = 7`, level ≠ 0; type 5 exempt). The bug is purely the client's local flag being more permissive than the rules.
+
+Requirements confirmed with reporter Santiago Sánchez via Slack on 2026-06-18.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the client Evidence green check honor: base evidence presence + Principal-marker evidence (all types) + Innovation-Readiness evidence (Innovation Development, readiness 1–9).
+- Rename the five Impact-Area checkbox labels to canonical names, without changing field bindings.
+- Reuse the existing validation helpers so the gate and the warnings stay in sync.
+
+**Non-Goals:**
+- No backend changes — the server validation already implements these rules.
+- No change to the warning messages (already correct), to evidence creation/deletion, or to other evidence labels (those belong to `p2-2981`).
+- No change to the `youth_related` ↔ Climate mapping.
+
+## Decisions
+
+**Decision 1 — Reuse existing helpers in `isComplete` instead of new logic.**
+Extend the Evidence `isComplete` to:
+`evidences.length > 0 (or type 5)` **AND** `validateCheckBoxes()` is empty **AND** `validateHasInnoReadinessLevelEvidence()` is true.
+Rationale: the helpers already encode the exact rules and already drive the warnings; reusing them guarantees the green check and the yellow alerts never disagree. Alternative (re-deriving the conditions inline) was rejected as duplicate, drift-prone logic.
+To keep the template readable, expose a single getter (e.g. `get evidenceSectionComplete()`) on the component that combines the three conditions, and bind `[isComplete]` to it.
+
+**Decision 2 — Labels changed only in the two display spots.**
+Update the `tagFields` label strings (`rd-evidences.component.ts`) and the five `app-pr-checkbox` labels (`evidence-item.component.html`). `getSelectedImpactTags()` derives the read-only chips from `tagFields`, so the chips update automatically. Bindings/`field` keys are untouched.
+
+**Decision 3 — Verify where the user-visible check is sourced before claiming the fix.**
+The side-menu check is painted from the backend green-check; the in-section flag is the client `isComplete`. During verification, confirm which one the user saw turning green prematurely, so the fix demonstrably closes the reported bug. If the backend value already blocks correctly, the client fix removes the visual inconsistency; if the side menu also relied on the client flag, the same fix covers it.
+
+## Risks / Trade-offs
+
+- [Calling `validateCheckBoxes()` from a getter bound in the template runs it on each change detection] → It is a light array scan over ≤6 evidences and a 5-element list; negligible. Avoid heavier work in the getter.
+- [`isOptionalReadinessLevel` must be correctly populated for non-Innovation-Development types so readiness never blocks them] → The readiness rule is already guarded by `result_type_id === 7` in the template alert; mirror that guard in the getter so non-Innovation-Development results are never blocked by readiness.
+- [Client gate could diverge from backend SQL if rules change later] → Both now reflect the same rules; document the coupling in the spec so future edits update both.
+
+## Migration Plan
+
+Pure frontend change, no migrations. Deploy with the client build. Rollback = revert the commit; no data impact.
+
+## Open Questions
+
+- Confirm during verification whether the reported premature green check is the in-section flag, the side-menu (backend) check, or both. (To be answered by manual testing on prtest/local before closing.)

--- a/openspec/changes/p2-3056-evidence-green-check/proposal.md
+++ b/openspec/changes/p2-3056-evidence-green-check/proposal.md
@@ -33,6 +33,7 @@ In the Evidence section the green check turns valid as soon as **any** single pi
   - `pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.html` — line 101 `[isComplete]` of the Evidence `appFeedbackValidation` block: extend the condition with the existing validation helpers.
   - `pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.ts` — `tagFields` array labels (5 Impact-Area entries); possibly expose a small getter to keep the template condition readable.
   - `pages/results/pages/result-detail/pages/rd-evidences/evidence-item/evidence-item.component.html` — the five `app-pr-checkbox` labels.
+  - `pages/results/pages/result-detail/pages/rd-result-types-pages/innovation-dev-info/components/user-evidence/user-evidence.component.html` — the same five `app-pr-checkbox` labels (separate copy used by Innovation Development results).
   - Specs: `rd-evidences.component.spec.ts` (green-check gate), `evidence-item.component.spec.ts` (labels).
 - **No backend changes**: server green-check (`onecgiar-pr-server/.../results-validation-module.repository.ts`, `evidenceValidation()`) already enforces these rules in SQL (markers `tag_level_id = 3`; readiness for result_type 7, level ≠ 0). Server is read-only for this change.
 - No API contract changes, no migrations.

--- a/openspec/changes/p2-3056-evidence-green-check/proposal.md
+++ b/openspec/changes/p2-3056-evidence-green-check/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+In the Evidence section the green check turns valid as soon as **any** single piece of evidence is uploaded, even when mandatory marker- or readiness-specific evidence is still missing. This lets users mark a result as "done" without the evidence the reporting rules actually require, which is the bug reported in **P2-3056** (child of P2-3012, *Open Phase Step 1 — open PRMS 2026 phase*). Requirements were confirmed with the reporter, Santiago Sánchez, over Slack on 2026-06-18. Separately, the five Impact-Area checkbox labels still show the old short names while the rest of the section (alerts) already uses the new canonical Impact-Area names.
+
+**Scope: frontend-only.** The backend green-check (`results-validation-module.repository.ts`, raw SQL) already enforces all three completeness rules below; the defect is that the client's local `isComplete` flag for the Evidence section does not. No server change is required.
+
+## What Changes
+
+- **Block the Evidence green check** in the client so the section is only complete when ALL of these hold (today only the first is checked):
+  - at least one piece of evidence is uploaded;
+  - **AND** every Impact-Area marker set to **Principal (score 2 / `tag_level` 3)** in General Information has at least one piece of evidence tagged to it — applies to **all result types**;
+  - **AND** when the Innovation Development readiness field ("How would you assess the current readiness of this innovation?") is **1–9**, at least one Innovation-Readiness-tagged evidence exists — applies **only to Innovation Development** (readiness 0 = exempt).
+  - The blocking reuses the already-present `validateCheckBoxes()` and `validateHasInnoReadinessLevelEvidence()` helpers (today they only render yellow warnings without affecting `isComplete`).
+- **Rename the five Impact-Area checkbox labels** in the Evidence section to the canonical names (matching the alert text that already uses them):
+  - Gender → **Gender equality, youth and social inclusion**
+  - Climate change → **Climate adaptation and mitigation**
+  - Nutrition → **Nutrition, health and food security**
+  - Environment → **Environmental health and biodiversity**
+  - Poverty → **Poverty reduction, livelihoods and jobs**
+  - Label text only. The "Climate adaptation and mitigation" checkbox stays bound to the existing `youth_related` field (intentional historical column reuse) — **no binding change**.
+
+## Capabilities
+
+### New Capabilities
+- `evidence-green-check`: Defines when the Evidence section's local completeness flag (green check) is satisfied — base evidence presence plus mandatory marker-Principal evidence (all result types) and Innovation-Readiness evidence (Innovation Development, readiness 1–9). Also fixes the five Impact-Area checkbox labels to the canonical Impact-Area names.
+
+### Modified Capabilities
+- (none) — `evidence-alert-messaging` already standardized the alert wording on the new Impact-Area names; this change only aligns the checkbox labels and the local green-check gate with that behavior.
+
+## Impact
+
+- **Client only** (`onecgiar-pr-client`):
+  - `pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.html` — line 101 `[isComplete]` of the Evidence `appFeedbackValidation` block: extend the condition with the existing validation helpers.
+  - `pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.ts` — `tagFields` array labels (5 Impact-Area entries); possibly expose a small getter to keep the template condition readable.
+  - `pages/results/pages/result-detail/pages/rd-evidences/evidence-item/evidence-item.component.html` — the five `app-pr-checkbox` labels.
+  - Specs: `rd-evidences.component.spec.ts` (green-check gate), `evidence-item.component.spec.ts` (labels).
+- **No backend changes**: server green-check (`onecgiar-pr-server/.../results-validation-module.repository.ts`, `evidenceValidation()`) already enforces these rules in SQL (markers `tag_level_id = 3`; readiness for result_type 7, level ≠ 0). Server is read-only for this change.
+- No API contract changes, no migrations.
+- Verification must confirm whether the user-visible side-menu check is driven by the backend green-check, the client `isComplete`, or both, so the fix lands where the user actually sees the bug.
+- SDD baseline: behavior fits `docs/system-design/design.md` (Evidence section) and `docs/detailed-design/detailed-design.md` (results validation). Related changes: `p2-2981-evidence-labels-frontend` (other evidence labels, no overlap), spec `evidence-alert-messaging` (alert names).

--- a/openspec/changes/p2-3056-evidence-green-check/specs/evidence-green-check/spec.md
+++ b/openspec/changes/p2-3056-evidence-green-check/specs/evidence-green-check/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Evidence green check requires base evidence
+
+The Evidence section's local completeness flag (green check) SHALL NOT be satisfied unless at least one piece of evidence has been uploaded, except for result types that are exempt from evidence (Capacity Sharing for Development, result type 5), which remain complete with no evidence.
+
+#### Scenario: No evidence uploaded
+
+- **WHEN** a result that is not exempt has zero pieces of evidence
+- **THEN** the Evidence section green check is not satisfied (stays red)
+
+#### Scenario: Exempt result type with no evidence
+
+- **WHEN** the result type is Capacity Sharing for Development (type 5) and has zero pieces of evidence
+- **THEN** the Evidence section green check is satisfied
+
+### Requirement: Green check requires evidence for each Principal marker
+
+When an Impact-Area marker is set to Principal (score 2, `tag_level` value 3) in General Information, the Evidence section green check SHALL NOT be satisfied until at least one piece of evidence is tagged to that Impact Area. This rule applies to all result types.
+
+#### Scenario: Principal marker without tagged evidence
+
+- **WHEN** an Impact Area (e.g. Poverty reduction, livelihoods and jobs) is set to Principal score 2 and no uploaded evidence is tagged to that Impact Area
+- **THEN** the Evidence section green check is not satisfied (stays red)
+
+#### Scenario: Principal marker with tagged evidence
+
+- **WHEN** every Impact Area set to Principal score 2 has at least one piece of evidence tagged to it
+- **THEN** that marker rule no longer blocks the green check
+
+#### Scenario: Marker not at Principal level
+
+- **WHEN** an Impact Area is set to a level other than Principal (none, or significant) 
+- **THEN** that Impact Area does not require tagged evidence for the green check
+
+### Requirement: Green check requires Innovation Readiness evidence when applicable
+
+For Innovation Development results, when the readiness field ("How would you assess the current readiness of this innovation?") is set to a value between 1 and 9, the Evidence section green check SHALL NOT be satisfied until at least one piece of Innovation-Readiness-tagged evidence exists. When readiness is 0 (idea), no Innovation-Readiness evidence is required. This rule applies only to Innovation Development.
+
+#### Scenario: Readiness 1-9 without readiness evidence
+
+- **WHEN** an Innovation Development result has readiness level between 1 and 9 and no Innovation-Readiness-tagged evidence
+- **THEN** the Evidence section green check is not satisfied (stays red)
+
+#### Scenario: Readiness 0 exempts readiness evidence
+
+- **WHEN** an Innovation Development result has readiness level 0
+- **THEN** the Innovation-Readiness rule does not block the green check
+
+#### Scenario: Non-Innovation-Development result
+
+- **WHEN** the result is not an Innovation Development result
+- **THEN** the Innovation-Readiness rule does not apply to its green check
+
+### Requirement: Impact-Area checkbox labels use canonical names
+
+The five Impact-Area checkboxes in the Evidence section SHALL display the canonical Impact-Area names, matching the wording already used in the Evidence alerts.
+
+#### Scenario: Canonical labels shown
+
+- **WHEN** the Evidence section renders the Impact-Area checkboxes
+- **THEN** the labels read "Gender equality, youth and social inclusion", "Climate adaptation and mitigation", "Nutrition, health and food security", "Environmental health and biodiversity", and "Poverty reduction, livelihoods and jobs"
+
+#### Scenario: Climate checkbox binding unchanged
+
+- **WHEN** the user checks "Climate adaptation and mitigation"
+- **THEN** the value is stored against the existing `youth_related` evidence field (binding unchanged; only the label text changed)

--- a/openspec/changes/p2-3056-evidence-green-check/tasks.md
+++ b/openspec/changes/p2-3056-evidence-green-check/tasks.md
@@ -3,6 +3,7 @@
 - [x] 1.1 Update the five Impact-Area `label` strings in the `tagFields` array in `rd-evidences.component.ts` (Gender equality, youth and social inclusion / Climate adaptation and mitigation / Nutrition, health and food security / Environmental health and biodiversity / Poverty reduction, livelihoods and jobs) — keep `field` keys unchanged
 - [x] 1.2 Update the five `app-pr-checkbox` labels in `evidence-item.component.html` to the same canonical names — keep the `[(ngModel)]` bindings (incl. Climate → `youth_related`) unchanged
 - [x] 1.3 Confirm the read-only impact-tag chips (`getSelectedImpactTags()`) now render the canonical names automatically
+- [x] 1.4 Rename the same five labels in the Innovation Development evidence component `user-evidence.component.html` (separate checkbox copy used by Innovation Development results) — bindings unchanged
 
 ## 2. Block the Evidence green check
 

--- a/openspec/changes/p2-3056-evidence-green-check/tasks.md
+++ b/openspec/changes/p2-3056-evidence-green-check/tasks.md
@@ -1,0 +1,24 @@
+## 1. Rename Impact-Area checkbox labels
+
+- [x] 1.1 Update the five Impact-Area `label` strings in the `tagFields` array in `rd-evidences.component.ts` (Gender equality, youth and social inclusion / Climate adaptation and mitigation / Nutrition, health and food security / Environmental health and biodiversity / Poverty reduction, livelihoods and jobs) — keep `field` keys unchanged
+- [x] 1.2 Update the five `app-pr-checkbox` labels in `evidence-item.component.html` to the same canonical names — keep the `[(ngModel)]` bindings (incl. Climate → `youth_related`) unchanged
+- [x] 1.3 Confirm the read-only impact-tag chips (`getSelectedImpactTags()`) now render the canonical names automatically
+
+## 2. Block the Evidence green check
+
+- [x] 2.1 Add a getter on `rd-evidences.component.ts` (e.g. `evidenceSectionComplete`) combining: base evidence present (or result type 5) AND `validateCheckBoxes()` returns empty AND `validateHasInnoReadinessLevelEvidence()` is true; guard the readiness condition so it only applies to Innovation Development (result_type_id 7)
+- [x] 2.2 Bind `[isComplete]` of the Evidence `appFeedbackValidation` block (`rd-evidences.component.html:101`) to the new getter
+- [x] 2.3 Sanity-check that the yellow warnings and the green check now agree in all branches (no evidence, Principal marker missing, readiness 1–9 missing, readiness 0, type 5)
+
+## 3. Tests
+
+- [x] 3.1 Add/extend `rd-evidences.component.spec.ts`: green check blocked with no evidence; blocked when a Principal marker lacks tagged evidence; blocked when Innovation Development readiness is 1–9 without readiness evidence; satisfied when readiness is 0; satisfied for type 5 with no evidence; satisfied when all rules met
+- [x] 3.2 Add/extend `evidence-item.component.spec.ts` (or rd-evidences spec): the five checkboxes render the canonical labels (covered via `getSelectedImpactTags` test in rd-evidences spec)
+- [x] 3.3 Run `npm run test src/.../rd-evidences.component.spec.ts` and the evidence-item spec; ensure green — 46 + 29 passing
+
+## 4. Manual verification
+
+- [ ] 4.1 Run the client locally; on an Innovation Development result, confirm the Evidence green check stays red until base + Principal-marker + readiness evidence are provided, and turns green once all are met
+- [ ] 4.2 On a non-Innovation-Development result with a Principal marker, confirm the green check requires the marker evidence and is NOT blocked by readiness
+- [ ] 4.3 Confirm where the user-visible check (in-section flag vs side-menu/backend) was turning green prematurely, and that the fix closes the reported P2-3056 case; capture before/after screenshots into `onecgiar_pr/.local-screenshots/`
+- [ ] 4.4 Report results to reporter Santiago Sánchez (Slack) with the panorama and verification status


### PR DESCRIPTION
## Summary
- Gate the Evidence section green check so it stays red until all mandatory evidence is present: at least one evidence, evidence for every Impact-Area marker at Principal level (all result types), and Innovation-Readiness evidence when readiness is 1–9 (Innovation Development only).
- Rename the five Impact-Area checkbox labels to the canonical names in both evidence components (standard + Innovation Development).
- Frontend-only: the backend green-check already enforces these rules.

## Files changed
| File | Change |
|------|--------|
| `rd-evidences.component.ts` | New `evidenceSectionComplete` getter reusing `validateCheckBoxes()` + `validateHasInnoReadinessLevelEvidence()`; renamed 5 `tagFields` labels |
| `rd-evidences.component.html` | Bind Evidence `[isComplete]` to the new getter |
| `evidence-item.component.html` | Renamed the 5 Impact-Area checkbox labels |
| `user-evidence.component.html` | Same 5 label renames (Innovation Development evidence component) |
| `rd-evidences.component.spec.ts` | Tests for the green-check gate (all branches) + canonical labels |

## Why this approach is correct
- Reuses the existing `validateCheckBoxes()` and `validateHasInnoReadinessLevelEvidence()` helpers that already drive the yellow warnings, so the green check and the warnings can never disagree (single source of truth).
- The readiness rule is guarded by `result_type_id === 7`, so non-Innovation-Development results are never blocked by readiness.
- Label changes are text-only; the "Climate adaptation and mitigation" checkbox stays bound to `youth_related` (intentional historical column reuse) — no binding/data changes.

## Code walkthrough
```ts
// rd-evidences.component.ts — new getter
get evidenceSectionComplete(): boolean {
  const resultTypeId = this.api.dataControlSE.currentResult?.result_type_id;
  const hasBaseEvidence = this.evidencesBody.evidences.length > 0 || resultTypeId == 5; // type 5 exempt
  const markersCovered = !this.validateCheckBoxes();                 // '' => no Principal marker missing evidence
  const readinessCovered = resultTypeId !== 7 || this.validateHasInnoReadinessLevelEvidence(); // only InnoDev
  return hasBaseEvidence && markersCovered && readinessCovered;
}
```
```html
<!-- rd-evidences.component.html -->
[isComplete]="this.evidenceSectionComplete"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
