### PR TITLE
P2-3114 + P2-3085: ToC popup Centers preselect/split + notification ToC review fields

### DIFF
--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/components/aow-hlo-table-create-modal/aow-hlo-create-modal.component.html
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/components/aow-hlo-table-create-modal/aow-hlo-create-modal.component.html
@@ -134,22 +134,28 @@
             [disabled]="creatingResult()" />
         </div>
 
+        <!-- P2-3114: Contributing CGIAR Centers split into "from ToC" (dropdown 1) + "Other(s)" (dropdown 2). -->
         <div>
-          <app-pr-multi-select
-            [options]="this.centersSE.centersList"
-            label="Contributing CGIAR Centers"
-            selectedLabel="Center(s) selected"
-            optionLabel="full_name"
-            optionValue="code"
-            [required]="false"
-            [(ngModel)]="createResultBody().contributing_center"
-            placeholder="Select center(s)">
-          </app-pr-multi-select>
+          @if (hasReferenceCenters()) {
+            <app-pr-multi-select
+              [options]="dropdown1Options()"
+              label="Contributing CGIAR Centers"
+              selectedLabel="Center(s) selected"
+              optionLabel="full_name"
+              optionValue="code"
+              [required]="false"
+              [(ngModel)]="createResultBody().contributing_center"
+              placeholder="Select center(s)"
+              (selectOptionEvent)="onContributingCenterSelect($event)">
+            </app-pr-multi-select>
+          } @else {
+            <app-pr-field-header label="Contributing CGIAR Centers" [required]="false"></app-pr-field-header>
+          }
 
           <div class="medal_selector selected_container">
             <div class="centers chips_container">
               <div class="center pr_chip_selected" *ngFor="let center of createResultBody().contributing_center; let i = index">
-                <div class="name" [innerHtml]="center?.name"></div>
+                <div class="name" [innerHtml]="center?.acronym || center?.name"></div>
                 <i
                   *ngIf="!this.api.rolesSE.readOnly && !this.api.dataControlSE?.currentResult?.status && !center.from_cgspace"
                   class="material-icons-round"
@@ -159,6 +165,33 @@
               </div>
             </div>
           </div>
+
+          @if (showOtherCenters() || !hasReferenceCenters()) {
+            <app-pr-multi-select
+              [options]="otherCentersList()"
+              label="Other(s) Contributing CGIAR Centers"
+              selectedLabel="Center(s) selected"
+              optionLabel="full_name"
+              optionValue="code"
+              [required]="false"
+              [(ngModel)]="otherCentersSelected"
+              placeholder="Select other center(s)">
+            </app-pr-multi-select>
+
+            <div class="medal_selector selected_container">
+              <div class="centers chips_container">
+                <div class="center pr_chip_selected" *ngFor="let center of otherCentersSelected(); let i = index">
+                  <div class="name" [innerHtml]="center?.acronym || center?.name"></div>
+                  <i
+                    *ngIf="!this.api.rolesSE.readOnly && !this.api.dataControlSE?.currentResult?.status"
+                    class="material-icons-round"
+                    (click)="deleteOtherCenter(i)"
+                    >cancel</i
+                  >
+                </div>
+              </div>
+            </div>
+          }
         </div>
 
         <div>

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/components/aow-hlo-table-create-modal/aow-hlo-create-modal.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/components/aow-hlo-table-create-modal/aow-hlo-create-modal.component.spec.ts
@@ -40,6 +40,90 @@ describe('AowHloCreateModalComponent - Unit Tests', () => {
     });
   });
 
