### PR TITLE
✨ Add Clarisa API key guard and validation in Bilateral modue

### DIFF
--- a/onecgiar-pr-server/src/api/bilateral/bilateral.controller.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.controller.ts
@@ -6,6 +6,7 @@ import {
   ParseIntPipe,
   Post,
   Query,
+  UseGuards,
   UseInterceptors,
   ValidationPipe,
 } from '@nestjs/common';
@@ -13,6 +14,7 @@ import { SkipThrottle } from '@nestjs/throttler';
 import { BilateralService } from './bilateral.service';
 import {
   ApiBody,
+  ApiHeader,
   ApiOperation,
   ApiParam,
   ApiQuery,
@@ -21,15 +23,24 @@ import {
 import { ResponseInterceptor } from '../../shared/Interceptors/Return-data.interceptor';
 import { RootResultsDto } from './dto/create-bilateral.dto';
 import { ListResultsQueryDto } from './dto/list-results-query.dto';
+import { ClarisaApiKeyGuard } from './guards/clarisa-api-key.guard';
+import { BilateralClarisaEndpoint } from './decorators/bilateral-clarisa-endpoint.decorator';
 
 @Controller()
 @ApiTags('Bilaterals')
+@ApiHeader({
+  name: 'X-API-Key',
+  required: true,
+  description: 'CLARISA API key for bilateral access',
+})
+@UseGuards(ClarisaApiKeyGuard)
 @SkipThrottle()
 @UseInterceptors(ResponseInterceptor)
 export class BilateralController {
   constructor(private readonly bilateralService: BilateralService) {}
 
   @Post('create')
+  @BilateralClarisaEndpoint('/api/bilateral/create')
   @ApiBody({ type: RootResultsDto })
   async create(
     @Body(
@@ -45,6 +56,7 @@ export class BilateralController {
   }
 
   @Get()
+  @BilateralClarisaEndpoint('/api/bilateral')
   @ApiOperation({
     summary: 'Get all bilateral results',
     description:
@@ -64,6 +76,7 @@ export class BilateralController {
   }
 
   @Get('list')
+  @BilateralClarisaEndpoint('/api/bilateral/list')
   @ApiOperation({
     summary: 'List all results with pagination and filters',
     description:
@@ -186,6 +199,7 @@ export class BilateralController {
   }
 
   @Get('results')
+  @BilateralClarisaEndpoint('/api/bilateral/results')
   @ApiOperation({
     summary: 'Get all bilateral results for synchronization',
     description:
@@ -214,6 +228,7 @@ export class BilateralController {
   }
 
   @Get(':id')
+  @BilateralClarisaEndpoint('/api/bilateral/:id')
   @ApiOperation({
     summary: 'Get bilateral result by ID',
     description:

--- a/onecgiar-pr-server/src/api/bilateral/bilateral.module.ts
+++ b/onecgiar-pr-server/src/api/bilateral/bilateral.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
 import { BilateralService } from './bilateral.service';
 import { BilateralController } from './bilateral.controller';
 import { ResultsModule } from '../results/results.module';
@@ -45,9 +46,12 @@ import { ResultsPolicyChangesRepository } from '../results/summary/repositories/
 import { NoopBilateralHandler } from './handlers/noop.handler';
 import { NonPooledProjectBudgetRepository } from '../results/result_budget/repositories/non_pooled_proyect_budget.repository';
 import { PathwayModule } from '../ipsr-framework/pathway/pathway.module';
+import { ClarisaApiKeyValidationService } from './services/clarisa-api-key-validation.service';
+import { ClarisaApiKeyGuard } from './guards/clarisa-api-key.guard';
 
 @Module({
   imports: [
+    HttpModule,
     ResultsModule,
     VersioningModule,
     UserModule,
@@ -84,6 +88,8 @@ import { PathwayModule } from '../ipsr-framework/pathway/pathway.module';
   ],
   controllers: [BilateralController],
   providers: [
+    ClarisaApiKeyValidationService,
+    ClarisaApiKeyGuard,
     BilateralService,
     KnowledgeProductBilateralHandler,
     CapacityChangeBilateralHandler,

--- a/onecgiar-pr-server/src/api/bilateral/constants/bilateral-auth.constants.ts
+++ b/onecgiar-pr-server/src/api/bilateral/constants/bilateral-auth.constants.ts
@@ -1,0 +1,3 @@
+export const BILATERAL_CLARISA_MICROSERVICE_NAME = 'Bilateral Service';
+
+export const BILATERAL_UNAUTHORIZED_MESSAGE = 'Unauthorized';

--- a/onecgiar-pr-server/src/api/bilateral/decorators/bilateral-clarisa-endpoint.decorator.ts
+++ b/onecgiar-pr-server/src/api/bilateral/decorators/bilateral-clarisa-endpoint.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const BILATERAL_CLARISA_ENDPOINT_KEY = 'bilateralClarisaEndpoint';
+
+export const BilateralClarisaEndpoint = (endpointAccessed: string) =>
+  SetMetadata(BILATERAL_CLARISA_ENDPOINT_KEY, endpointAccessed);

--- a/onecgiar-pr-server/src/api/bilateral/guards/clarisa-api-key.guard.spec.ts
+++ b/onecgiar-pr-server/src/api/bilateral/guards/clarisa-api-key.guard.spec.ts
@@ -1,0 +1,87 @@
+import { Reflector } from '@nestjs/core';
+import { UnauthorizedException } from '@nestjs/common';
+import { ClarisaApiKeyGuard } from './clarisa-api-key.guard';
+import { BILATERAL_CLARISA_ENDPOINT_KEY } from '../decorators/bilateral-clarisa-endpoint.decorator';
+import { BILATERAL_UNAUTHORIZED_MESSAGE } from '../constants/bilateral-auth.constants';
+
+describe('ClarisaApiKeyGuard', () => {
+  const validationService = {
+    validate: jest.fn(),
+  };
+
+  const reflector = {
+    get: jest.fn(),
+  };
+
+  const guard = new ClarisaApiKeyGuard(
+    validationService as any,
+    reflector as unknown as Reflector,
+  );
+
+  const makeContext = (headers: Record<string, string | string[]>) =>
+    ({
+      getHandler: () => function handler() {},
+      switchToHttp: () => ({
+        getRequest: () => ({
+          headers,
+          socket: { remoteAddress: '127.0.0.1' },
+        }),
+      }),
+    }) as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    reflector.get.mockReturnValue('/api/bilateral/create');
+  });
+
+  it('should reject requests without X-API-Key', async () => {
+    await expect(guard.canActivate(makeContext({}))).rejects.toThrow(
+      new UnauthorizedException(BILATERAL_UNAUTHORIZED_MESSAGE),
+    );
+    expect(validationService.validate).not.toHaveBeenCalled();
+  });
+
+  it('should reject requests when endpoint metadata is missing', async () => {
+    reflector.get.mockReturnValue(undefined);
+
+    await expect(
+      guard.canActivate(makeContext({ 'x-api-key': 'cl_prod_key' })),
+    ).rejects.toThrow(
+      new UnauthorizedException(BILATERAL_UNAUTHORIZED_MESSAGE),
+    );
+    expect(validationService.validate).not.toHaveBeenCalled();
+  });
+
+  it('should allow requests when CLARISA validates the API key', async () => {
+    validationService.validate.mockResolvedValue(true);
+
+    await expect(
+      guard.canActivate(
+        makeContext({
+          'x-api-key': 'cl_prod_key',
+          'x-forwarded-for': '203.0.113.42',
+        }),
+      ),
+    ).resolves.toBe(true);
+
+    expect(reflector.get).toHaveBeenCalledWith(
+      BILATERAL_CLARISA_ENDPOINT_KEY,
+      expect.any(Function),
+    );
+    expect(validationService.validate).toHaveBeenCalledWith(
+      'cl_prod_key',
+      '/api/bilateral/create',
+      '203.0.113.42',
+    );
+  });
+
+  it('should reject requests when CLARISA rejects the API key', async () => {
+    validationService.validate.mockResolvedValue(false);
+
+    await expect(
+      guard.canActivate(makeContext({ 'x-api-key': 'bad-key' })),
+    ).rejects.toThrow(
+      new UnauthorizedException(BILATERAL_UNAUTHORIZED_MESSAGE),
+    );
+  });
+});

--- a/onecgiar-pr-server/src/api/bilateral/guards/clarisa-api-key.guard.ts
+++ b/onecgiar-pr-server/src/api/bilateral/guards/clarisa-api-key.guard.ts
@@ -1,0 +1,69 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+import { BILATERAL_UNAUTHORIZED_MESSAGE } from '../constants/bilateral-auth.constants';
+import { BILATERAL_CLARISA_ENDPOINT_KEY } from '../decorators/bilateral-clarisa-endpoint.decorator';
+import { ClarisaApiKeyValidationService } from '../services/clarisa-api-key-validation.service';
+
+@Injectable()
+export class ClarisaApiKeyGuard implements CanActivate {
+  constructor(
+    private readonly clarisaApiKeyValidationService: ClarisaApiKeyValidationService,
+    private readonly reflector: Reflector,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const apiKey = this.extractApiKey(request);
+
+    if (!apiKey) {
+      throw new UnauthorizedException(BILATERAL_UNAUTHORIZED_MESSAGE);
+    }
+
+    const endpointAccessed = this.reflector.get<string>(
+      BILATERAL_CLARISA_ENDPOINT_KEY,
+      context.getHandler(),
+    );
+
+    if (!endpointAccessed) {
+      throw new UnauthorizedException(BILATERAL_UNAUTHORIZED_MESSAGE);
+    }
+
+    const isValid = await this.clarisaApiKeyValidationService.validate(
+      apiKey,
+      endpointAccessed,
+      this.extractClientIp(request),
+    );
+
+    if (!isValid) {
+      throw new UnauthorizedException(BILATERAL_UNAUTHORIZED_MESSAGE);
+    }
+
+    return true;
+  }
+
+  private extractApiKey(request: Request): string | undefined {
+    const headerValue = request.headers['x-api-key'];
+
+    if (Array.isArray(headerValue)) {
+      return headerValue[0]?.trim() || undefined;
+    }
+
+    const apiKey = headerValue?.trim();
+    return apiKey || undefined;
+  }
+
+  private extractClientIp(request: Request): string | undefined {
+    const forwardedFor = request.headers['x-forwarded-for'];
+    const ip = Array.isArray(forwardedFor)
+      ? forwardedFor[0]
+      : forwardedFor || request.socket?.remoteAddress;
+
+    return typeof ip === 'string' ? ip.trim() : undefined;
+  }
+}

--- a/onecgiar-pr-server/src/api/bilateral/interfaces/clarisa-api-key-validation.interface.ts
+++ b/onecgiar-pr-server/src/api/bilateral/interfaces/clarisa-api-key-validation.interface.ts
@@ -1,0 +1,28 @@
+export interface ClarisaApiKeyValidationRequest {
+  api_key: string;
+  microservice_name: string;
+  endpoint_accessed: string;
+  ip_address?: string;
+}
+
+export interface ClarisaApiKeyValidationMis {
+  id: number;
+  name: string;
+  acronym: string;
+}
+
+export interface ClarisaApiKeyValidationSuccess {
+  valid: true;
+  mis: ClarisaApiKeyValidationMis;
+  environment: string;
+  scopes: string[];
+}
+
+export interface ClarisaApiKeyValidationFailure {
+  valid: false;
+  error?: string;
+}
+
+export type ClarisaApiKeyValidationResponse =
+  | ClarisaApiKeyValidationSuccess
+  | ClarisaApiKeyValidationFailure;

--- a/onecgiar-pr-server/src/api/bilateral/services/clarisa-api-key-validation.service.spec.ts
+++ b/onecgiar-pr-server/src/api/bilateral/services/clarisa-api-key-validation.service.spec.ts
@@ -1,0 +1,120 @@
+import { HttpService } from '@nestjs/axios';
+import { Logger } from '@nestjs/common';
+import { of, throwError } from 'rxjs';
+import { AxiosError, AxiosHeaders } from 'axios';
+import { ClarisaApiKeyValidationService } from './clarisa-api-key-validation.service';
+import { BILATERAL_CLARISA_MICROSERVICE_NAME } from '../constants/bilateral-auth.constants';
+
+const originalEnv = { ...process.env };
+
+describe('ClarisaApiKeyValidationService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.CLA_URL = 'https://clarisa.example/';
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  const createService = (httpService: HttpService) =>
+    new ClarisaApiKeyValidationService(httpService);
+
+  it('should validate API key against CLARISA without Basic Auth', async () => {
+    const post = jest.fn().mockReturnValue(
+      of({
+        data: {
+          valid: true,
+          mis: { id: 12, name: 'Reporting Tool', acronym: 'PRMS' },
+          environment: 'PROD',
+          scopes: ['bilateral:read'],
+        },
+      }),
+    );
+    const httpService = { post } as unknown as HttpService;
+
+    const service = createService(httpService);
+    const isValid = await service.validate(
+      'cl_prod_key',
+      '/api/bilateral/list',
+      '203.0.113.42',
+    );
+
+    expect(isValid).toBe(true);
+    expect(post).toHaveBeenCalledWith(
+      'https://clarisa.example/api/auth/validate-api-key',
+      {
+        api_key: 'cl_prod_key',
+        microservice_name: BILATERAL_CLARISA_MICROSERVICE_NAME,
+        endpoint_accessed: '/api/bilateral/list',
+        ip_address: '203.0.113.42',
+      },
+      expect.objectContaining({
+        headers: { 'Content-Type': 'application/json' },
+        timeout: 5000,
+      }),
+    );
+    expect(post.mock.calls[0][2]).not.toHaveProperty('auth');
+  });
+
+  it('should return false when CLARISA responds with valid false', async () => {
+    const httpService = {
+      post: jest.fn().mockReturnValue(
+        of({
+          data: {
+            valid: false,
+            error: 'Invalid API key',
+          },
+        }),
+      ),
+    } as unknown as HttpService;
+
+    const service = createService(httpService);
+    await expect(
+      service.validate('bad-key', '/api/bilateral/create'),
+    ).resolves.toBe(false);
+  });
+
+  it('should return false when CLARISA responds with HTTP 401', async () => {
+    const axiosError = new AxiosError(
+      'Unauthorized',
+      '401',
+      undefined,
+      undefined,
+      {
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: {},
+        config: { headers: new AxiosHeaders() },
+        data: { valid: false, error: 'Missing required scope' },
+      },
+    );
+
+    const httpService = {
+      post: jest.fn().mockReturnValue(throwError(() => axiosError)),
+    } as unknown as HttpService;
+
+    const service = createService(httpService);
+    await expect(
+      service.validate('bad-key', '/api/bilateral/results'),
+    ).resolves.toBe(false);
+  });
+
+  it('should return false and log when CLARISA is unreachable', async () => {
+    const warnSpy = jest
+      .spyOn(Logger.prototype, 'warn')
+      .mockImplementation(() => undefined);
+
+    const httpService = {
+      post: jest
+        .fn()
+        .mockReturnValue(throwError(() => new Error('network error'))),
+    } as unknown as HttpService;
+
+    const service = createService(httpService);
+    await expect(
+      service.validate('some-key', '/api/bilateral'),
+    ).resolves.toBe(false);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/onecgiar-pr-server/src/api/bilateral/services/clarisa-api-key-validation.service.ts
+++ b/onecgiar-pr-server/src/api/bilateral/services/clarisa-api-key-validation.service.ts
@@ -1,0 +1,63 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable, Logger } from '@nestjs/common';
+import { AxiosError } from 'axios';
+import { env } from 'process';
+import { firstValueFrom } from 'rxjs';
+import { BILATERAL_CLARISA_MICROSERVICE_NAME } from '../constants/bilateral-auth.constants';
+import {
+  ClarisaApiKeyValidationRequest,
+  ClarisaApiKeyValidationResponse,
+} from '../interfaces/clarisa-api-key-validation.interface';
+
+@Injectable()
+export class ClarisaApiKeyValidationService {
+  private readonly logger = new Logger(ClarisaApiKeyValidationService.name);
+  private readonly validateUrl: string;
+
+  constructor(private readonly httpService: HttpService) {
+    const baseUrl = (env.CLA_URL ?? '').replace(/\/+$/, '');
+    this.validateUrl = `${baseUrl}/api/auth/validate-api-key`;
+  }
+
+  async validate(
+    apiKey: string,
+    endpointAccessed: string,
+    ipAddress?: string,
+  ): Promise<boolean> {
+    const payload: ClarisaApiKeyValidationRequest = {
+      api_key: apiKey,
+      microservice_name: BILATERAL_CLARISA_MICROSERVICE_NAME,
+      endpoint_accessed: endpointAccessed,
+    };
+
+    if (ipAddress) {
+      payload.ip_address = ipAddress;
+    }
+
+    try {
+      const response = await firstValueFrom(
+        this.httpService.post<ClarisaApiKeyValidationResponse>(
+          this.validateUrl,
+          payload,
+          {
+            headers: { 'Content-Type': 'application/json' },
+            timeout: 5000,
+          },
+        ),
+      );
+
+      return response.data?.valid === true;
+    } catch (error) {
+      const axiosError = error as AxiosError<ClarisaApiKeyValidationResponse>;
+
+      if (axiosError.response?.data?.valid === false) {
+        return false;
+      }
+
+      this.logger.warn(
+        `CLARISA API key validation failed for endpoint ${endpointAccessed}`,
+      );
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
Protect bilateral endpoints with CLARISA API key validation: adds a ClarisaApiKeyGuard that extracts X-API-Key and client IP, checks endpoint metadata (BilateralClarisaEndpoint) and delegates validation to ClarisaApiKeyValidationService. The service calls CLARISA (CLA_URL) /api/auth/validate-api-key via HttpService and handles responses and errors. Also adds decorator, constants, request/response interfaces, unit tests for the guard and service, and updates the bilateral module/controller to import HttpModule, register the new providers, require the X-API-Key header, and apply the guard and endpoint metadata to relevant routes.