### PR TITLE
🎨 style(rd-evidences) P2-3045: update evidence guidance video tutorial link

### DIFF
--- a/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.ts
@@ -50,7 +50,7 @@ export class RdEvidencesComponent implements OnInit {
     <li>Links to SharePoint, One Drive, Google Drive, DropBox and other file storage platforms are not allowed.</li>
     <li>Files can be also uploaded to the PRMS repository.</li>
     <li>For confidential evidence, select “Upload file” and then “No” to indicate that it should not be public.</li>
-    <li>If you need additional information or guidance on how to create an evidence entry, you can find a video tutorial at the following a <a class="open_route" href="https://cgiar.sharepoint.com/:v:/s/OneCGIARPRMSRepository/ETb3eWyBPm9FumJV75XyUDABeVD57nTvz9zz1kNzL_Ob9w?e=kvLk2t" target="_blank">link</a>.</li>
+    <li>If you need additional information or guidance on how to create an evidence entry, you can find a video tutorial at the following a <a class="open_route" href="https://cgiar.sharepoint.com/:v:/s/OneCGIARPRMSRepository/IQCPCRtUOihDQKJExjQgfIOIAZQAZH4pnHDucy3HX-w14WU?e=Xoy42x" target="_blank">link</a>.</li>
     `;
 
     if (this.api.dataControlSE?.currentResult?.result_type_id === 5)

--- a/openspec/changes/p2-3045-update-evidence-guidance-video-link/.openspec.yaml
+++ b/openspec/changes/p2-3045-update-evidence-guidance-video-link/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/p2-3045-update-evidence-guidance-video-link/design.md
+++ b/openspec/changes/p2-3045-update-evidence-guidance-video-link/design.md
@@ -1,0 +1,25 @@
+## Context
+
+P2-3045 is a copy-only adjustment to an existing help tip in the Result Detail → Evidence section (`rd-evidences`). The tip is a static HTML string returned by the `information` getter in `rd-evidences.component.ts` and rendered as a bulleted list; one `<li>` links to an external SharePoint video tutorial via `<a class="open_route" target="_blank">`.
+
+The video content itself lives on SharePoint (OneCGIAR PRMS Repository) and was re-recorded outside the codebase. The app only stores the link, so the entire scope of this change in the repository is the URL string.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Point the existing tutorial link at the new SharePoint recording.
+
+**Non-Goals:**
+- No change to the tip wording, its `<a>` markup/attributes, its position in the list, or any Evidence-section logic.
+- No change to how or when the tip is rendered.
+- No backend, API, or data-contract change.
+
+## Decisions
+
+- **Edit the URL literal in place.** The link appears in exactly one location (verified by grep for the old URL and for "video tutorial" across `onecgiar-pr-client/src`). Swapping the string is the minimal, complete change.
+- **No unit test added.** The link is a static string with no branching logic to assert; the value is verified by grep (no old occurrence remains) and by manual click-through. This matches the low-risk, copy-only nature of the change.
+
+## Risks / Trade-offs
+
+- [Hardcoded SharePoint URL, not sourced from config] → Accepted: this matches the existing implementation and every other help link in the app; externalizing tutorial links is out of scope for a link swap.
+- [Link could go stale again if the video is re-recorded] → Accepted: same operational process (QA provides the new link) applies; no code mitigation warranted.

--- a/openspec/changes/p2-3045-update-evidence-guidance-video-link/proposal.md
+++ b/openspec/changes/p2-3045-update-evidence-guidance-video-link/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The Result Detail → Evidence section shows a help tip pointing users to a video tutorial on how to create an evidence entry. That tutorial was **re-recorded** to reflect the latest evidence-upload flow — specifically, it now explains that selecting a principal contribution score (2) for an Impact Area in Tab 1 (General Information) requires evidence to be attached.
+
+Santi uploaded the new recording to the OneCGIAR PRMS Repository on SharePoint and QA (María Camila) confirmed the final version. The only remaining task is to point the in-app link at the new video so users are redirected to the up-to-date resource instead of the outdated one (P2-3045).
+
+This is a **frontend-only, one-line copy change**: swap the SharePoint URL. No backend, no behavior, no styling change.
+
+## What Changes
+
+- In the Evidence-section help tip, replace the outdated tutorial video URL with the new one provided by QA:
+  - Old: `https://cgiar.sharepoint.com/:v:/s/OneCGIARPRMSRepository/ETb3eWyBPm9FumJV75XyUDABeVD57nTvz9zz1kNzL_Ob9w?e=kvLk2t`
+  - New: `https://cgiar.sharepoint.com/:v:/s/OneCGIARPRMSRepository/IQCPCRtUOihDQKJExjQgfIOIAZQAZH4pnHDucy3HX-w14WU?e=Xoy42x`
+- No change to the surrounding sentence, the `<a class="open_route" target="_blank">` markup, the tip's placement, or the trigger logic.
+
+## Capabilities
+
+### New Capabilities
+- `evidence-guidance-video-link`: The in-app help tip in the Evidence section that links users to the external video tutorial on how to create an evidence entry.
+
+### Modified Capabilities
+<!-- None — no existing spec covers this behavior. -->
+
+## Impact
+
+- **Frontend only** — `onecgiar-pr-client`.
+- File: `src/app/pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.component.ts` — the `information` getter (help-tip `<li>` template string).
+- No backend, API, entity, DTO, or migration changes.
+- SDD baseline: UI copy governed by `docs/system-design/design.md`; no requirement-level change to `docs/prd.md` or `docs/detailed-design/detailed-design.md`.
+- Jira: **P2-3045** (Enhancement under epic P2-2338 "Enhancements 2026").

--- a/openspec/changes/p2-3045-update-evidence-guidance-video-link/specs/evidence-guidance-video-link/spec.md
+++ b/openspec/changes/p2-3045-update-evidence-guidance-video-link/specs/evidence-guidance-video-link/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: Evidence-section tutorial video link points to the current recording
+
+The Evidence section SHALL show a help tip linking users to the external video tutorial on how to create an evidence entry. The link's `href` MUST point to the current SharePoint recording:
+
+`https://cgiar.sharepoint.com/:v:/s/OneCGIARPRMSRepository/IQCPCRtUOihDQKJExjQgfIOIAZQAZH4pnHDucy3HX-w14WU?e=Xoy42x`
+
+The link MUST open in a new tab (`target="_blank"`) and keep the surrounding help-tip wording unchanged.
+
+#### Scenario: User opens the tutorial link from the Evidence section
+- **WHEN** a user viewing a result's Evidence section clicks the "video tutorial" link in the help tip
+- **THEN** a new browser tab opens the current SharePoint recording (`IQCPCRtUOihD…?e=Xoy42x`)
+- **AND** the outdated recording (`ETb3eWyBPm9F…?e=kvLk2t`) is no longer referenced anywhere in the client

--- a/openspec/changes/p2-3045-update-evidence-guidance-video-link/tasks.md
+++ b/openspec/changes/p2-3045-update-evidence-guidance-video-link/tasks.md
@@ -1,0 +1,8 @@
+## 1. Update the tutorial video link
+
+- [x] 1.1 In `rd-evidences.component.ts`, replace the old SharePoint video URL (`ETb3eWyBPm9F…?e=kvLk2t`) with the new one (`IQCPCRtUOihD…?e=Xoy42x`) in the Evidence-section help tip, keeping the sentence and `<a class="open_route" target="_blank">link</a>` markup unchanged.
+
+## 2. Verification
+
+- [x] 2.1 Confirm the URL is the only change and no other occurrence of the old link remains (`grep` across `onecgiar-pr-client/src`).
+- [ ] 2.2 Manually verify in the browser: open a result's Evidence section, click the "video tutorial" link, and confirm it opens the new recording.


### PR DESCRIPTION
## What was done
- Updated the "video tutorial" link in the Evidence section (Result Detail) so it points to the newly re-recorded tutorial that Santi uploaded to the OneCGIAR PRMS Repository on SharePoint, replacing the outdated one (P2-3045).

## Why
- QA (María Camila) flagged that the in-app tutorial link still pointed to the old recording. The video was re-recorded to reflect the current evidence-upload flow (selecting a principal contribution score of 2 for an Impact Area in Tab 1 → General Information requires evidence).

## How to verify
- Open any result → Evidence section.
- In the help tips, click the "video tutorial" link.
- Confirm it opens the new recording in a new tab.

## Scope / risk
- Frontend only, single-line copy change (a static `href`). No logic, styling, backend, API, or migration changes.
- File: `onecgiar-pr-client/.../rd-evidences/rd-evidences.component.ts`
- SDD: OpenSpec change `p2-3045-update-evidence-guidance-video-link` included.

## Technical references
- Jira: P2-3045 (Enhancement under epic P2-2338)
- Branch: `P2-3045-Update-the-evidence-guidance-video-according-to-the-latest-system-changes`
- Commit: `2f8676d18`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
