### PR TITLE
🚀 release: P2-3141 AoW-level indicator search bar

### DIFF
--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-2030/entity-aow-2030.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-2030/entity-aow-2030.component.spec.ts
@@ -16,6 +16,7 @@ describe('EntityAow2030Component', () => {
       currentAowSelected: jest.fn(() => ({})),
       get2030Outcomes: jest.fn(),
       tocResults2030Outcomes: signal<any[]>([]),
+      searchText: signal<string>(''),
       isLoadingTocResults2030Outcomes: signal<boolean>(false),
       isLoadingTocResultsByAowId: signal<boolean>(false),
       showReportResultModal: signal<boolean>(false),
@@ -43,6 +44,14 @@ describe('EntityAow2030Component', () => {
   });
 
   describe('ngOnInit', () => {
+    it('should reset searchText on init (P2-3141)', () => {
+      mockEntityAowService.searchText.set('stale query');
+
+      component.ngOnInit();
+
+      expect(mockEntityAowService.searchText()).toBe('');
+    });
+
     it('should call get2030Outcomes with entityId from service', () => {
       const entityId = 'test-entity-id';
       mockEntityAowService.entityId.set(entityId);

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-2030/entity-aow-2030.component.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-2030/entity-aow-2030.component.ts
@@ -14,6 +14,7 @@ export class EntityAow2030Component implements OnInit {
   entityAowService = inject(EntityAowService);
 
   ngOnInit() {
+    this.entityAowService.searchText.set('');
     this.entityAowService.get2030Outcomes(this.entityAowService.entityId());
   }
 }

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.html
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.html
@@ -1,7 +1,16 @@
+<div class="search_input" style="width: 100%; margin-bottom: 1rem">
+  <i class="material-icons-round">search</i>
+  <input
+    type="text"
+    placeholder="Find indicator..."
+    [ngModel]="entityAowService.searchText()"
+    (ngModelChange)="entityAowService.searchText.set($event)" />
+</div>
+
 <p-table
   id="tocResultsByAowIdTable"
   styleClass="p-datatable-gridlines p-datatable-sm"
-  [value]="tableData()"
+  [value]="filteredTableData()"
   [loading]="entityAowService.isLoadingTocResultsByAowId() || entityAowService.isLoadingTocResults2030Outcomes()"
   sortField="result_title"
   [sortOrder]="1"
@@ -119,7 +128,13 @@
 
   <ng-template #emptymessage>
     <tr style="height: 200px">
-      <td colspan="8" class="tab-content_empty">There are no High-Level Outputs Indicators found.</td>
+      <td colspan="8" class="tab-content_empty">
+        @if (entityAowService.searchText().trim()) {
+          No indicators match your search.
+        } @else {
+          There are no High-Level Outputs Indicators found.
+        }
+      </td>
     </tr>
   </ng-template>
 </p-table>

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.html
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.html
@@ -1,8 +1,10 @@
 <div class="search_input" style="width: 100%; margin-bottom: 1rem">
   <i class="material-icons-round">search</i>
   <input
+    id="aowIndicatorSearchInput"
     type="text"
     placeholder="Find indicator..."
+    aria-label="Find indicator"
     [ngModel]="entityAowService.searchText()"
     (ngModelChange)="entityAowService.searchText.set($event)" />
 </div>

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.spec.ts
@@ -165,6 +165,7 @@ describe('AowHloTableComponent', () => {
       tocResultsOutputsByAowId: signal<any[]>([]),
       tocResultsOutcomesByAowId: signal<any[]>([]),
       tocResults2030Outcomes: signal<any[]>([]),
+      searchText: signal<string>(''),
       isLoadingTocResults2030Outcomes: signal<boolean>(false),
       isLoadingTocResultsByAowId: signal<boolean>(false),
       showReportResultModal: mockShowReportResultModal,
@@ -561,6 +562,125 @@ describe('AowHloTableComponent', () => {
         'Result 1': true,
         'Result 2': true
       });
+    });
+  });
+
+  describe('filteredTableData computed (P2-3141 search)', () => {
+    const searchMockData = [
+      {
+        result_title: 'Climate adaptation outcome',
+        indicators: [
+          { indicator_id: 'ind-1', indicator_description: 'Number of farmers trained', type_name: 'Capacity sharing' },
+          { indicator_id: 'ind-2', indicator_description: 'Policies influenced', type_name: 'Policy change' }
+        ]
+      },
+      {
+        result_title: 'Gender equality outcome',
+        indicators: [{ indicator_id: 'ind-3', indicator_description: 'Number of women reached', type_name: 'Knowledge products' }]
+      },
+      {
+        result_title: 'Empty group outcome',
+        indicators: []
+      }
+    ];
+
+    beforeEach(() => {
+      mockEntityAowService.tocResultsOutputsByAowId.set(searchMockData);
+      component.tableType = 'outputs';
+      mockEntityAowService.searchText.set('');
+    });
+
+    it('should return tableData untouched (same reference) when search is empty', () => {
+      expect(component.filteredTableData()).toBe(component.tableData());
+    });
+
+    it('should return tableData untouched when search is only whitespace', () => {
+      mockEntityAowService.searchText.set('   ');
+      expect(component.filteredTableData()).toBe(component.tableData());
+    });
+
+    it('should filter indicators by indicator_description and drop groups without matches', () => {
+      mockEntityAowService.searchText.set('Number of');
+
+      const result = component.filteredTableData();
+
+      expect(result).toHaveLength(2);
+      expect(result[0].result_title).toBe('Climate adaptation outcome');
+      expect(result[0].indicators).toEqual([
+        { indicator_id: 'ind-1', indicator_description: 'Number of farmers trained', type_name: 'Capacity sharing' }
+      ]);
+      expect(result[1].result_title).toBe('Gender equality outcome');
+      expect(result[1].indicators).toHaveLength(1);
+    });
+
+    it('should filter indicators by type_name (Indicator typology)', () => {
+      mockEntityAowService.searchText.set('Policy change');
+
+      const result = component.filteredTableData();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].result_title).toBe('Climate adaptation outcome');
+      expect(result[0].indicators).toEqual([
+        { indicator_id: 'ind-2', indicator_description: 'Policies influenced', type_name: 'Policy change' }
+      ]);
+    });
+
+    it('should keep the whole group with all indicators when the group title matches', () => {
+      mockEntityAowService.searchText.set('Climate adaptation');
+
+      const result = component.filteredTableData();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].indicators).toHaveLength(2);
+    });
+
+    it('should match case-insensitively', () => {
+      mockEntityAowService.searchText.set('nUmBeR oF wOmEn');
+
+      const result = component.filteredTableData();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].result_title).toBe('Gender equality outcome');
+    });
+
+    it('should return empty array when nothing matches', () => {
+      mockEntityAowService.searchText.set('zzz-no-match');
+
+      expect(component.filteredTableData()).toEqual([]);
+    });
+
+    it('should keep a title-matching group even if it has no indicators', () => {
+      mockEntityAowService.searchText.set('Empty group');
+
+      const result = component.filteredTableData();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].result_title).toBe('Empty group outcome');
+      expect(result[0].indicators).toEqual([]);
+    });
+
+    it('should not mutate the source data held in the service signal', () => {
+      mockEntityAowService.searchText.set('Policies');
+
+      component.filteredTableData();
+
+      const source = mockEntityAowService.tocResultsOutputsByAowId();
+      expect(source[0].indicators).toHaveLength(2);
+      expect(source).toEqual(searchMockData);
+    });
+
+    it('should restore the full table when the search is cleared', () => {
+      mockEntityAowService.searchText.set('Policies');
+      expect(component.filteredTableData()).toHaveLength(1);
+
+      mockEntityAowService.searchText.set('');
+      expect(component.filteredTableData()).toEqual(searchMockData);
+    });
+
+    it('should drive expandedRowKeys from the filtered data', () => {
+      mockEntityAowService.searchText.set('Gender');
+
+      expect(component.expandedRowKeys()).toEqual({ 'Gender equality outcome': true });
     });
   });
 

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, computed, inject, Input, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { TableModule } from 'primeng/table';
 import { EntityAowService } from '../../../../services/entity-aow.service';
 import { ProgressBarModule } from 'primeng/progressbar';
