### PR TITLE
🔀 Release staging → master: P2-3181 partners reactivation + Clarisa API key env fix

### DIFF
--- a/onecgiar-pr-server/src/api/bilateral/services/clarisa-api-key-validation.service.spec.ts
+++ b/onecgiar-pr-server/src/api/bilateral/services/clarisa-api-key-validation.service.spec.ts
@@ -10,7 +10,7 @@ const originalEnv = { ...process.env };
 describe('ClarisaApiKeyValidationService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    process.env.CLA_URL = 'https://clarisa.example/';
+    process.env.CLA_VALIDATE_URL = 'https://clarisa.example/';
   });
 
   afterAll(() => {

--- a/onecgiar-pr-server/src/api/bilateral/services/clarisa-api-key-validation.service.ts
+++ b/onecgiar-pr-server/src/api/bilateral/services/clarisa-api-key-validation.service.ts
@@ -1,7 +1,7 @@
 import { HttpService } from '@nestjs/axios';
 import { Injectable, Logger } from '@nestjs/common';
 import { AxiosError } from 'axios';
-import { env } from 'process';
+import { env } from 'node:process';
 import { firstValueFrom } from 'rxjs';
 import { BILATERAL_CLARISA_MICROSERVICE_NAME } from '../constants/bilateral-auth.constants';
 import {
@@ -23,7 +23,7 @@ export class ClarisaApiKeyValidationService {
   private readonly validateUrl: string;
 
   constructor(private readonly httpService: HttpService) {
-    const baseUrl = trimTrailingSlashes(env.CLA_URL ?? '');
+    const baseUrl = trimTrailingSlashes(env.CLA_VALIDATE_URL ?? '');
     this.validateUrl = `${baseUrl}/api/auth/validate-api-key`;
   }
 

--- a/onecgiar-pr-server/src/api/ipsr/results-package-toc-result/results-package-toc-result.service.ts
+++ b/onecgiar-pr-server/src/api/ipsr/results-package-toc-result/results-package-toc-result.service.ts
@@ -327,19 +327,25 @@ export class ResultsPackageTocResultService {
               last_updated_by: user?.id,
               created_by: user.id,
             });
+          } else if (!instExist.is_active) {
+            // Soft-deleted partner re-selected / still in payload: reactivate
+            // before writing deliveries (P2-3181).
+            await this._resultByIntitutionsRepository.update(
+              { id: instExist.id },
+              { is_active: true, last_updated_by: user.id },
+            );
+            instExist.is_active = true;
+            instExist.last_updated_by = user.id;
           }
+
+          const partnerRbi = instExist ?? rbi;
 
           if (ins?.deliveries?.length) {
             const { deliveries } = ins;
-            await this.saveDeliveries(
-              instExist ? instExist : rbi,
-              deliveries,
-              user.id,
-              version,
-            );
+            await this.saveDeliveries(partnerRbi, deliveries, user.id, version);
           } else {
             await this._resultByInstitutionsByDeliveriesTypeRepository.inactiveResultDeLivery(
-              (instExist ? instExist : rbi).id,
+              partnerRbi.id,
               [],
               user.id,
             );

--- a/onecgiar-pr-server/src/api/results/results_by_institutions/result_by_intitutions.repository.spec.ts
+++ b/onecgiar-pr-server/src/api/results/results_by_institutions/result_by_intitutions.repository.spec.ts
@@ -89,4 +89,50 @@ describe('ResultByIntitutionsRepository', () => {
       });
     });
   });
