### PR TITLE
🔀 Release staging → master: P2-3181 avoid cascading delivery save on RBI reactivation

### DIFF
--- a/onecgiar-pr-server/src/api/results/results_by_institutions/results_by_institutions.service.spec.ts
+++ b/onecgiar-pr-server/src/api/results/results_by_institutions/results_by_institutions.service.spec.ts
@@ -22,6 +22,7 @@ describe('ResultsByInstitutionsService', () => {
   };
   const mockDeliveriesTypeRepository = {
     update: jest.fn(),
+    save: jest.fn(),
   };
   const mockHandlersError = {
     returnErrorRes: jest.fn((payload) => payload),
@@ -284,6 +285,51 @@ describe('ResultsByInstitutionsService', () => {
       const deliveryWhere =
         mockDeliveriesTypeRepository.update.mock.calls[0][0];
       expect(deliveryWhere.id).toBeUndefined();
+    });
+
+    it('reactivates inactive partner without cascading delivery on RBI save', async () => {
+      const inactiveRbi = {
+        id: 500,
+        institutions_id: 11585,
+        is_active: false,
+        delivery: [{ id: 90553, partner_delivery_type_id: 1, is_active: true }],
+      };
+      mockResultByInstitutionsRepository.find.mockResolvedValueOnce([
+        inactiveRbi,
+      ]);
+      mockResultByInstitutionsRepository.update.mockResolvedValueOnce(
+        {} as any,
+      );
+      mockResultByInstitutionsRepository.save.mockResolvedValueOnce([]);
+
+      const incomingInstitutions = [
+        {
+          institutions_id: 11585,
+          is_leading_result: false,
+          delivery: [{ partner_delivery_type_id: 2 }],
+        },
+      ] as any[];
+
+      await (service as any).handleInstitutions(
+        incomingInstitutions,
+        [],
+        false,
+        false,
+        32177,
+        5,
+      );
+
+      expect(mockResultByInstitutionsRepository.update).toHaveBeenCalledWith(
+        { id: 500 },
+        expect.objectContaining({ is_active: true, last_updated_by: 5 }),
+      );
+      expect(mockResultByInstitutionsRepository.save).not.toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ id: 500 })]),
+      );
+      expect(mockDeliveriesTypeRepository.save).toHaveBeenCalled();
+      const savedDeliveries =
+        mockDeliveriesTypeRepository.save.mock.calls[0][0] ?? [];
+      expect(savedDeliveries[0]?.result_by_institution_id).toBe(500);
     });
   });
 

--- a/onecgiar-pr-server/src/api/results/results_by_institutions/results_by_institutions.service.ts
+++ b/onecgiar-pr-server/src/api/results/results_by_institutions/results_by_institutions.service.ts
@@ -963,6 +963,7 @@ export class ResultsByInstitutionsService {
                 institutions_id: In(incomingInstitutionIds),
                 institution_roles_id: institutionRoleId,
               },
+              relations: { delivery: true },
             })
           : [];
 
@@ -984,7 +985,6 @@ export class ResultsByInstitutionsService {
           existing.last_updated_by = userId;
           existing.institutions_id = a.institutions_id;
           existing.is_leading_result = a.is_leading_result;
-          existing.delivery = a.delivery ?? [];
           institutionsToReactivate.push(existing);
         } else {
           // Create new only if no existing record found
@@ -995,17 +995,26 @@ export class ResultsByInstitutionsService {
           toAdd.result_id = resultId;
           toAdd.institutions_id = a.institutions_id;
           toAdd.institution_roles_id = institutionRoleId;
-          toAdd.delivery = a.delivery ?? [];
           toAdd['isNew'] = true;
           toAdd.is_leading_result = a.is_leading_result;
           institutionsToCreate.push(toAdd);
         }
       }
 
-      // Save reactivated and new institutions separately
+      // Persist reactivations without cascading delivery relations (P2-3181).
       if (institutionsToReactivate.length) {
-        await this._resultByIntitutionsRepository.save(
-          institutionsToReactivate,
+        await Promise.all(
+          institutionsToReactivate.map((rbi) =>
+            this._resultByIntitutionsRepository.update(
+              { id: rbi.id },
+              {
+                is_active: rbi.is_active,
+                last_updated_by: rbi.last_updated_by,
+                institutions_id: rbi.institutions_id,
+                is_leading_result: rbi.is_leading_result,
+              },
+            ),
+          ),
         );
       }
 
@@ -1094,20 +1103,14 @@ export class ResultsByInstitutionsService {
       dto != null && Object.prototype.hasOwnProperty.call(dto, 'delivery');
 
     for (const inst of toUpdate.concat(added)) {
-      if (inst['isNew']) {
-        const incoming = (inst.delivery ?? []) as any[];
-        if (incoming.length) {
-          await this.handleDeliveries(incoming, [], inst.id, userId);
-        }
-        continue;
-      }
-
-      const dto = incomingInstitutions.find((i) => i.id === inst.id);
+      const dto = incomingInstitutions.find(
+        (i) => i.id === inst.id || i.institutions_id === inst.institutions_id,
+      );
 
       if (!dtoHasDelivery(dto)) continue;
 
       const incoming = (dto?.delivery ?? []) as any[];
-      const old = (inst.delivery ?? []) as any[];
+      const old = (inst.delivery ?? []).filter((d) => d.is_active !== false);
 
       await this.handleDeliveries(incoming, old, inst.id, userId);
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Release: staging → master

### App code shipped (production impact)

- **P2-3181 (follow-up)** — Avoid cascading delivery saves when reactivating `ResultByInstitution` (RBI) records.
  - Persist reactivation with `repository.update` per record instead of `repository.save` (prevents cascading delivery relation saves).
  - Load delivery relations when querying existing RBIs.
  - Stop transferring delivery arrays onto RBI entities during reactivate/create.
  - Match delivery handling to incoming DTOs by `id` or `institutions_id`.
  - Filter out inactive deliveries when computing old deliveries.
  - Unit test: inactive partner reactivated without cascading delivery creation.

### Scope

| Area | Change |
|------|--------|
| `results_by_institutions.service.ts` | Safer RBI reactivation without cascading delivery saves |
| `results_by_institutions.service.spec.ts` | Coverage for reactivation without delivery cascade |

### Diff summary

- 2 files changed, ~64 insertions / ~15 deletions
- Backend only (`onecgiar-pr-server`)

### Commits on staging (not in master)

1. `♻️ Avoid cascading delivery save when reactivating RBIs`

### Validation

- Please confirm CI on this PR (lint, unit tests, SonarCloud, Snyk) before merge to production.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f85b2-75b3-7961-8a63-9fc0594b1eed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f85b2-75b3-7961-8a63-9fc0594b1eed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