@@ -22,6 +23,7 @@ export interface ColumnOrder {
   selector: 'app-aow-hlo-table',
   imports: [
     CommonModule,
+    FormsModule,
     TableModule,
     ProgressBarModule,
     ButtonModule,
@@ -53,9 +55,30 @@ export class AowHloTableComponent {
     }
   });
 
+  // P2-3141: filter groups/indicators by the AoW-level search text without mutating the service signals.
+  filteredTableData = computed(() => {
+    const search = this.entityAowService.searchText().trim().toUpperCase();
+    if (!search) return this.tableData();
+
+    return this.tableData()
+      .map((item: any) => {
+        if ((item.result_title || '').toUpperCase().includes(search)) return item;
+
+        return {
+          ...item,
+          indicators: (item.indicators || []).filter(
+            (indicator: any) =>
+              (indicator.indicator_description || '').toUpperCase().includes(search) ||
+              (indicator.type_name || '').toUpperCase().includes(search)
+          )
+        };
+      })
+      .filter((item: any) => item.indicators?.length || (item.result_title || '').toUpperCase().includes(search));
+  });
+
   expandedRowKeys = computed(() => {
     const expanded: { [key: string]: boolean } = {};
-    this.tableData().forEach((item: any) => {
+    this.filteredTableData().forEach((item: any) => {
       expanded[item.result_title] = true;
     });
     return expanded;

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/entity-aow-aow.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/entity-aow-aow.component.spec.ts
@@ -22,6 +22,7 @@ describe('EntityAowAowComponent', () => {
       getTocResultsByAowId: jest.fn(),
       tocResultsOutputsByAowId: signal<any[]>([]),
       tocResultsOutcomesByAowId: signal<any[]>([]),
+      searchText: signal<string>(''),
       isLoadingTocResultsByAowId: signal<boolean>(false),
       showReportResultModal: signal<boolean>(false),
       isLoadingTocResults2030Outcomes: signal<boolean>(false),
@@ -91,6 +92,15 @@ describe('EntityAowAowComponent', () => {
       component.ngOnInit();
 
       expect(mockEntityAowService.aowId()).toBe(aowId);
+    });
+
+    it('should reset searchText when route params emit (P2-3141)', () => {
+      mockEntityAowService.searchText.set('stale query');
+      mockActivatedRoute.params = of({ aowId: 'another-aow' });
+
+      component.ngOnInit();
+
+      expect(mockEntityAowService.searchText()).toBe('');
     });
   });
 
@@ -242,6 +252,14 @@ describe('EntityAowAowComponent', () => {
       component.ngOnDestroy();
 
       expect(mockEntityAowService.aowId()).toBe('');
+    });
+
+    it('should reset searchText on destroy (P2-3141)', () => {
+      mockEntityAowService.searchText.set('stale query');
+
+      component.ngOnDestroy();
+
+      expect(mockEntityAowService.searchText()).toBe('');
     });
   });
 });

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/entity-aow-aow.component.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/entity-aow-aow.component.ts
@@ -33,6 +33,7 @@ export class EntityAowAowComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.route.params.subscribe(params => {
       this.entityAowService.aowId.set(params['aowId']);
+      this.entityAowService.searchText.set('');
     });
     this.entityAowService.getTocResultsByAowId(this.entityAowService.entityId(), this.entityAowService.aowId());
   }