+
+  describe('getGenericResultByInstitutionExists', () => {
+    it('prefers active rows via order by is_active desc limit 1', async () => {
+      const activeRow = { id: 2, institutions_id: 11585, is_active: 1 };
+      queryMock.mockResolvedValueOnce([activeRow]);
+
+      const result = await repository.getGenericResultByInstitutionExists(
+        10,
+        11585,
+        2,
+      );
+
+      expect(queryMock).toHaveBeenCalledWith(
+        expect.stringMatching(/order by rbi\.is_active desc[\s\S]*limit 1/i),
+        [10, 2, 11585],
+      );
+      expect(result).toEqual(activeRow);
+    });
+
+    it('returns undefined when no row exists', async () => {
+      queryMock.mockResolvedValueOnce([]);
+
+      const result = await repository.getGenericResultByInstitutionExists(
+        10,
+        999,
+        2,
+      );
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('getResultByInstitutionExists', () => {
+    it('prefers active rows via order by is_active desc limit 1', async () => {
+      const inactiveRow = { id: 1, institutions_id: 50, is_active: 0 };
+      queryMock.mockResolvedValueOnce([inactiveRow]);
+
+      const result = await repository.getResultByInstitutionExists(5, 50);
+
+      expect(queryMock).toHaveBeenCalledWith(
+        expect.stringMatching(/order by rbi\.is_active desc[\s\S]*limit 1/i),
+        [5, expect.anything(), 50],
+      );
+      expect(result).toEqual(inactiveRow);
+    });
+  });
 });

--- a/onecgiar-pr-server/src/api/results/results_by_institutions/result_by_intitutions.repository.ts
+++ b/onecgiar-pr-server/src/api/results/results_by_institutions/result_by_intitutions.repository.ts
@@ -297,7 +297,9 @@ export class ResultByIntitutionsRepository
     from results_by_institution rbi 
     where rbi.result_id = ?
       and institution_roles_id = ?
-      and rbi.institutions_id = ?;
+      and rbi.institutions_id = ?
+    order by rbi.is_active desc, rbi.id desc
+    limit 1;
     `;
     try {
       const completeUser: ResultsByInstitution[] = await this.query(queryData, [
@@ -334,7 +336,9 @@ export class ResultByIntitutionsRepository
     from results_by_institution rbi 
     where rbi.result_id = ?
       and institution_roles_id = ?
-      and rbi.institutions_id = ?;
+      and rbi.institutions_id = ?
+    order by rbi.is_active desc, rbi.id desc
+    limit 1;
     `;
     try {
       const completeUser: ResultsByInstitution[] = await this.query(queryData, [

--- a/onecgiar-pr-server/src/api/results/results_by_institutions/results_by_institutions.service.spec.ts
+++ b/onecgiar-pr-server/src/api/results/results_by_institutions/results_by_institutions.service.spec.ts
@@ -34,6 +34,7 @@ describe('ResultsByInstitutionsService', () => {
   };
   const mockResultInstitutionsBudgetRepository = {
     update: jest.fn(),
+    save: jest.fn(),
   };
   const mockGlobalParameterRepository = {
     findOne: jest.fn(),
@@ -58,7 +59,10 @@ describe('ResultsByInstitutionsService', () => {
   const mockResultsByProjectsService = {
     syncBilateralProjects: jest.fn(),
   };
-  const mockResultsByProjectsRepository = {};
+  const mockResultsByProjectsRepository = {
+    findResultsByProjectsByResultId: jest.fn(),
+    find: jest.fn(),
+  };
 
   const createService = () =>
     new ResultsByInstitutionsService(
@@ -80,6 +84,9 @@ describe('ResultsByInstitutionsService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockResultByInstitutionsRepository.find.mockReset();
+    mockResultKnowledgeProductRepository.findOne.mockReset();
+    mockResultsByProjectsRepository.findResultsByProjectsByResultId.mockReset();
     service = createService();
   });
 
@@ -186,6 +193,97 @@ describe('ResultsByInstitutionsService', () => {
           }),
         }),
       );
+    });
+  });
+
+  describe('getInstitutionsPartnersByResultIdV2', () => {
+    const baseResult = {
+      id: 42,
+      no_applicable_partner: false,
+      is_lead_by_partner: false,
+      result_type_id: 2,
+    };
+
+    it('excludes partners whose Clarisa institution is inactive', async () => {
+      mockResultRepository.getResultById.mockResolvedValueOnce(baseResult);
+      mockResultKnowledgeProductRepository.findOne.mockResolvedValue(null);
+      mockResultByInstitutionsRepository.find.mockResolvedValue([
+        {
+          id: 1,
+          institutions_id: 11585,
+          delivery: [{ id: 10, is_active: true }],
+          obj_institutions: {
+            is_active: false,
+            name: 'ARTIS',
+            website_link: null,
+            obj_institution_type_code: { code: 1, name: 'Type' },
+          },
+        },
+        {
+          id: 2,
+          institutions_id: 100,
+          delivery: [{ id: 11, is_active: true }],
+          obj_institutions: {
+            is_active: true,
+            name: 'Active Partner',
+            website_link: null,
+            obj_institution_type_code: { code: 2, name: 'Type B' },
+          },
+        },
+      ]);
+      mockResultsCenterRepository.getAllResultsCenterByResultId.mockResolvedValue(
+        [],
+      );
+      mockResultsByProjectsRepository.findResultsByProjectsByResultId.mockResolvedValue(
+        [],
+      );
+
+      const response = await service.getInstitutionsPartnersByResultIdV2(42);
+      const payload = response.response as {
+        institutions: Array<{ id: number; institutions_id: number }>;
+      };
+
+      expect(payload.institutions).toHaveLength(1);
+      expect(payload.institutions[0]).toMatchObject({
+        id: 2,
+        institutions_id: 100,
+      });
+    });
+  });
+
+  describe('handleInstitutions', () => {
+    it('soft-deletes deliveries by result_by_institution_id when removing partners', async () => {
+      mockResultByInstitutionsRepository.update.mockResolvedValueOnce(
+        {} as any,
+      );
+      mockResultInstitutionsBudgetRepository.update.mockResolvedValueOnce(
+        {} as any,
+      );
+      mockDeliveriesTypeRepository.update.mockResolvedValueOnce({} as any);
+
+      const oldInstitutions = [
+        { id: 77, institutions_id: 11585, delivery: [{ id: 900 }] },
+      ] as any[];
+      const incomingInstitutions = [] as any[];
+
+      await (service as any).handleInstitutions(
+        incomingInstitutions,
+        oldInstitutions,
+        false,
+        false,
+        42,
+        5,
+      );
+
+      expect(mockDeliveriesTypeRepository.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          result_by_institution_id: expect.anything(),
+        }),
+        { is_active: false, last_updated_by: 5 },
+      );
+      const deliveryWhere =
+        mockDeliveriesTypeRepository.update.mock.calls[0][0];
+      expect(deliveryWhere.id).toBeUndefined();
     });
   });
 