+  describe('preselectTocCenters logic (P2-3114)', () => {
+    const deriveTocCenters = (indicator: any, centersList: any[]) => {
+      const tocAcronyms = (indicator?.targets_by_center?.centers ?? []).map((c: any) => c?.center_acronym).filter(Boolean);
+      if (!tocAcronyms.length) return [];
+      return centersList.filter((c: any) => tocAcronyms.includes(c.acronym)).map((c: any) => ({ ...c, from_toc: true }));
+    };
+
+    it('should preselect the ToC-mapped centers tagged from_toc:true', () => {
+      const indicator = { targets_by_center: { centers: [{ center_acronym: 'ABC' }, { center_acronym: 'CIP' }] } };
+      const centersList = [
+        { code: 'ABC', acronym: 'ABC', name: 'Alliance' },
+        { code: 'CIP', acronym: 'CIP', name: 'CIP' },
+        { code: 'IRRI', acronym: 'IRRI', name: 'IRRI' }
+      ];
+
+      const preselected = deriveTocCenters(indicator, centersList);
+
+      expect(preselected.map(c => c.acronym)).toEqual(['ABC', 'CIP']);
+      expect(preselected.every(c => c.from_toc === true)).toBe(true);
+    });
+
+    it('should preselect nothing when the indicator has no mapped centers', () => {
+      const indicator = { targets_by_center: { centers: [] } };
+      const centersList = [{ code: 'ABC', acronym: 'ABC', name: 'Alliance' }];
+
+      expect(deriveTocCenters(indicator, centersList)).toEqual([]);
+    });
+  });
+
+  describe('createResult from_toc tagging (P2-3114)', () => {
+    it('should default from_toc to false for manually-added centers', () => {
+      const contributing_center = [
+        { code: 'ABC', from_toc: true },
+        { code: 'IRRI' } // manually added, no from_toc
+      ];
+
+      const tagged = contributing_center.map((c: any) => ({ ...c, from_toc: c?.from_toc ?? false }));
+
+      expect(tagged.find(c => c.code === 'ABC')?.from_toc).toBe(true);
+      expect(tagged.find(c => c.code === 'IRRI')?.from_toc).toBe(false);
+    });
+  });
+
+  describe('Centers ToC/Other split logic (P2-3114)', () => {
+    const OTHER = '__OTHER_CENTERS__';
+
+    it('should open dropdown 2 and drop the sentinel when "Other(s)" is picked', () => {
+      const showOtherCenters = signal(false);
+      const contributing_center = signal<any[]>([{ code: 'IRRI', from_toc: true }, { code: OTHER }]);
+
+      // onContributingCenterSelect logic
+      const event = { option: { code: OTHER } };
+      if (event?.option?.code === OTHER) {
+        showOtherCenters.set(true);
+        contributing_center.set(contributing_center().filter((c: any) => c?.code !== OTHER));
+      }
+
+      expect(showOtherCenters()).toBe(true);
+      expect(contributing_center().some(c => c.code === OTHER)).toBe(false);
+      expect(contributing_center().map(c => c.code)).toEqual(['IRRI']);
+    });
+
+    it('should merge dropdown1 (from_toc:true) + otherCenters (from_toc:false), excluding the sentinel', () => {
+      const dropdown1 = [{ code: 'IRRI', from_toc: true }, { code: OTHER }];
+      const otherCentersSelected = [{ code: 'CIAT' }];
+
+      const merged = [
+        ...dropdown1.filter((c: any) => c?.code !== OTHER).map((c: any) => ({ ...c, from_toc: true })),
+        ...otherCentersSelected.map((c: any) => ({ ...c, from_toc: false }))
+      ];
+
+      expect(merged).toEqual([
+        { code: 'IRRI', from_toc: true },
+        { code: 'CIAT', from_toc: false }
+      ]);
+    });
+
+    it('should auto-open dropdown 2 when the ToC returns no centers (AC4)', () => {
+      const tocCenters: any[] = [];
+      const showOtherCenters = signal(tocCenters.length === 0);
+      expect(showOtherCenters()).toBe(true);
+    });
+  });
+
   describe('onResultTypeChange logic', () => {
     it('should update result_type_id in createResultBody', () => {
       const createResultBody = signal({

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/components/aow-hlo-table-create-modal/aow-hlo-create-modal.component.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/components/aow-hlo-table-create-modal/aow-hlo-create-modal.component.ts
@@ -54,7 +54,7 @@ export class AowHloCreateModalComponent implements OnInit {
     toc_progressive_narrative: '',
     result_type_id: null,
     contribution_to_indicator_target: null,
-    contributing_center: null
+    contributing_center: []
   });
   mqapJson = signal<any>(null);
   validatingHandler = signal<boolean>(false);
@@ -71,6 +71,26 @@ export class AowHloCreateModalComponent implements OnInit {
   });
 
   creatingResult = signal<boolean>(false);
+
+  // P2-3114: ToC/Other split for Contributing CGIAR Centers (mirrors the C&P surface).
+  readonly OTHER_CENTERS_CODE = '__OTHER_CENTERS__';
+  tocCenters = signal<any[]>([]);
+  otherCentersSelected = signal<any[]>([]);
+  showOtherCenters = signal<boolean>(false);
+
+  hasReferenceCenters = computed(() => this.tocCenters().length > 0);
+
+  // Dropdown 1: the ToC-derived centers + the "Other(s)" sentinel that opens dropdown 2.
+  dropdown1Options = computed(() => [
+    ...this.tocCenters(),
+    { code: this.OTHER_CENTERS_CODE, acronym: 'Other(s)', name: 'Other(s) CGIAR Centers', full_name: '<strong>Other(s) CGIAR Centers</strong>' }
+  ]);
+
+  // Dropdown 2: every center not derived from the ToC node.
+  otherCentersList = computed(() => {
+    const tocCodes = new Set(this.tocCenters().map((c: any) => c.code));
+    return this.centersSE.centersList.filter((c: any) => !tocCodes.has(c.code));
+  });
 
   ngOnInit() {
     this.entityAowService.getW3BilateralProjects();
@@ -92,6 +112,47 @@ export class AowHloCreateModalComponent implements OnInit {
         )?.options
       );
     }
+
+    this.preselectTocCenters();
+  }
+
+  // P2-3114: preselect the CGIAR Centers mapped in the selected indicator's ToC node.
+  // The AoW payload exposes them under indicators[0].targets_by_center.centers (by acronym).
+  // The ToC centers feed dropdown 1 (preselected, from_toc:true); the rest live in the "Other(s)" dropdown.
+  private preselectTocCenters(): void {
+    this.centersSE.getData().then(() => {
+      const tocAcronyms = (this.entityAowService.currentResultToReport()?.indicators?.[0]?.targets_by_center?.centers ?? [])
+        .map((center: any) => center?.center_acronym)
+        .filter(Boolean);
+
+      const preselected = this.centersSE.centersList
+        .filter((center: any) => tocAcronyms.includes(center.acronym))
+        .map((center: any) => ({ ...center, from_toc: true }));
+
+      this.tocCenters.set(preselected);
+      // AC4: when the ToC returns no reference centers, the Other(s) dropdown auto-activates.
+      this.showOtherCenters.set(preselected.length === 0);
+      this.createResultBody.set({ ...this.createResultBody(), contributing_center: [...preselected] });
+    });
+  }
+
+  // P2-3114: opening the "Other(s)" sentinel in dropdown 1 reveals dropdown 2 and keeps the sentinel out of the payload.
+  onContributingCenterSelect(event: any): void {
+    if (event?.option?.code === this.OTHER_CENTERS_CODE) {
+      this.showOtherCenters.set(true);
+      this.createResultBody.set({
+        ...this.createResultBody(),
+        contributing_center: (this.createResultBody().contributing_center ?? []).filter(
+          (center: any) => center?.code !== this.OTHER_CENTERS_CODE
+        )
+      });
+    }
+  }
+
+  deleteOtherCenter(index: number): void {
+    const next = [...this.otherCentersSelected()];
+    next.splice(index, 1);
+    this.otherCentersSelected.set(next);
   }
 
   onResultTypeChange(resultTypeId: number) {
@@ -217,7 +278,14 @@ export class AowHloCreateModalComponent implements OnInit {
       number_target: this.entityAowService.currentResultToReport()?.indicators?.[0]?.number_target,
       target_date: this.entityAowService.currentResultToReport()?.indicators?.[0]?.target_date,
       contributing_indicator: this.createResultBody().contribution_to_indicator_target,
-      contributing_center: this.createResultBody().contributing_center,
+      // P2-3114: merge dropdown 1 (ToC, from_toc:true) + dropdown 2 (Other, from_toc:false), dropping the sentinel,
+      // so the C&P form buckets them identically on redirect.
+      contributing_center: [
+        ...(this.createResultBody().contributing_center ?? [])
+          .filter((center: any) => center?.code !== this.OTHER_CENTERS_CODE)
+          .map((center: any) => ({ ...center, from_toc: true })),
+        ...this.otherCentersSelected().map((center: any) => ({ ...center, from_toc: false }))
+      ],
       knowledge_product: this.mqapJson(),
       toc_result_id: this.entityAowService.currentResultToReport().toc_result_id,
       toc_progressive_narrative: this.createResultBody().toc_progressive_narrative,

--- a/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-notifications/components/notification-item/notification-item.component.html
+++ b/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-notifications/components/notification-item/notification-item.component.html
@@ -76,6 +76,23 @@
           }
         </div>
 
+        <!-- P2-3085: read-only ToC metadata the submitter configured (from backend toc_contribution_review[]). -->
+        @if (notification?.is_map_to_toc && tocReview.length) {
+          <div class="toc_review">
+            @for (review of tocReview; track $index) {
+              <div class="toc_review_card">
+                <div class="toc_review_row"><span class="toc_review_label">Level</span><span class="toc_review_value">{{ review.level || '—' }}</span></div>
+                <div class="toc_review_row"><span class="toc_review_label">High Level Output / Intermediate Outcome / 2030 Outcome</span><span class="toc_review_value">{{ review.outcome_label || '—' }}</span></div>
+                <div class="toc_review_row"><span class="toc_review_label">Outcome Statement</span><span class="toc_review_value">{{ review.outcome_statement || '—' }}</span></div>
+                <div class="toc_review_row"><span class="toc_review_label">Indicator Typology</span><span class="toc_review_value">{{ review.indicator_typology || '—' }}</span></div>
+                <div class="toc_review_row"><span class="toc_review_label">Unit of measurement</span><span class="toc_review_value">{{ review.unit_of_measurement || '—' }}</span></div>
+                <div class="toc_review_row"><span class="toc_review_label">Target</span><span class="toc_review_value">{{ review.target ?? '—' }}</span></div>
+                <div class="toc_review_row"><span class="toc_review_label">Contribution Target</span><span class="toc_review_value">{{ review.contribution_target ?? '—' }}</span></div>
+              </div>
+            }
+          </div>
+        }
+
         <div class="notification_content_actions">
           @if (!isSent) {
             <!-- P2-3106: unify accept/reject labels to "Accept contribution" / "Decline contribution". Click handlers unchanged. -->

--- a/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-notifications/components/notification-item/notification-item.component.scss
+++ b/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-notifications/components/notification-item/notification-item.component.scss
@@ -139,3 +139,40 @@ p {
 .reject {
   color: var(--pr-color-red-500);
 }
+
+/* P2-3085: read-only ToC metadata block in the Contribution Request review */
+.toc_review {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 8px 0 4px;
+
+  &_card {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 10px 12px;
+    border: 1px solid var(--pr-color-neutral-300);
+    border-radius: 8px;
+    background: var(--pr-color-accents-1);
+  }
+
+  &_row {
+    display: flex;
+    gap: 8px;
+    align-items: baseline;
+    justify-content: space-between;
+  }
+
+  &_label {
+    color: var(--pr-color-neutral-600);
+    font-weight: 500;
+    flex: 0 0 auto;
+    max-width: 60%;
+  }
+
+  &_value {
+    color: var(--pr-color-black);
+    text-align: right;
+  }
+}

--- a/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-notifications/components/notification-item/notification-item.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-notifications/components/notification-item/notification-item.component.spec.ts
@@ -392,4 +392,32 @@ describe('NotificationItemComponent', () => {
       expect(emitSpy).toHaveBeenCalled();
     });
   });
+
+  describe('tocReview getter (P2-3085)', () => {
+    it('should return [] when toc_contribution_review is absent', () => {
+      component.notification = { is_map_to_toc: true };
+      expect(component.tocReview).toEqual([]);
+    });
+
+    it('should return [] when notification is null', () => {
+      component.notification = null;
+      expect(component.tocReview).toEqual([]);
+    });
+
+    it('should return the review entries when present', () => {
+      const entry = {
+        level: 'Output',
+        outcome_label: 'HLO1.AOW1.IO1',
+        outcome_statement: 'Statement text',
+        indicator_typology: 'Number of knowledge products',
+        unit_of_measurement: 'Number',
+        target: 6,
+        contribution_target: 2
+      };
+      component.notification = { is_map_to_toc: true, toc_contribution_review: [entry] };
+      expect(component.tocReview.length).toBe(1);
+      expect(component.tocReview[0].outcome_label).toBe('HLO1.AOW1.IO1');
+      expect(component.tocReview[0].contribution_target).toBe(2);
+    });
+  });
 });

--- a/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-notifications/components/notification-item/notification-item.component.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-notifications/components/notification-item/notification-item.component.ts
@@ -8,6 +8,20 @@ import { finalize } from 'rxjs/operators';
 import { Router } from '@angular/router';
 import { BilateralResultsService } from '../../../../../../../result-framework-reporting/pages/bilateral-results/bilateral-results.service';
 
+// P2-3085: shape of each ToC contribution review entry (backend contract, P2-3086).
+export interface TocContributionReview {
+  level?: string;
+  outcome_label?: string;
+  outcome_statement?: string;
+  indicator_typology?: string;
+  unit_of_measurement?: string;
+  target?: string | number;
+  contribution_target?: string | number;
+  toc_result_id?: number;
+  toc_results_indicator_id?: number;
+  planned_result?: boolean;
+}
+
 @Component({
   selector: 'app-notification-item',
   templateUrl: './notification-item.component.html',
@@ -46,6 +60,12 @@ export class NotificationItemComponent {
     return this.notification?.is_map_to_toc
       ? this.notification?.obj_owner_initiative?.official_code
       : this.notification?.obj_shared_inititiative?.official_code;
+  }
+
+  // P2-3085: ToC metadata the submitter configured, shown read-only in the Contribution Request review.
+  // Sourced from the backend `toc_contribution_review[]` (P2-3086); empty when absent / non-ToC requests.
+  get tocReview(): TocContributionReview[] {
+    return this.notification?.toc_contribution_review ?? [];
   }
 
   invalidateRequest() {

--- a/openspec/changes/p2-3085-notification-toc-review-fields/.openspec.yaml
+++ b/openspec/changes/p2-3085-notification-toc-review-fields/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/p2-3085-notification-toc-review-fields/design.md
+++ b/openspec/changes/p2-3085-notification-toc-review-fields/design.md
@@ -1,0 +1,42 @@
+# Design: P2-3085 — ToC review fields in the Contribution Request notification
+
+## Context
+
+`notification-item.component` renders each request in a `@switch` by type. The main contribution case shows the request sentence (inside an `@if (is_map_to_toc) … @else …`) followed by `.notification_content_actions` (Accept/Decline, P2-3106). The component takes `@Input() notification: any`. The backend now adds `notification.toc_contribution_review[]` for `is_map_to_toc: true` requests.
+
+## Goals / Non-Goals
+
+- **Goals:** render a read-only ToC review block (7 fields, fixed order) per `toc_contribution_review` entry, between the sentence and the actions; no change to accept/decline.
+- **Non-Goals:** editing any field, changing the request workflow, backend changes, the popup create surface (P2-3114).
+
+## Decisions
+
+### D1 — Placement & structure
+Insert the block inside the `@if (notification?.is_map_to_toc)` branch, after the request sentence (`~line 76`) and before `.notification_content_actions` (`~line 79`). Iterate `@for (review of tocReview(); track $index)`; render one card per entry with the 7 fields in AC order.
+
+### D2 — Typed accessor
+Add a getter/computed `tocReview()` returning `notification?.toc_contribution_review ?? []` so the template stays clean and null-safe. Optionally introduce a small interface `TocContributionReview` for the entry shape (level, outcome_label, outcome_statement, indicator_typology, unit_of_measurement, target, contribution_target, + ids) instead of `any`.
+
+### D3 — Read-only presentation
+All fields are display-only text (label + value), reusing the existing notification styles (`notification_content_body` / a new `.toc_review` block in the component scss). No form controls. "Read-only" fields (statement, typology, unit, target) are simply non-editable text — consistent with the ToC section's read-only rendering.
+
+### D4 — Empty / partial safety
+If `toc_contribution_review` is absent or empty (older payloads, non-ToC requests), render nothing (the block is gated on `is_map_to_toc` AND a non-empty array). Individual missing fields render a neutral placeholder (e.g. `—`) rather than "undefined".
+
+## Field mapping
+
+See proposal table. Open question carried to design: **Q1** — does AC "Statement" map to `outcome_statement` (assumed) or `statement`? Default to `outcome_statement`; if Juanda confirms otherwise, swap the binding (1-line change).
+
+## Risks / Trade-offs
+
+- **No runtime data (main risk):** the reviewer test user has no contribution requests. Mitigation: implement against Juanda's documented contract + unit tests with a fixture; do the runtime e2e once a test contribution exists (coordinate with Juanda/QA).
+- **Payload shape drift:** if `toc_contribution_review` keys differ from the contract, the block shows placeholders (D4) rather than breaking. Confirm keys against the first real payload.
+
+## Migration / Rollout
+
+Frontend-only, gated on `is_map_to_toc` + non-empty `toc_contribution_review`. Safe to ship ahead of having runtime data (renders nothing without the array).
+
+## Open Questions
+
+- **Q1:** "Statement" → `outcome_statement` vs `statement` (default `outcome_statement`).
+- **Q2:** should multiple `toc_contribution_review` entries be visually separated (one card each) — assumed yes.

--- a/openspec/changes/p2-3085-notification-toc-review-fields/proposal.md
+++ b/openspec/changes/p2-3085-notification-toc-review-fields/proposal.md
@@ -1,0 +1,44 @@
+# Proposal: P2-3085 — Show updated ToC metadata fields in the Contribution Request review
+
+## Why
+
+When an SP Contributor opens a Contribution Request notification to accept/reject a result contribution (`is_map_to_toc: true`), the review interface currently shows only the request sentence + Accept/Decline buttons — none of the ToC metadata the submitter configured. The user cannot see the mapped targets/indicators before deciding (P2-3003 / P2-3085).
+
+The backend (P2-3086, Juanda — already deployed to test) now enriches `request/get/received` (and sent/popup) for `is_map_to_toc: true` requests with a `toc_contribution_review[]` array (one entry per contribution), carrying the exact fields the ToC section shows, plus useful ids (`toc_result_id`, `toc_results_indicator_id`, `planned_result`).
+
+## What Changes
+
+- In `notification-item.component`, when `is_map_to_toc: true`, render a read-only ToC review block from `notification.toc_contribution_review[]`, placed between the request sentence and the Accept/Decline actions.
+- Display the fields in this exact order (per AC1): **Level · HLO/IO/2030 Outcome · HLO/IO/2030 Outcome Statement (read-only) · Indicator Typology (read-only) · Unit of measurement (read-only) · Target (read-only) · Contribution Target**.
+- One block per entry in `toc_contribution_review[]` (a request may cover multiple contributions).
+- No behavior change to Accept/Decline (P2-3106) — this is presentation only.
+
+## Capabilities
+
+### New Capabilities
+- `notification-toc-review`: the Contribution Request review interface renders the submitter's ToC metadata (level, outcome, statement, indicator typology, unit, target, contribution target) read-only, sourced from `toc_contribution_review[]`, so the contributor reviews the mapping before accepting or rejecting.
+
+### Modified Capabilities
+<!-- none — P2-3106 covered the accept/decline labels + validation; the review fields are new presentation. -->
+
+## Impact
+
+- `onecgiar-pr-client/.../notification-item/notification-item.component.{html,ts,scss}` — the read-only ToC block + a typed accessor for `toc_contribution_review`.
+- Jest specs for the component.
+- Depends on the backend `toc_contribution_review[]` payload (P2-3086, in test).
+- **Out of scope:** the Accept/Decline flow, the popup/sent surfaces beyond rendering the same block if present, any backend change.
+- **Verification note:** end-to-end runtime verification needs a real Contribution Request with `is_map_to_toc: true` in the reviewer's inbox — the current test user has none; coordinate a test contribution with Juanda/QA.
+
+## Field mapping (from Juanda's contract)
+
+| AC field | payload key |
+|---|---|
+| Level | `level` |
+| HLO/IO/2030 Outcome | `outcome_label` |
+| HLO/IO/2030 Outcome Statement (RO) | `outcome_statement` |
+| Indicator Typology (RO) | `indicator_typology` |
+| Unit of measurement (RO) | `unit_of_measurement` |
+| Target (RO) | `target` |
+| Contribution Target | `contribution_target` |
+
+> Open: the payload also carries `statement` (likely the indicator statement, distinct from `outcome_statement`). Confirm with Juanda whether the AC "Statement" means the outcome statement (assumed) or the indicator statement.

--- a/openspec/changes/p2-3085-notification-toc-review-fields/specs/notification-toc-review/spec.md
+++ b/openspec/changes/p2-3085-notification-toc-review-fields/specs/notification-toc-review/spec.md
@@ -1,0 +1,35 @@
+# Spec: notification-toc-review
+
+## ADDED Requirements
+
+### Requirement: ToC review fields shown in the Contribution Request notification
+When a user opens a Contribution Request notification with `is_map_to_toc: true` that carries a non-empty `toc_contribution_review`, the review interface SHALL display, for each contribution, the ToC metadata fields read-only in this exact order: Level, HLO/IO/2030 Outcome, HLO/IO/2030 Outcome Statement, Indicator Typology, Unit of measurement, Target, Contribution Target.
+
+#### Scenario: ToC request shows the metadata block
+- **WHEN** a `is_map_to_toc: true` request with a `toc_contribution_review` entry is rendered
+- **THEN** the seven fields SHALL appear, in the specified order, between the request sentence and the Accept/Decline actions
+
+#### Scenario: multiple contributions render one block each
+- **WHEN** `toc_contribution_review` has more than one entry
+- **THEN** each entry SHALL render its own metadata block
+
+### Requirement: block is hidden when there is no ToC review data
+The metadata block SHALL NOT render when the request is not ToC-mapped or when `toc_contribution_review` is absent or empty.
+
+#### Scenario: non-ToC request shows no block
+- **WHEN** a request has `is_map_to_toc: false` (or no `toc_contribution_review`)
+- **THEN** no ToC metadata block SHALL be shown and the existing sentence + actions render unchanged
+
+### Requirement: missing individual fields degrade gracefully
+A missing individual field value SHALL render a neutral placeholder, never the literal text "undefined" or "null".
+
+#### Scenario: absent field value
+- **WHEN** an entry lacks one of the fields (e.g. no `target`)
+- **THEN** that field SHALL show a neutral placeholder (e.g. "—") instead of "undefined"
+
+### Requirement: Accept/Decline behavior unchanged
+Rendering the ToC review block SHALL NOT alter the Accept/Decline actions or their validation (P2-3106).
+
+#### Scenario: actions still work with the block present
+- **WHEN** the ToC block is shown
+- **THEN** the Accept contribution / Decline contribution buttons SHALL behave exactly as before

--- a/openspec/changes/p2-3085-notification-toc-review-fields/tasks.md
+++ b/openspec/changes/p2-3085-notification-toc-review-fields/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: P2-3085 — ToC review fields in the Contribution Request notification
+
+## 1. Component logic
+- [x] 1.1 Add a `TocContributionReview` interface (level, outcome_label, outcome_statement, indicator_typology, unit_of_measurement, target, contribution_target, toc_result_id, toc_results_indicator_id, planned_result).
+- [x] 1.2 Add `tocReview()` accessor on `notification-item.component.ts` returning `notification?.toc_contribution_review ?? []`.
+
+## 2. Template
+- [x] 2.1 In `notification-item.component.html`, inside the `@if (notification?.is_map_to_toc)` branch, after the request sentence and before `.notification_content_actions`, add `@if (tocReview().length) { … }`.
+- [x] 2.2 `@for (review of tocReview(); track $index)` → one card per entry, rendering the 7 fields in AC order (Level, HLO/IO/2030 Outcome, Outcome Statement, Indicator Typology, Unit of measurement, Target, Contribution Target).
+- [x] 2.3 Neutral placeholder ("—") for missing values (D4).
+
+## 3. Styles
+- [x] 3.1 Add a `.toc_review` block in `notification-item.component.scss` (label/value rows, read-only look, multi-card separation), reusing `--pr-*` tokens.
+
+## 4. Tests
+- [x] 4.1 Jest: `tocReview()` returns `[]` when absent and the array when present.
+- [ ] 4.2 Jest (fixture from Juanda's contract): block renders the 7 fields in order for a ToC request; hidden for non-ToC / empty.
+- [ ] 4.3 Jest: missing field → placeholder, never "undefined".
+
+## 5. Verification
+- [ ] 5.1 BLOCKED on data: e2e runtime needs a real `is_map_to_toc: true` request in the reviewer's inbox. Coordinate a test contribution with Juanda/QA, then verify the 7 fields render in order and Accept/Decline still work.
+- [ ] 5.2 Confirm field mapping Q1 (`outcome_statement` vs `statement`) against the first real payload.

--- a/openspec/changes/p2-3114-popup-toc-prefill-centers-sp/.openspec.yaml
+++ b/openspec/changes/p2-3114-popup-toc-prefill-centers-sp/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/p2-3114-popup-toc-prefill-centers-sp/design.md
+++ b/openspec/changes/p2-3114-popup-toc-prefill-centers-sp/design.md
@@ -1,0 +1,42 @@
+# Design: P2-3114 — ToC prefill for Centers & SP in the Report-result popup
+
+## Context
+
+The popup lives in `aow-hlo-create-modal.component.{ts,html}`; its state is held in `entity-aow.service.ts`. On open, `aow-hlo-table.openReportResultModal(item, indicatorId)` sets `currentResultToReport = { ...item, indicators: [selectedIndicator] }`. The selected indicator already carries `targets_by_center.centers: { center_id, target_value }[]` — the ToC-mapped centers for that node. `createResult()` builds the create payload and sends `contributing_center`, `contributors_result_toc_result` (selected SP entities), and `bilateral_project`.
+
+The C&P surface (result detail) already implements the target behavior: two buckets per field — ToC-derived (`from_toc: true`, preselected) and Other (`from_toc: false`) — reconciled reactively and merged in `onSaveSection`. We mirror the *shape* of that contract in the popup, at a smaller scale (single-shot creation, no reactive reconciliation loop needed because the indicator/node is fixed for the popup session).
+
+## Goals / Non-Goals
+
+- **Goals:** preselect ToC-mapped Centers (and SP) on popup open; expose "Other(s)" dropdowns for the remainder; tag `from_toc`; carry tags into the create payload; fix the "(undefined)" chip label.
+- **Non-Goals:** reactive re-derivation on node change (the popup targets a single fixed indicator), C&P surface changes, bilateral behavior, backend changes for Centers.
+
+## Decisions
+
+### D1 — Centers: derive from `targets_by_center.centers`
+On popup open, map `currentResultToReport().indicators[0].targets_by_center.centers[].center_id` to the matching entries in `centersSE.centersList` (by code/id) to build the **ToC bucket** (preselected, `from_toc: true`). The main Centers dropdown shows the ToC bucket; an **"Other(s) Contributing CGIAR Centers"** dropdown (enabled via a sentinel "Other" option, matching the C&P UX) offers the remaining centers (`from_toc: false`). `createResult()` sends `contributing_center = [...tocCenters, ...otherCenters]` with `from_toc` on each, reusing the C&P payload shape so `handleContributingCenters` persists the flag.
+
+### D2 — Science Programs: split with ToC bucket (data source TBD)
+Mirror D1 for SP: a main dropdown preseleccts the ToC-derived SP + an **"Other(s) Science Program(s)"** dropdown for the rest. **Open dependency:** unlike Centers, the indicator payload does not clearly expose the ToC synergy SP. Options, in order of preference: (a) a field already present on the AoW `item`/indicator response (verify the raw GET); (b) reuse of the same source the C&P uses; (c) a backend addition (coordinate with Juanda). Until confirmed, the SP dropdown keeps today's manual behavior and the ToC-preselect for SP is gated behind the confirmed source — shipped separately if needed, so Centers is not blocked.
+
+### D3 — `from_toc` end-to-end
+Preselected (ToC) items → `from_toc: true`; Other-dropdown items → `from_toc: false`. This matches the C&P `onSaveSection` merge and the `handleContributingCenters` / SP persistence contract, so the C&P form on redirect buckets them identically (no drift).
+
+### D4 — Fix "Center(s) selected (undefined)" chip
+The multiselect chip label interpolates an undefined count/label. Bind the `selectedLabel`/count to the actual selected array length (or the item's display field), so the summary reads e.g. "2 Center(s) selected".
+
+## Risks / Trade-offs
+
+- **SP source (D2):** the main risk. Mitigated by shipping Centers first and gating SP preselect behind a confirmed data source; the popup remains functional (manual SP) if the source is missing.
+- **Duplication with C&P:** the create payload already re-derives on the C&P form. Sending `from_toc` from the popup keeps the two surfaces consistent instead of divergent; not sending it would let the C&P silently re-bucket, which is the current inconsistent behavior we are removing.
+- **CLARISA id/code mapping (D1):** `targets_by_center.centers` uses `center_id`; the dropdown options key on `code`. Confirm the join key when mapping.
+
+## Migration / Rollout
+
+Frontend-only (assuming Centers path). Behind the existing 2026 popup; no flag needed. If D2 needs backend, split into a follow-up task gated on Juanda's payload.
+
+## Open Questions
+
+- **Q1 (blocking SP only) — RESOLVED as a GAP:** the AoW `toc-results` response exposes no Science Program / synergy field on the node or indicator. SP preselect needs a backend source (Juanda).
+- **Q2 — RESOLVED:** join key is `targets_by_center.centers[].center_acronym` → `CenterDto.acronym` (then take `.code`). `CenterDto = { code, financial_code, name, acronym, full_name }`.
+- **Q3 — Binding inconsistency to fix first:** the Centers `<app-pr-multi-select>` uses `optionValue="code"`, so `createResultBody().contributing_center` holds an array of **code strings** — yet the chip `*ngFor` reads `center?.name` / `center.from_cgspace` (**objects**), and the create payload / `from_toc` tagging need objects too. This mismatch is the likely source of the "(undefined)" chip. Fix: drop `optionValue="code"` so the model holds full center objects (matching the C&P shape), and align the chip loop + `createResult()` payload accordingly.

--- a/openspec/changes/p2-3114-popup-toc-prefill-centers-sp/proposal.md
+++ b/openspec/changes/p2-3114-popup-toc-prefill-centers-sp/proposal.md
@@ -1,0 +1,36 @@
+# Proposal: P2-3114 — Apply ToC business rules for Centers & Science Programs in the Report-result popup
+
+## Why
+
+The 2026 ToC business rules for **Contributing CGIAR Centers** (P2-2998) and **Contributing Science Programs** (P2-2929) were implemented only in the Contributors & Partners section of the result detail. Their own acceptance criteria, however, state: *"this behavior applies as the first popup when a result is being created."* The `reactive-toc-prefill` change also flags the popup as pending (out of scope there, tracked as **P2-3114**).
+
+Today the Report-result popup (`aow-hlo-create-modal`) ignores the ToC entirely:
+- **Centers** dropdown is bound to the full CLARISA list (`centersSE.centersList`), manual selection only — no ToC preselection, no ToC/Other split, no `from_toc` tag.
+- **Science Programs** dropdown is bound to `allInitiatives()`, manual selection only — same gaps.
+
+So a user reporting an indicator whose ToC node maps specific centers/SP must re-pick them by hand, and nothing is tagged `from_toc`. When they land on the C&P form after creation, the section re-derives the ToC preselection, creating an inconsistent two-step experience the AC intended to avoid.
+
+A minor display defect is also visible: the Centers multiselect chip renders **"Center(s) selected (undefined)"**.
+
+## What Changes
+
+- In the Report-result popup, when the user opens it for an indicator, **derive the ToC-mapped Centers** from the indicator payload already present (`currentResultToReport().indicators[0].targets_by_center.centers`) and **preselect** them in a first dropdown, with an **"Other(s) Contributing CGIAR Centers"** dropdown enabled for the rest. Tag preselected items `from_toc: true`, Other items `from_toc: false`.
+- Apply the equivalent split for **Science Programs**: a first dropdown with the ToC-derived SP preselected + an **"Other(s) Science Program(s)"** dropdown. (See design — the SP ToC source in the popup context is a data dependency to confirm.)
+- Carry the `from_toc` tags into the create payload (`bilateral_project` unaffected; `contributing_center` and the SP contribution list gain `from_toc`) so the C&P form shows the same preselection after redirect, with no re-derivation drift.
+- Fix the **"Center(s) selected (undefined)"** chip label.
+
+## Capabilities
+
+### New Capabilities
+- `popup-toc-prefill`: on the Report-result creation popup, preselect the ToC-mapped Contributing CGIAR Centers and Science Programs derived from the selected indicator's ToC node, expose "Other(s)" dropdowns for the remainder, and persist the `from_toc` distinction into the created result so the C&P form is consistent on redirect.
+
+### Modified Capabilities
+<!-- none — the existing C&P specs cover the result-detail surface; the popup surface is new behavior. -->
+
+## Impact
+
+- `onecgiar-pr-client/.../aow-hlo-table/components/aow-hlo-table-create-modal/aow-hlo-create-modal.component.{ts,html}` — Centers & SP dropdowns, split logic, `from_toc` tagging, chip label fix.
+- `onecgiar-pr-client/.../entity-aow/services/entity-aow.service.ts` — derive/expose ToC-mapped centers & SP for the popup; reset on close.
+- Jest specs for the popup component + service.
+- **Out of scope:** the C&P result-detail surface (already done — P2-2929/P2-2998), the W3/bilateral dropdown (P2-3001, SP-level list, node-independent by design), any backend change (assumed the indicator payload already carries `targets_by_center.centers`; SP source TBD in design).
+- **Dependency/risk:** the ToC-mapped **Science Programs** source in the popup is not yet confirmed in the indicator payload (Centers are, via `targets_by_center.centers`). If unavailable, SP preselection needs a data source from backend (coordinate with Juanda, P2-3114 owner).

--- a/openspec/changes/p2-3114-popup-toc-prefill-centers-sp/specs/popup-toc-prefill/spec.md
+++ b/openspec/changes/p2-3114-popup-toc-prefill-centers-sp/specs/popup-toc-prefill/spec.md
@@ -1,0 +1,39 @@
+# Spec: popup-toc-prefill
+
+## ADDED Requirements
+
+### Requirement: Centers preselected from the indicator's ToC node in the Report-result popup
+When the user opens the Report-result popup for an indicator whose ToC node maps CGIAR Centers, those centers SHALL be preselected in the main "Contributing CGIAR Centers" dropdown and tagged `from_toc: true`, without the user selecting them manually.
+
+#### Scenario: node with mapped centers preselects them
+- **WHEN** the user clicks "Report result" on an indicator whose `targets_by_center.centers` is non-empty
+- **THEN** the popup SHALL preselect those centers in the Centers dropdown, each tagged `from_toc: true`
+
+#### Scenario: node without mapped centers preselects nothing
+- **WHEN** the indicator's `targets_by_center.centers` is empty
+- **THEN** no center SHALL be preselected and the user may add centers only via the "Other(s)" dropdown
+
+### Requirement: "Other(s)" dropdowns for non-ToC Centers and Science Programs
+The popup SHALL expose an "Other(s) Contributing CGIAR Centers" dropdown and an "Other(s) Science Program(s)" dropdown, enabled when the user chooses the "Other" option in the main dropdown, offering the entries not derived from the ToC node. Items chosen there SHALL be tagged `from_toc: false`.
+
+#### Scenario: adding a non-ToC center
+- **WHEN** the user selects "Other" in the Centers dropdown and picks a center not mapped by the ToC node
+- **THEN** that center SHALL be added tagged `from_toc: false`, alongside the ToC-preselected ones
+
+#### Scenario: Other option is not itself persisted
+- **WHEN** the create payload is built
+- **THEN** the "Other" sentinel option SHALL NOT be sent as a contributing center/SP; only real selections are sent
+
+### Requirement: from_toc tags carried into the create payload for form consistency
+When the result is created, the `contributing_center` (and the Science Program contribution list) SHALL include the `from_toc` flag per item, so that on redirect to the Contributors & Partners form the same items appear in the ToC bucket vs the Other bucket with no re-derivation drift.
+
+#### Scenario: preselection persists into the C&P form
+- **WHEN** the user creates the result from the popup with ToC-preselected centers and is redirected to the C&P form
+- **THEN** those centers SHALL appear in the ToC (preselected) bucket, not re-bucketed as Other
+
+### Requirement: Centers multiselect chip shows a valid count
+The Centers multiselect summary chip SHALL display the actual number of selected centers, never the literal text "undefined".
+
+#### Scenario: chip label with selections
+- **WHEN** two centers are selected in the popup
+- **THEN** the chip summary SHALL read a valid count (e.g. "2 Center(s) selected"), not "Center(s) selected (undefined)"

--- a/openspec/changes/p2-3114-popup-toc-prefill-centers-sp/tasks.md
+++ b/openspec/changes/p2-3114-popup-toc-prefill-centers-sp/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: P2-3114 — ToC prefill for Centers & SP in the Report-result popup
+
+## 1. Investigation / data sources
+- [x] 1.1 CONFIRMED: `targets_by_center.centers[] = { center_id, center_acronym, center_name }`. Join key is **`center_acronym` → `code`** (Centers dropdown uses `optionValue="code"`). (prtest GET `toc-results?program=SP01&areaOfWork=AOW01`)
+- [x] 1.2 CONFIRMED GAP: the AoW `toc-results` response (node = `{ toc_result_id, category, result_title, related_node_id, result_level_id, indicators[] }`) exposes **no Science Program / synergy field**. SP preselect in the popup is **blocked on a backend source** — hand to Juanda (P2-3114 owner). Centers path proceeds independently.
+
+## 2. Centers — ToC preselect + Other split (not blocked)
+- [x] 2.1 DONE (in component, not service): `preselectTocCenters()` in `ngOnInit` derives the ToC centers from `currentResultToReport().indicators[0].targets_by_center.centers` (by `center_acronym` → `CenterDto.acronym`) via `centersSE.getData()`, tags `from_toc:true`, and sets `createResultBody().contributing_center`.
+- [x] 2.2 DONE: visual 2-dropdown split implemented (mirrors C&P) — dropdown 1 = ToC centers + "Other(s)" sentinel (`dropdown1Options`); `onContributingCenterSelect` opens dropdown 2 on sentinel; dropdown 2 = `otherCentersList` (non-ToC), `[(ngModel)]=otherCentersSelected`; both with chips; AC4 auto-opens dropdown 2 when ToC has no centers. Runtime: dropdown 1 (IRRI + "Other(s)") verified; dropdown 2 appearance covered by unit tests (overlay virtual-scroll not automated; logic identical to C&P in prod).
+- [x] 2.3 DONE: `createResult()` maps `contributing_center` with `from_toc: c.from_toc ?? false` (ToC-preselected = true, manually-added = false).
+- [x] 2.4 DONE: fixed "Center(s) selected (undefined)" — root cause was `contributing_center: null` default (pr-multi-select renders `(${value?.length})`); changed default to `[]`. NOTE: reverted an initial wrong attempt to drop `optionValue="code"` — the custom pr-multi-select needs it for `writeValue`/`onSelectOption` matching.
+
+## 3. Science Programs — ToC preselect + Other split (gated on 1.2)
+- [ ] 3.1 If the SP ToC source is confirmed: derive the SP ToC bucket on popup open and expose/reset it in the service.
+- [ ] 3.2 Add the split UI (main SP dropdown preselected + "Other(s) Science Program(s)" dropdown) in the template.
+- [ ] 3.3 Carry `from_toc` on the SP contribution list into the create payload.
+- [ ] 3.4 If the source is NOT available, keep today's manual SP behavior and hand the backend dependency to Juanda; ship Centers (section 2) independently.
+
+## 4. Tests
+- [x] 4.1 Jest: preselect derives ToC centers tagged `from_toc:true`; empty node preselects none. (11/11 passing)
+- [x] 4.3 Jest: create payload defaults `from_toc:false` for manually-added centers.
+- [x] 4.2 Jest: sentinel opens dropdown 2 + drops sentinel; merge ToC(from_toc:true)+Other(from_toc:false); AC4 auto-open. (14/14 passing)
+- [ ] 4.4 Jest (blocked): SP preselect — pending backend source (Juanda).
+
+## 5. Verification
+- [x] 5.1 DONE (runtime, local front vs prtest-back): opened the popup on indicator 7295 (SP01/AOW01, innovation development, ToC center IRRI) → **IRRI preselected** (chip + checkbox marked), chip count "(1)" not "(undefined)". Screenshot `p2-3114-centers-preselect-IRRI-local.png`.
+- [x] 5.2 DONE (runtime e2e, result 8604/id 11072, then deleted): created from the popup with preselected IRRI + 1 bilateral → C&P GET `contributors-partners/11072` returned `contributing_center: [{code:"CENTER-13", acronym:"IRRI", from_toc:1}]` (ToC bucket) and `bilateral_projects: ["8"]`. Centers persist with `from_toc`; W3/bilateral (P2-3001) no regression.


### PR DESCRIPTION
## What was done
- **P2-3114** — In the Report-result creation popup, Contributing CGIAR Centers now **preselect** the centers mapped in the selected indicator's ToC node, split into a first dropdown (ToC, tagged `from_toc`) + an **"Other(s)"** dropdown for the rest. Fixes the "Center(s) selected (undefined)" chip.
- **P2-3085** — The Contribution Request notification review now shows the submitter's **ToC metadata read-only** (Level, HLO/IO/2030 Outcome, Outcome Statement, Indicator Typology, Unit of measurement, Target, Contribution Target), sourced from the backend `toc_contribution_review[]`.

## Why
Apply the 2026 ToC business rules where they were still missing: the creation popup (AC of P2-2998/P2-2929 said it applies "as the first popup when a result is being created") and the contribution-review notification (P2-3003).

## How to verify
- **P2-3114 (Centers):** open an indicator whose ToC node maps centers → Report result → the centers appear preselected; picking "Other(s)" reveals the second dropdown; on create they persist with `from_toc` and show in the C&P ToC bucket. *(Verified e2e on prtest-back.)*
- **P2-3085:** open a ToC-mapped Contribution Request (`is_map_to_toc: true`) → the 7 ToC fields render read-only before Accept/Decline. *(Runtime pending a real ToC contribution request.)*

## Not included
- **P2-3114 Science Programs preselect** — pending backend (the AoW payload doesn't expose ToC synergy SPs) → Juanda.

## Technical references
- Branch: `P2-2928-TOC-Improvements`
- Commits: `2037bb1b` (P2-3114), `8472545` (P2-3085)
- Tests: 14/14 (popup) + 13/13 (notification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)