@@ -47,5 +48,6 @@ export class EntityAowAowComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.entityAowService.aowId.set('');
+    this.entityAowService.searchText.set('');
   }
 }

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/services/entity-aow.service.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/services/entity-aow.service.ts
@@ -36,6 +36,7 @@ export class EntityAowService {
   tocResultsOutputsByAowId = signal<any[]>([]);
   tocResultsOutcomesByAowId = signal<any[]>([]);
   tocResults2030Outcomes = signal<any[]>([]);
+  searchText = signal<string>('');
   isLoadingTocResults2030Outcomes = signal<boolean>(false);
   isLoadingTocResultsByAowId = signal<boolean>(false);
 

--- a/openspec/changes/p2-3141-aow-kpi-search-bar/.openspec.yaml
+++ b/openspec/changes/p2-3141-aow-kpi-search-bar/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/p2-3141-aow-kpi-search-bar/design.md
+++ b/openspec/changes/p2-3141-aow-kpi-search-bar/design.md
@@ -1,0 +1,69 @@
+# Design — P2-3141: Search Bar for KPIs at the AoW level
+
+## Context
+
+**Ticket:** [P2-3141](https://cgiarmel.atlassian.net/browse/P2-3141). Frontend-only.
+
+Current state (verified in code, branch base `staging`):
+
+- **Data flow (API → service → component → template):**
+  1. `EntityAowAowComponent.ngOnInit` (`entity-aow-aow.component.ts:33-38`) reads `:aowId` from the route and calls `EntityAowService.getTocResultsByAowId(entityId, aowId)`.
+  2. `EntityAowService` (`entity-aow/services/entity-aow.service.ts`) calls `GET_TocResultsByAowId` / `GET_2030Outcomes` (declared in `results-api.service.ts`) and stores results in signals: `tocResultsOutputsByAowId`, `tocResultsOutcomesByAowId`, `tocResults2030Outcomes`.
+  3. `AowHloTableComponent.tableData` (computed, `aow-hlo-table.component.ts:43-54`) picks the signal per `@Input() tableType` (`outputs` | `outcomes` | `2030-outcomes`).
+  4. Template renders a PrimeNG `<p-table>` with `rowGroupMode="subheader"`, `groupRowsBy="result_title"`, `dataKey="result_title"`; groups are HLO/Outcome (`result_title`), rows are `item.indicators[]` (fields used: `indicator_id`, `indicator_description`, `type_name`, `target_value_sum`, `actual_achieved_value_sum`, `progress_percentage`).
+- **Consumers of the same data/shape** (behavior to preserve): `expandedRowKeys` computed (`:56-62`, keys by `result_title`); `openReportResultModal` / `openViewResultDrawer` / `openTargetDetailsDrawer` (`:92-126`) receive the **group item** and filter `item.indicators` by `indicator_id` — they must keep receiving objects with the full group shape; tab counts in `EntityAowAowComponent.tabs` (`:26-29`) read the **unfiltered** service signals.
+- **Table usages (3):** Outputs tab, Outcomes tab (`entity-aow-aow.component.html:36,47` — instances are created/destroyed per tab via `@switch`), and 2030 Outcomes page (`entity-aow-2030.component.html:9`).
+- **No search/filter exists** in the AoW view today.
+- **Existing search pattern elsewhere:** `outcome-indicator` module — service-level `searchText` signal, global `.search_input` pill style (`src/styles.scss:66-86`, icon `material-icons-round` + borderless input), and `FilterIndicatorBySearchPipe` (`outcome-indicator/pipes/filter-indicator-by-search.pipe.ts`).
+
+Stakeholders: Ángel Jarrín (requester — asked that the change be documented so QA can derive test cases), Cami / María Camila Giraldo (QA), SP users reporting against hundreds of indicators.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A search input at the AoW indicators view that filters, as the user types, the grouped table by **KPI statement** (`indicator_description`), **Indicator typology** (`type_name`) and **group title** (`result_title`), case-insensitively.
+- Works in all three usages of the table: High-Level Outputs tab, Outcomes tab, and 2030 Outcomes page.
+- Search text persists when switching between the Outputs/Outcomes tabs (same page), and resets when navigating to another AoW/page.
+- Groups with no matching indicators are hidden; a clear "no matches" empty state shows when nothing matches.
+- Clearing the input restores the full table. No mutation of the service signal data.
+
+**Non-Goals:**
+- No backend/search-API work (data is already fully client-side).
+- No fuzzy matching, highlighting of matched text, or search across numeric/status columns (targets, achieved, status).
+- No search on the sibling pages `entity-aow-all` / `entity-aow-unplanned` (different views; out of ticket scope).
+- No pagination changes (table has no paginator).
+
+## Decisions
+
+1. **Search input lives inside `AowHloTableComponent`** (above the `<p-table>`), not in each host page.
+   - *Why:* one implementation automatically covers the 3 usages (Outputs, Outcomes, 2030 Outcomes) with identical UX; the ticket targets exactly this table.
+   - *Alternative considered:* placing it in `entity-aow-aow.component.html` above the `@switch` — rejected: it would need duplicating in `entity-aow-2030` and separates the control from the data it filters.
+
+2. **Search state = `searchText: signal<string>('')` in `EntityAowService`**, reset on page init/destroy.
+   - *Why:* tab switches destroy/recreate the table component (`@switch`), so component-local state would lose the query between tabs; the service signal survives tab switches (deliberate UX) and follows the `outcome-indicator` precedent (`OutcomeIndicatorService.searchText`). Reset in `EntityAowAowComponent` (`ngOnInit`/`ngOnDestroy`, where `aowId` is already managed) and in the 2030 page init so a stale query never leaks across AoWs/pages.
+
+3. **Filtering via a non-mutating `computed` (`filteredTableData`) in `AowHloTableComponent`** instead of reusing `FilterIndicatorBySearchPipe`.
+   - *Why:* the pipe expects the `outcome-indicator` shape (`item.toc_results[].indicators`, `toc_result_title`) and **mutates** its input (`originalIndicators`, `isVisible`) — unsafe against shared service signals and misaligned with this component's signals + `OnPush` architecture (existing `tableData`/`expandedRowKeys` computeds).
+   - *Matching rules (based on the pipe's WPs behavior, extended per user feedback):* if the group `result_title` matches → the whole group stays with all its indicators; otherwise keep only indicators whose `indicator_description` (KPI statement) **or `type_name` (Indicator typology)** matches; drop groups with no visible indicators (title-matching groups survive even if they have zero indicators, preserving their existing "no associated indicators" row). Empty/whitespace query → return `tableData()` untouched.
+   - Group objects passed to modals/drawers keep their shape (`{ ...group, indicators: filtered }`), so `openReportResultModal`/drawers keep working on filtered rows.
+   - `expandedRowKeys` switches to `filteredTableData()` so remaining groups stay expanded while searching.
+
+4. **Markup/UX:** global `.search_input` pill (already in `styles.scss` — no new CSS), `material-icons-round` `search` icon, placeholder `Find indicator...`, `FormsModule` + `[ngModel]`/`(ngModelChange)` bound to the service signal. The `wp-home` quirk `(keydown.backspace)="searchText.set('')"` (backspace wipes the whole query) is **not** replicated — standard editing behavior instead.
+   - Search-aware empty state: when a query yields no rows, `#emptymessage` shows "No indicators match your search." instead of the generic message.
+
+5. **Testing:** extend/create the Jest spec for `AowHloTableComponent` covering the filtering computed (match by indicator, match by group title, no-match, clear/reset, non-mutation of source signal) — this doubles as the documented behavior list QA asked for.
+
+## Risks / Trade-offs
+
+- [Filtering recomputes `{ ...group }` copies on each keystroke] → data sets are hundreds of rows at most; `computed` memoization + `OnPush` keep this cheap. No debounce needed at this scale.
+- [Service-level `searchText` could leak between pages sharing `EntityAowService` (root-provided)] → explicit reset on `EntityAowAowComponent` init/destroy and 2030 page init.
+- [Groups hidden while searching also hide their "Report result" empty-state row] → intended: search is a find tool; clearing restores everything. Covered in specs so QA tests it deliberately.
+- [Existing `#emptymessage` text is Outputs-specific ("High-Level Outputs Indicators")] → out of scope to fix generally; only the search-active variant is added.
+
+## Migration Plan
+
+Pure additive frontend change: ship with the branch PR to `staging`; rollback = revert commit. No data, API, or config migration.
+
+## Open Questions
+
+- None blocking. (Ángel confirmed by voice note to proceed with the ticket as described; placement/behavior follows the existing outcome-indicator pattern.)

--- a/openspec/changes/p2-3141-aow-kpi-search-bar/proposal.md
+++ b/openspec/changes/p2-3141-aow-kpi-search-bar/proposal.md
@@ -1,0 +1,35 @@
+# Proposal — P2-3141: Search Bar for KPIs at the AoW level
+
+**Jira ticket:** [P2-3141](https://cgiarmel.atlassian.net/browse/P2-3141) — Enhancement, Medium priority.
+**Scope type:** **Frontend-only** (Angular client). No backend changes required — the AoW indicators data is already fully loaded client-side and filtering happens in memory.
+
+## Why
+
+Some Science Programs have hundreds of KPIs/indicators with very similar statements at the Area of Work (AoW) level. Today the only way to locate the indicator to report against is scrolling through the grouped table (`AowHloTableComponent`), which is slow and error-prone — users may pick the wrong indicator. A search bar lets users find the correct indicator quickly and confidently (acceptance criteria of P2-3141).
+
+## What Changes
+
+- Add a **search bar at the AoW level** in the Results Framework Reporting module (`entity-aow` → `EntityAowAowComponent` page), above the HLO/Outcomes indicators table.
+- Typing filters the grouped PrimeNG table (`AowHloTableComponent`) **by indicator statement (KPI), by indicator typology and by group title (HLO/Outcome `result_title`)**: only matching indicators remain visible; groups with no matching indicators are hidden.
+- The filter applies to both **High-Level Outputs** and **Outcomes** tabs (they share the same table component and page-level search state), and to the **2030 Outcomes** view (same `AowHloTableComponent` with `tableType="2030-outcomes"`).
+- Clearing the search restores the full table.
+- Reuses the existing search UX pattern from the `outcome-indicator` module (global `.search_input` pill style + indicator filter pipe), keeping the UI consistent with the rest of PRMS.
+
+## Capabilities
+
+### New Capabilities
+- `aow-indicator-search`: search/filter behavior for indicators in the AoW-level tables (search input placement, matching rules, group visibility, empty-state, reset behavior across tabs and AoW navigation).
+
+### Modified Capabilities
+<!-- none — no existing spec under openspec/specs/ covers the entity-aow tables -->
+
+## Impact
+
+- **Client (modified):**
+  - `src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/entity-aow-aow.component.html|ts` — host the search bar (or the table component, per design.md).
+  - `src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.ts|html` — filtered data source + empty state.
+  - `src/app/pages/result-framework-reporting/pages/entity-aow/services/entity-aow.service.ts` — search text signal (shared across tabs).
+- **Client (reused, read-only reference):** `src/app/pages/outcome-indicator/pipes/filter-indicator-by-search.pipe.ts`, global `.search_input` style in `src/styles.scss`.
+- **Server:** none. Endpoints `GET_TocResultsByAowId` / `GET_2030Outcomes` unchanged.
+- **SDD baseline:** aligns with `docs/system-design/design.md` (consistent search/filter UX, material-icons-round) and `docs/detailed-design/detailed-design.md` (results-framework-reporting module, client-side signals architecture). No module spec exists yet under `docs/specs/` for results-framework-reporting; this change documents behavior at the OpenSpec level.
+- **QA:** design.md + specs will spell out testable flows so QA (Cami) can derive test cases (explicit request from Ángel).

--- a/openspec/changes/p2-3141-aow-kpi-search-bar/specs/aow-indicator-search/spec.md
+++ b/openspec/changes/p2-3141-aow-kpi-search-bar/specs/aow-indicator-search/spec.md
@@ -1,0 +1,59 @@
+# Spec — aow-indicator-search (P2-3141)
+
+## ADDED Requirements
+
+### Requirement: Search input at the AoW indicators view
+The AoW indicators table (`AowHloTableComponent`) SHALL display a search input above the table in all its usages: the High-Level Outputs tab, the Outcomes tab, and the 2030 Outcomes page. The input SHALL use the global `.search_input` style (pill with `material-icons-round` search icon) and the placeholder `Find indicator...`.
+
+#### Scenario: Search bar visible on the Outputs tab
+- **WHEN** a user opens an AoW page (`/result-framework-reporting/entity-details/:entityId/aow/:aowId`) on the High-Level Outputs tab
+- **THEN** a search input with placeholder `Find indicator...` is rendered above the indicators table
+
+#### Scenario: Search bar visible on Outcomes and 2030 Outcomes
+- **WHEN** the user switches to the Outcomes tab, or opens the 2030 Outcomes view
+- **THEN** the same search input is rendered above the corresponding indicators table
+
+### Requirement: Filter indicators by KPI statement, indicator typology, or group title
+As the user types, the table SHALL filter case-insensitively: an indicator row remains visible when its KPI statement (`indicator_description`) or its Indicator typology (`type_name`) contains the query, and a whole group (HLO/Outcome) remains visible with all its indicators when the group title (`result_title`) contains the query. Groups with no visible indicators SHALL be hidden, except groups whose title matches (they keep their existing "no associated indicators" row). Remaining groups SHALL stay expanded. The filtering SHALL NOT mutate the underlying data held in `EntityAowService` signals, and tab counts SHALL keep reflecting the unfiltered totals.
+
+#### Scenario: Match by indicator statement
+- **WHEN** the user types text contained in the KPI statement of some indicators
+- **THEN** only the matching indicator rows remain visible, inside their (expanded) groups, and groups without matches disappear
+
+#### Scenario: Match by indicator typology
+- **WHEN** the user types text contained in the Indicator typology of some indicators (e.g. "knowledge products")
+- **THEN** the indicator rows with a matching typology remain visible, even if their KPI statement does not contain the query
+
+#### Scenario: Match by group title
+- **WHEN** the user types text contained in an HLO/Outcome title but not in its indicators' statements
+- **THEN** that whole group remains visible with all of its indicators
+
+#### Scenario: Case-insensitive matching
+- **WHEN** the user types a query differing from the data only in letter case
+- **THEN** matches are found as if the case were identical
+
+#### Scenario: Actions still work on filtered rows
+- **WHEN** the table is filtered and the user clicks "Report result", "View results" or "Target details" on a visible indicator
+- **THEN** the modal/drawer opens for that exact indicator, exactly as without filtering
+
+### Requirement: No-match empty state
+WHEN a non-empty query matches no group and no indicator, the table SHALL show the message `No indicators match your search.` instead of the generic empty message.
+
+#### Scenario: Query with no matches
+- **WHEN** the user types a query that matches nothing
+- **THEN** the table body shows `No indicators match your search.`
+
+### Requirement: Clearing and resetting the search
+Clearing the input SHALL restore the full, unfiltered table immediately. The query SHALL persist when switching between the High-Level Outputs and Outcomes tabs of the same AoW, and SHALL reset to empty when the user navigates to a different AoW or enters/leaves the AoW page or the 2030 Outcomes page.
+
+#### Scenario: Clear restores the table
+- **WHEN** the user deletes the query (input becomes empty)
+- **THEN** all groups and indicators are shown again, with the default expanded state
+
+#### Scenario: Query persists across tabs
+- **WHEN** the user types a query on the High-Level Outputs tab and switches to the Outcomes tab
+- **THEN** the same query is shown in the input and applied to the Outcomes table
+
+#### Scenario: Query resets on navigation
+- **WHEN** the user navigates to another AoW or to another page and comes back
+- **THEN** the search input is empty and the table is unfiltered

--- a/openspec/changes/p2-3141-aow-kpi-search-bar/tasks.md
+++ b/openspec/changes/p2-3141-aow-kpi-search-bar/tasks.md
@@ -1,0 +1,30 @@
+# Tasks — P2-3141: Search Bar for KPIs at the AoW level
+
+All tasks are **frontend-only** (`onecgiar-pr-client/`). No backend, migration, or git-state tasks.
+
+## 1. Search state (service)
+
+- [x] 1.1 Add `searchText = signal<string>('')` to `src/app/pages/result-framework-reporting/pages/entity-aow/services/entity-aow.service.ts` (next to the existing table signals).
+
+## 2. Search bar + filtering (table component)
+
+- [x] 2.1 In `.../entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.ts`: import `FormsModule`; add `filteredTableData` computed implementing the matching rules from `specs/aow-indicator-search/spec.md` (case-insensitive; group-title match keeps whole group; otherwise filter indicators by `indicator_description` or `type_name`; drop groups without visible indicators unless their title matches; empty query returns `tableData()` untouched; never mutate source arrays — build `{ ...group, indicators: [...] }` copies).
+- [x] 2.2 Point `expandedRowKeys` at `filteredTableData()` so remaining groups stay expanded while searching.
+- [x] 2.3 In `aow-hlo-table.component.html`: add the `.search_input` block (material-icons-round `search` icon + input, placeholder `Find indicator...`) above the `<p-table>`, bound with `[ngModel]="entityAowService.searchText()"` / `(ngModelChange)="entityAowService.searchText.set($event)"`; switch `[value]` to `filteredTableData()`.
+- [x] 2.4 Make the `#emptymessage` search-aware: when `entityAowService.searchText()` is non-empty show `No indicators match your search.`, otherwise keep the current generic message.
+
+## 3. Reset behavior (host pages)
+
+- [x] 3.1 Reset `entityAowService.searchText.set('')` in `.../entity-aow-aow/entity-aow-aow.component.ts` (`ngOnInit` and `ngOnDestroy`, where `aowId` is already managed) and re-reset on route `aowId` param changes.
+- [x] 3.2 Reset `searchText` on init of the 2030 Outcomes page `.../entity-aow-2030/entity-aow-2030.component.ts`.
+
+## 4. Tests (Jest)
+
+- [x] 4.1 Extend/create `aow-hlo-table.component.spec.ts`: filtering by indicator statement, by group title, case-insensitivity, no-match → empty list, empty query returns original reference, source signal data not mutated, title-matching empty group survives.
+- [x] 4.2 Update `entity-aow-aow.component.spec.ts` (and 2030 spec if present) for the search reset behavior.
+- [x] 4.3 Run the affected test files and `npm run lint:fix` on touched files; fix fallout.
+
+## 5. Verification (UI, against prtest backend)
+
+- [x] 5.1 `npm start` in `onecgiar-pr-client` and open `http://localhost:4200/result-framework-reporting/entity-details/:entityId/aow/:aowId` for a program with many indicators; verify every scenario in `specs/aow-indicator-search/spec.md` (search bar visible on both tabs and 2030 view, filtering, group-title match, actions on filtered rows, no-match message, clear, tab persistence, navigation reset).
+- [x] 5.2 Capture screenshots to `onecgiar_pr/.local-screenshots/p2-3141-*.png` (not committed) for the Jira documentation / QA test cases.


### PR DESCRIPTION
## Summary
- Release of **[P2-3141](https://cgiarmel.atlassian.net/browse/P2-3141) — Search Bar for KPIs**: adds a search bar above the AoW indicators table in the Results Framework Reporting module so users can quickly find the indicator to report against (some Science Programs have 100+ indicators with very similar statements).
- Filtering is client-side, case-insensitive and live: matches the **KPI statement** (`indicator_description`), the **Indicator typology** (`type_name`) and the **HLO/Outcome group title** (`result_title`). A group-title match keeps the whole group visible; groups with no matching indicators are hidden; a dedicated "No indicators match your search." empty state is shown when nothing matches.
- Applies to the **High-Level Outputs** and **Outcomes** tabs and to the **2030 Outcomes** view. The query persists when switching tabs within the same AoW and resets when navigating to another AoW/page.
- **Frontend-only** — no backend, API or migration changes. This PR carries exactly the P2-3141 commits (staging has no other pending work).

## Files changed
| File | Change |
|------|--------|
| `entity-aow/services/entity-aow.service.ts` | New `searchText = signal<string>('')` — shared search state |
| `aow-hlo-table/aow-hlo-table.component.ts` | `filteredTableData` computed with the matching rules (non-mutating); `expandedRowKeys` driven by filtered data; `FormsModule` import |
| `aow-hlo-table/aow-hlo-table.component.html` | Search input (`.search_input` global style, `id` + `aria-label` for a11y/Sonar) above the `p-table`; table bound to `filteredTableData()`; search-aware `emptymessage` |
| `entity-aow-aow.component.ts` / `entity-aow-2030.component.ts` | Reset `searchText` on init/destroy and on `aowId` route changes |
| `*.spec.ts` (3 files) | Jest coverage for all filtering rules and reset behavior (273 tests green in the module) |
| `openspec/changes/p2-3141-aow-kpi-search-bar/` | SDD artifacts: proposal, design, spec (WHEN/THEN scenarios), tasks |

## Why this approach is correct
- **Non-mutating `computed` filter** instead of reusing the outcome-indicator `FilterIndicatorBySearchPipe`: that pipe mutates its input (`originalIndicators`, `isVisible` flags) and expects a different data shape; a memoized computed fits this component's signals + `OnPush` architecture and never touches the service signal data, so tab counts and drawers keep working on the original dataset.
- **Service-level search state**: the Outputs/Outcomes tabs destroy/recreate the table component (`@switch`), so component-local state would lose the query between tabs; explicit resets on page init/destroy prevent stale queries leaking across AoWs.
- **Existing UX patterns reused**: global `.search_input` pill style and "Find indicator..." placeholder (same pattern as the outcome-indicator module) — no new CSS, consistent look & feel.
- **Quality gates**: SonarCloud green (a11y issue on the input fixed with `id` + `aria-label`), Snyk green, Cypress green, Jest suite green. Validated manually against prtest data (SP08/AOW04, 109 indicators), including actions (Report result / View results / Target details) on filtered rows.

## Verification
- Deployed to **dev** and validated in prtest; documented in [P2-3141](https://cgiarmel.atlassian.net/browse/P2-3141) (What/Why/How to verify + screenshots). Ángel Jarrín (reporter) is testing in prtest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[P2-3141]: https://cgiarmel.atlassian.net/browse/P2-3141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[P2-3141]: https://cgiarmel.atlassian.net/browse/P2-3141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