--- a/onecgiar-pr-server/src/api/results/results_by_institutions/results_by_institutions.service.ts
+++ b/onecgiar-pr-server/src/api/results/results_by_institutions/results_by_institutions.service.ts
@@ -560,6 +560,11 @@ export class ResultsByInstitutionsService {
         order: { id: 'ASC' },
       });
 
+      // Align with P22 GET: hide partners whose Clarisa institution is inactive (P2-3181).
+      institutions = institutions.filter(
+        (i) => i.obj_institutions?.is_active !== false,
+      );
+
       institutions = institutions.map((i) => ({
         ...i,
         delivery: i.delivery.filter((d) => d.is_active),
@@ -934,7 +939,7 @@ export class ResultsByInstitutionsService {
       );
 
       await this._resultByInstitutionsByDeliveriesTypeRepository.update(
-        { id: In(removed.map((d) => d.id)) },
+        { result_by_institution_id: In(removed.map((i) => i.id)) },
         { is_active: false, last_updated_by: userId },
       );
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Release: staging → master

### App code shipped (production impact)

- **P2-3181** — Partners / deliveries: reactivate inactive partners before deliveries and align the P25 Clarisa filter (`results_by_institutions` repository/service + related IPSR ToC package service adjustments). Includes unit test coverage for the reactivation and filter behavior.
- **Clarisa API key validation** — Use `CLA_VALIDATE_URL` (instead of `CLA_URL`) in `ClarisaApiKeyValidationService` so API key validation hits the correct Clarisa endpoint. Spec updated accordingly.

### Scope

| Area | Change |
|------|--------|
| `results_by_institutions` | Reactivate inactive partners before deliveries; P25 Clarisa filter alignment |
| `results-package-toc-result` | Related initiative/partner query adjustments |
| `clarisa-api-key-validation` | Env var `CLA_VALIDATE_URL` for validation URL |

### Diff summary

- 7 files changed, ~173 insertions / ~14 deletions
- Backend only (`onecgiar-pr-server`)

### Commits on staging (not in master)

1. `🔧 fix(results_by_institutions) P2-3181: reactivate inactive partners before deliveries and align P25 Clarisa filter`
2. `🔧 Fix environment variable for API key validation in ClarisaApiKeyValidationService`

### Validation

- Please confirm CI on this PR (lint, unit tests, SonarCloud, Snyk) before merge to production.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f85b2-75b3-7961-8a63-9fc0594b1eed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f85b2-75b3-7961-8a63-9fc0594b1eed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

