### PR TITLE
🔧 fix(rd-contributors-and-partners) P2-2998: preload Contributing CGIAR Centers on HLO/KPI selection

### DIFF
--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-contributors-and-partners/components/multiple-wps/components/multiple-wps-content/multiple-wps-content.component.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-contributors-and-partners/components/multiple-wps/components/multiple-wps-content/multiple-wps-content.component.ts
@@ -56,6 +56,11 @@ export class CPMultipleWPsContentComponent implements OnChanges {
   showIndicators = signal<boolean>(false);
   selectedIndicatorData = signal<IndicatorItem | null>(null);
 
+  // P2-2998: reactive trigger for syncTocReferenceIds. `allTabsCreated` is a plain @Input() array whose
+  // in-place mutations (HLO/Outcome or KPI selection) don't notify the effect. Bumping this signal from the
+  // selection handlers forces the centers reference set to recompute on selection, not only on tab switch.
+  selectionVersion = signal<number>(0);
+
   secondFieldLabel = computed(() => {
     return this.tocResultListFiltered().find(item => item.toc_level_id === this.activeTabSignal()?.toc_level_id)?.name;
   });
@@ -131,6 +136,8 @@ export class CPMultipleWPsContentComponent implements OnChanges {
     const oc = this.outcomeList();
     const eoi = this.eoiList();
     this.activeTabSignal();
+    // P2-2998: subscribe to in-tab HLO/KPI selection changes (see selectionVersion + getIndicatorsList/mapTocResultsIndicatorId).
+    this.selectionVersion();
     const tabs: any[] = this.allTabsCreated ?? [];
     const listForLevel = (lvl: any): any[] => (lvl === 3 ? eoi : lvl === 2 ? oc : lvl === 1 ? out : []);
     const num = (v: any) => Number(v);
@@ -240,6 +247,8 @@ export class CPMultipleWPsContentComponent implements OnChanges {
     }
     this.hideIndicators();
     this.updateSelectedIndicatorData();
+    // P2-2998: HLO/Outcome node changed → recompute the centers reference set now (don't wait for a tab switch).
+    this.selectionVersion.update(v => v + 1);
   }
 
   hideIndicators() {
@@ -255,6 +264,8 @@ export class CPMultipleWPsContentComponent implements OnChanges {
     this.fieldsManagerSE.hasSelectedIndicator.set(true);
     this.activeTab.indicators[0].toc_results_indicator_id = this.activeTab.indicators[0].related_node_id;
     this.updateSelectedIndicatorData();
+    // P2-2998: KPI Statement changed → union the indicator's toc_target_center_ids into the centers reference set now.
+    this.selectionVersion.update(v => v + 1);
   }
 
   updateSelectedIndicatorData() {

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-contributors-and-partners/rd-contributors-and-partners.component.html
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-contributors-and-partners/rd-contributors-and-partners.component.html
@@ -69,6 +69,24 @@
         [autogenerate]="true">
       </app-pr-textarea>
     }
+
+    <!-- P2-3063 / P2-3036 AC6 (2026, unplanned): mandatory Yes/No "financial resources" radio + info note. -->
+    @if (isCP2026() && !this.rdPartnersSE.partnersBody.result_toc_result.planned_result) {
+      <app-pr-yes-or-not
+        label="Did the Program invest financial resources in the achievement of this result?"
+        [required]="true"
+        [hideDescription]="true"
+        [(ngModel)]="programInvestedFinancialResources">
+      </app-pr-yes-or-not>
+
+      <app-alert-status [description]="financialResourcesInfoNote"></app-alert-status>
+
+      <!-- Hidden marker so the single radio counts in the section's mandatory-field validation. -->
+      <div
+        appFeedbackValidation
+        labelText="Did the Program invest financial resources in the achievement of this result?"
+        [isComplete]="programInvestedFinancialResources !== null"></div>
+    }
   }
 
   <!-- P2-2998 / P2-3036 (2026): Contributing CGIAR Centers split into "from ToC" + "Other(s)". SAVE NOT ADDRESSED YET. -->

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-contributors-and-partners/rd-contributors-and-partners.component.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-contributors-and-partners/rd-contributors-and-partners.component.ts
@@ -83,6 +83,22 @@ export class RdContributorsAndPartnersComponent implements OnInit {
   // P2-3036: the 2026 redesign of this section applies only to phase 2026+. 2025 keeps the legacy copy/fields.
   isCP2026 = computed(() => this.fieldsManagerSE.isContributorsPartners2026());
 
+  // P2-3063 / P2-3036 AC6 (2026, unplanned scenario): single mandatory Yes/No radio
+  // "Did the Program invest financial resources in the achievement of this result?".
+  // Backend persists per row in result_toc_results[] (matched by result_toc_result_id, no dedup), so the single
+  // on-screen radio reads the first row and writes the same value across every active row (per Juan David's contract).
+  financialResourcesInfoNote =
+    "Select 'Yes' if direct program funds were utilized to achieve this result. Select 'No' if the result was achieved organically (e.g., policy influence) without financial investment from the program.";
+
+  get programInvestedFinancialResources(): boolean | null {
+    return this.rdPartnersSE.partnersBody?.result_toc_result?.result_toc_results?.[0]?.program_invested_financial_resources ?? null;
+  }
+  set programInvestedFinancialResources(value: boolean) {
+    (this.rdPartnersSE.partnersBody?.result_toc_result?.result_toc_results || []).forEach((row: any) => {
+      row.program_invested_financial_resources = value;
+    });
+  }
+
   tocQuestionLabel = computed(() =>
     this.isCP2026()
       ? 'Can this result be mapped to a planned TOC KPI or indicator?'

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-theory-of-change/model/theoryOfChangeBody.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-theory-of-change/model/theoryOfChangeBody.ts
@@ -67,4 +67,7 @@ export class ResultTocResultsInterface {
   initiative_id: number | string = null;
   toc_level_id?: number | string = null;
   indicators: IndicatorsTocInterface[] = new Array<IndicatorsTocInterface>();
+  // P2-3063 / P2-3036 AC6: "Did the Program invest financial resources…?" radio. Persisted per row by the backend
+  // (matched by result_toc_result_id); the single on-screen radio writes the same value across the active rows.
+  program_invested_financial_resources: boolean = null;
 }

--- a/openspec/changes/p2-2998-centers-preload-on-selection/.openspec.yaml
+++ b/openspec/changes/p2-2998-centers-preload-on-selection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/p2-2998-centers-preload-on-selection/design.md
+++ b/openspec/changes/p2-2998-centers-preload-on-selection/design.md
@@ -1,0 +1,37 @@
+## Context
+
+The 2026 Contributors & Partners section preloads Contributing CGIAR Centers from the ToC selection. The reference set lives in `rdPartnersSE.tocReferenceCenterInstitutionIds` (signal) and is populated by the `syncTocReferenceIds` effect in `multiple-wps-content.component.ts` (lines ~127-160).
+
+The effect iterates `this.allTabsCreated` — an `@Input()` **plain array**, not a signal — to union centers from each node's `toc_partners` plus each selected indicator's `toc_target_center_ids`. Its only reactive dependencies are the ToC lists (`outputList/outcomeList/eoiList`) and `activeTabSignal()`.
+
+**Root cause of the bug:** selecting an HLO/Outcome (`getIndicatorsList()`, via the level/node dropdown `(ngModelChange)`) or a KPI Statement (`mapTocResultsIndicatorId()`, via the indicator dropdown `(ngModelChange)`) mutates `allTabsCreated[i]` **in place**. Neither touches a signal the effect observes, so the effect does not re-run. Only switching tabs updates `activeTabSignal` (in the parent's `onActiveTab()`), which is why centers appear only after a tab change.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Recompute `tocReferenceCenterInstitutionIds` immediately when the user selects/changes an HLO/Outcome node or its KPI Statement, in any tab.
+- Preserve the existing union/dedupe contract across all tabs and the backend contract exactly.
+
+**Non-Goals:**
+- No change to the union/dedupe logic, the "Other(s)" split, the save/persist flow, or Science Programs.
+- No backend change.
+- Not addressing the secondary `tocConsumed` re-render timing (radio "Yes" removing/re-adding the component) unless testing shows the trigger alone is insufficient — tracked as a follow-up.
+
+## Decisions
+
+**Decision: add a reactive "selection version" signal as an explicit effect dependency.**
+- Introduce `selectionVersion = signal(0)` on the component.
+- Read `this.selectionVersion()` inside `syncTocReferenceIds` so the effect subscribes to it.
+- Increment it (`this.selectionVersion.update(v => v + 1)`) at the end of the two selection handlers: `getIndicatorsList()` (HLO/Outcome change) and `mapTocResultsIndicatorId()` (KPI change).
+- Rationale: the effect keeps reading `allTabsCreated` (already up to date via `[(ngModel)]` two-way binding by the time the handlers run), and the version bump is the minimal, explicit signal that "a ToC selection changed." It keeps the reactive-effect pattern intact.
+
+**Alternatives considered:**
+- *Convert `allTabsCreated` to a signal / clone on change.* Larger blast radius — it is bound from the parent and consumed elsewhere; risk of breaking existing tab logic. Rejected as over-scoped for a bug fix.
+- *Extract the effect body into a plain method and call it directly from the handlers.* Works, but duplicates the "when to run" logic and loses the single reactive entry point (load + tab switch already flow through the effect). The version-signal keeps one code path.
+- *Call `activeTabSignal.set({...})` in the handlers to force a change.* Abuses the active-tab signal semantics and could trigger unintended parent behavior. Rejected.
+
+## Risks / Trade-offs
+
+- **[Ordering: handler runs before `allTabsCreated` mutation is visible]** → `[(ngModel)]` updates the bound `activeTab.*` before the `(ngModelChange)` handler body executes, and `allTabsCreated` holds the same tab object references, so the effect reads fresh values. Verify in-browser that centers appear on the first selection (not one selection behind).
+- **[Extra effect runs]** → the version bump also re-runs on KPI change even when only `toc_partners` matter; recomputation is cheap (small sets, in-memory filter), so negligible.
+- **[Secondary `tocConsumed` timing not covered]** → if the radio "Yes" path still shows empty lists, a follow-up may need to also re-fetch/repopulate lists on re-render. Out of scope here; flagged for QA.

--- a/openspec/changes/p2-2998-centers-preload-on-selection/proposal.md
+++ b/openspec/changes/p2-2998-centers-preload-on-selection/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+In the 2026 Contributors & Partners section (P2-2998), the "Contributing CGIAR Centers" dropdown is supposed to auto-preload the centers referenced by the selected HLO/Outcome node and its KPI Statement. Today it only refreshes when the user **switches ToC tabs** — selecting an HLO with its KPI Statement inside the current tab does **not** load the centers, so users must change tabs to force the list to appear. This breaks the expected "select → centers appear instantly" behavior and is confusing when more than one HLO/KPI is selected.
+
+**Scope:** frontend-only. Ticket **P2-2998** (epic `P2-2928-TOC-Improvements`).
+
+## What Changes
+
+- Make the ToC → Centers reference sync **reactive to in-tab selection changes**, not just tab switches.
+- When the user selects an HLO/Outcome (level dropdown) OR its KPI Statement/indicator, the `Contributing CGIAR Centers` list preloads immediately from the selected node's `toc_partners` + the indicator's `toc_target_center_ids` (existing union/dedupe contract — unchanged).
+- No change to the union/dedupe logic, the backend contract, the save flow, or the "Other(s)" split. Only the **trigger/reactivity** of the existing `syncTocReferenceIds` effect changes.
+
+## Capabilities
+
+### New Capabilities
+- `toc-centers-reactive-preload`: The Contributing CGIAR Centers reference set must recompute reactively whenever the user changes the selected HLO/Outcome node or its KPI Statement within any ToC tab, not only when the active tab changes.
+
+### Modified Capabilities
+<!-- None. The base capability toc-contributors-centers (change p2-2998-centers-from-toc-split) is not yet archived; this change only sharpens the reactivity requirement, expressed as a new capability to avoid coupling to an unarchived delta. -->
+
+## Impact
+
+- **Component:** `onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-contributors-and-partners/components/multiple-wps/components/multiple-wps-content/multiple-wps-content.component.ts`
+  - `effect syncTocReferenceIds` (currently only reactive to `outputList/outcomeList/eoiList` + `activeTabSignal`; iterates the non-reactive `@Input() allTabsCreated`).
+  - Selection handlers `getIndicatorsList()` (HLO/Outcome select) and `mapTocResultsIndicatorId()` (KPI Statement select).
+- **Consumer (read-only, no change expected):** `rd-contributors-and-partners.component.ts` `referenceCenters` / `preselectCentersEffect`, fed by `rdPartnersSE.tocReferenceCenterInstitutionIds`.
+- **Backend:** none.
+- **SDD baseline:** UI behavior per `docs/system-design/design.md` (Contributors & Partners section); no data-model change vs `docs/detailed-design/detailed-design.md`.

--- a/openspec/changes/p2-2998-centers-preload-on-selection/specs/toc-centers-reactive-preload/spec.md
+++ b/openspec/changes/p2-2998-centers-preload-on-selection/specs/toc-centers-reactive-preload/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Centers preload reactively on HLO/Outcome selection
+
+In the 2026 Contributors & Partners section, the Contributing CGIAR Centers reference set (`tocReferenceCenterInstitutionIds`) SHALL recompute immediately when the user selects or changes the HLO/Outcome node in the current ToC tab, without requiring a tab switch.
+
+#### Scenario: Selecting an HLO/Outcome node preloads its centers
+- **WHEN** the user selects an HLO/Outcome node (level dropdown) in the active ToC tab and that node carries `toc_partners`
+- **THEN** the Contributing CGIAR Centers dropdown preloads the centers derived from that node's `toc_partners` right away, without the user needing to switch tabs
+
+#### Scenario: Changing the selected node updates the centers
+- **WHEN** the user changes the selected HLO/Outcome node to a different one within the same tab
+- **THEN** the Contributing CGIAR Centers reference set recomputes to reflect the newly selected node
+
+### Requirement: Centers preload reactively on KPI Statement selection
+
+The Contributing CGIAR Centers reference set SHALL recompute immediately when the user selects or changes the KPI Statement/indicator for the selected node, without requiring a tab switch.
+
+#### Scenario: Selecting a KPI Statement adds the indicator's centers
+- **WHEN** the user selects a KPI Statement/indicator whose `toc_target_center_ids` is non-empty
+- **THEN** the centers referenced by that indicator are unioned into the Contributing CGIAR Centers reference set immediately
+
+### Requirement: Multi-tab union is preserved
+
+Reactive recomputation SHALL preserve the existing union/dedupe contract across all selected ToC nodes and indicators (all tabs), applying no precedence logic on the frontend.
+
+#### Scenario: Second HLO/KPI with centers contributes to the union
+- **WHEN** the user has more than one ToC tab with selected nodes/indicators that carry centers, and updates any selection
+- **THEN** the Contributing CGIAR Centers reference set reflects the deduplicated union of centers from every selected node and indicator across all tabs, matching the behavior previously only produced by a tab switch

--- a/openspec/changes/p2-2998-centers-preload-on-selection/tasks.md
+++ b/openspec/changes/p2-2998-centers-preload-on-selection/tasks.md
@@ -1,0 +1,18 @@
+## 1. Implementation
+
+- [x] 1.1 Add `selectionVersion = signal(0)` field to `CPMultipleWPsContentComponent` (`multiple-wps-content.component.ts`).
+- [x] 1.2 Read `this.selectionVersion()` inside the `syncTocReferenceIds` effect so it subscribes to selection changes (add near the other dependency reads).
+- [x] 1.3 Increment `selectionVersion` at the end of `getIndicatorsList()` (HLO/Outcome selection handler).
+- [x] 1.4 Increment `selectionVersion` at the end of `mapTocResultsIndicatorId()` (KPI Statement selection handler).
+
+## 2. Verification
+
+- [x] 2.1 Build the client (`npm run build:dev`) and confirm no TypeScript/lint errors.
+- [x] 2.2 In-browser (prtest data, result 8574): changing the HLO/Outcome node recomputed `tocReferenceCenterInstitutionIds` immediately (from node 7026's centers to node 7029's `toc_partners`), no tab switch. `selectionVersion` incremented.
+- [x] 2.3 In-browser: selecting a KPI Statement whose indicator has `toc_target_center_ids` ([67]) unioned it into the centers reference set immediately. `selectionVersion` incremented.
+- [x] 2.4 Union/dedupe logic unchanged — the effect body that unions across `allTabsCreated` is untouched; only its reactivity (the `selectionVersion` dependency) changed. Verified single-tab recompute reflects the node+indicator union. (Result 8574 has 1 tab; multi-tab union path is the same loop already exercised on tab-switch.)
+- [x] 2.5 No regression: change is additive (a signal bump + one extra effect dependency); does not touch the "Other(s)" split, preselection, or Science Programs paths. `build:dev` clean.
+
+## 3. Follow-up (out of scope, flag only)
+
+- [ ] 3.1 If the radio "Can this result be mapped… → Yes" (`tocConsumed` re-render) still shows empty centers, note it for a separate ticket — do not fix here.


### PR DESCRIPTION
## What was done
- Contributing CGIAR Centers now **preload immediately** when the user selects an HLO/Outcome node or its KPI Statement inside the current ToC tab — no longer only after switching tabs.

## Why
- The `syncTocReferenceIds` effect iterated the non-reactive `@Input() allTabsCreated` array and only depended on `activeTabSignal` + the ToC lists. Selecting an HLO/KPI mutated the array in place, so the effect never re-ran and the Centers dropdown stayed empty until a tab switch (P2-2998).

## How to verify
1. Open a 2026 result → Contributors & partners → map to ToC (Yes).
2. Select an HLO/Outcome node with centers → Contributing CGIAR Centers preloads right away.
3. Select its KPI Statement (indicator with target centers) → those centers are added immediately. No tab switch needed.

## Technical references
- Branch: `P2-2928-TOC-Improvements`
- Commit: `9a5a685a3` — reactive `selectionVersion` signal bumped from `getIndicatorsList()` / `mapTocResultsIndicatorId()`
- OpenSpec change: `p2-2998-centers-preload-on-selection`

> Note: this PR also carries commit `305212d01` (P2-3063 mandatory "financial resources" radio), already on this epic branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)