### PR TITLE
🔀 Release staging → master: entity-aow per-center targets + AoW indicator UX

### DIFF
--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.html
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.html
@@ -56,7 +56,16 @@
     @if (item.indicators.length) {
       @for (result of item.indicators; track $index) {
         <tr>
-          <td class="text-secondary-300" style="min-width: 150px !important">{{ result.indicator_description }}</td>
+          <td class="text-secondary-300" style="min-width: 150px !important">
+            <div class="kpi-statement-cell">
+              <span class="kpi-statement-text">{{ result.indicator_description }}</span>
+              @if (result.center_acronym) {
+                <span class="tab-content_chip center-chip" [pTooltip]="'CGIAR Center: ' + result.center_acronym">
+                  {{ result.center_acronym }}
+                </span>
+              }
+            </div>
+          </td>
           <td>
             <div class="tab-content_chip" [pTooltip]="!result.type_name ? 'This information should be filled in the ToC Board' : ''">
               {{ result.type_name || 'Not provided' }}
@@ -98,7 +107,7 @@
                   label="Target details"
                   type="button"
                   class="p-button-outlined pr-body-3 tab-content_actions_button"
-                  (click)="openTargetDetailsDrawer(item, result.indicator_id)"></button>
+                  (click)="openTargetDetailsDrawer(item, result)"></button>
               }
             </div>
           </td>
@@ -134,7 +143,7 @@
         @if (entityAowService.searchText().trim()) {
           No indicators match your search.
         } @else {
-          There are no High-Level Outputs Indicators found.
+          {{ emptyStateMessage() }}
         }
       </td>
     </tr>

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.scss
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.scss
@@ -20,6 +20,21 @@ p {
   color: var(--pr-color-secondary-200);
 }
 
+.kpi-statement-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+.kpi-statement-text {
+  @include fonts.pr-typography('body-2');
+}
+
+.center-chip {
+  align-self: flex-start;
+}
+
 .achieved {
   border: 1px solid var(--pr-color-green-500) !important;
   color: var(--pr-color-green-500) !important;

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.spec.ts
@@ -153,6 +153,7 @@ describe('AowHloTableComponent', () => {
     const mockShowTargetDetailsDrawer = signal<boolean>(false);
     const mockTargetDetailsDrawerFullScreen = signal<boolean>(false);
     const mockCurrentTargetToView = signal<any>({});
+    const mockTargetDetailsSelectedCenterId = signal<string | number | null>(null);
     const mockExistingResultsContributors = signal<any[]>([]);
 
     mockEntityAowService = {
@@ -176,6 +177,7 @@ describe('AowHloTableComponent', () => {
       showTargetDetailsDrawer: mockShowTargetDetailsDrawer,
       targetDetailsDrawerFullScreen: mockTargetDetailsDrawerFullScreen,
       currentTargetToView: mockCurrentTargetToView,
+      targetDetailsSelectedCenterId: mockTargetDetailsSelectedCenterId,
       existingResultsContributors: mockExistingResultsContributors
     } as any;
 
@@ -187,6 +189,7 @@ describe('AowHloTableComponent', () => {
     jest.spyOn(mockShowTargetDetailsDrawer, 'set');
     jest.spyOn(mockTargetDetailsDrawerFullScreen, 'set');
     jest.spyOn(mockCurrentTargetToView, 'set');
+    jest.spyOn(mockTargetDetailsSelectedCenterId, 'set');
     jest.spyOn(mockExistingResultsContributors, 'set');
 
     mockResultLevelService = {
@@ -465,6 +468,25 @@ describe('AowHloTableComponent', () => {
     });
   });
 
+  describe('emptyStateMessage', () => {
+    it('should return High-Level Outputs message for outputs table', () => {
+      component.tableType = 'outputs';
+      expect(component.emptyStateMessage()).toBe('There are no High-Level Outputs indicators found.');
+    });
+
+    it('should return Intermediate Outcomes message for outcomes table', () => {
+      component.tableType = 'outcomes';
+      expect(component.emptyStateMessage()).toBe('There are no Intermediate Outcomes indicators found.');
+    });
+
+    it('should return 2030 Outcomes message for 2030-outcomes table', () => {
+      component.tableType = '2030-outcomes';
+      expect(component.emptyStateMessage()).toBe(
+        'There are no 2030 Outcomes indicators configured for this program in the current reporting phase.'
+      );
+    });
+  });
+
   testModalDrawerOpening('openReportResultModal', 'showReportResultModal', 'currentResultToReport');
 
   describe('openReportResultModal - Additional Tests', () => {
@@ -684,7 +706,54 @@ describe('AowHloTableComponent', () => {
     });
   });
 
-  testModalDrawerOpening('openTargetDetailsDrawer', 'showTargetDetailsDrawer', 'currentTargetToView');
+  testModalDrawerOpening('openViewResultDrawer', 'showViewResultDrawer', 'currentResultToView');
+
+  describe('openTargetDetailsDrawer', () => {
+    it('should open the drawer with the selected indicator row and matched center', () => {
+      const selectedIndicator = {
+        indicator_id: 'indicator-1',
+        center_id: 3,
+        target_value_sum: 79,
+        targets_by_center: {
+          centers: [
+            {
+              center_id: 1,
+              targets: [{ year: 2026, target_value: 95 }]
+            },
+            {
+              center_id: 3,
+              targets: [{ year: 2026, target_value: 79 }]
+            }
+          ]
+        }
+      };
+      const mockItem = createMockItem({ indicators: [selectedIndicator] });
+
+      component.openTargetDetailsDrawer(mockItem, selectedIndicator);
+
+      expect(mockEntityAowService.showTargetDetailsDrawer.set).toHaveBeenCalledWith(true);
+      expect(mockEntityAowService.targetDetailsSelectedCenterId.set).toHaveBeenCalledWith(3);
+      expect(mockEntityAowService.currentTargetToView.set).toHaveBeenCalledWith({
+        ...mockItem,
+        indicators: [selectedIndicator]
+      });
+    });
+
+    it('should clear selected center when no target match is found', () => {
+      const selectedIndicator = {
+        indicator_id: 'indicator-1',
+        target_value_sum: 50,
+        targets_by_center: {
+          centers: [{ center_id: 3, targets: [{ year: 2026, target_value: 79 }] }]
+        }
+      };
+      const mockItem = createMockItem({ indicators: [selectedIndicator] });
+
+      component.openTargetDetailsDrawer(mockItem, selectedIndicator);
+
+      expect(mockEntityAowService.targetDetailsSelectedCenterId.set).toHaveBeenCalledWith(null);
+    });
+  });
 
   describe('hasTargets', () => {
     it('should return true when indicator has targets with centers', () => {

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.spec.ts
@@ -370,6 +370,10 @@ describe('AowHloTableComponent', () => {
       const result = component.getStatusLabel(input);
       expect(result).toBe(expected);
     });
+
+    it('should return Not started for fractional progress below 1%', () => {
+      expect(component.getStatusLabel('0.5%')).toBe('Not started');
+    });
   });
 
   describe('tableData computed', () => {
@@ -752,6 +756,52 @@ describe('AowHloTableComponent', () => {
       component.openTargetDetailsDrawer(mockItem, selectedIndicator);
 
       expect(mockEntityAowService.targetDetailsSelectedCenterId.set).toHaveBeenCalledWith(null);
+    });
+
+    it('should resolve center by target value when center_id is missing', () => {
+      const selectedIndicator = {
+        indicator_id: 'indicator-1',
+        target_value_sum: 79,
+        targets_by_center: {
+          centers: [{ center_id: 3, targets: [{ year: 2026, target_value: 79 }] }]
+        }
+      };
+      const mockItem = createMockItem({ indicators: [selectedIndicator] });
+
+      component.openTargetDetailsDrawer(mockItem, selectedIndicator);
+
+      expect(mockEntityAowService.targetDetailsSelectedCenterId.set).toHaveBeenCalledWith(3);
+    });
+
+    it('should clear selected center when reporting year is unavailable', () => {
+      mockEntityAowService.reportingPhaseYear = '';
+      const selectedIndicator = {
+        indicator_id: 'indicator-1',
+        target_value_sum: 79,
+        targets_by_center: {
+          centers: [{ center_id: 3, targets: [{ year: 2026, target_value: 79 }] }]
+        }
+      };
+      const mockItem = createMockItem({ indicators: [selectedIndicator] });
+
+      component.openTargetDetailsDrawer(mockItem, selectedIndicator);
+
+      expect(mockEntityAowService.targetDetailsSelectedCenterId.set).toHaveBeenCalledWith(null);
+    });
+
+    it('should resolve center using target_value when target_value_sum is missing', () => {
+      const selectedIndicator = {
+        indicator_id: 'indicator-1',
+        target_value: 79,
+        targets_by_center: {
+          centers: [{ center_id: 3, targets: [{ year: 2026, target_value: 79 }] }]
+        }
+      };
+      const mockItem = createMockItem({ indicators: [selectedIndicator] });
+
+      component.openTargetDetailsDrawer(mockItem, selectedIndicator);
+
+      expect(mockEntityAowService.targetDetailsSelectedCenterId.set).toHaveBeenCalledWith(3);
     });
   });
 

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.ts
@@ -84,6 +84,18 @@ export class AowHloTableComponent {
     return expanded;
   });
 
+  emptyStateMessage(): string {
+    switch (this.tableType) {
+      case 'outcomes':
+        return 'There are no Intermediate Outcomes indicators found.';
+      case '2030-outcomes':
+        return 'There are no 2030 Outcomes indicators configured for this program in the current reporting phase.';
+      case 'outputs':
+      default:
+        return 'There are no High-Level Outputs indicators found.';
+    }
+  }
+
   // P2-3053: agreed nomenclature + dynamic phase year ("<year> target") instead of hardcoded "2025".
   columnOrder = computed<ColumnOrder[]>(() => [
     { title: 'KPI statement', attr: 'indicator_description', width: '30%' },
@@ -138,14 +150,43 @@ export class AowHloTableComponent {
     this.entityAowService.currentResultToView.set(selectedCurrentItem);
   }
 
-  openTargetDetailsDrawer(item: any, currentItemId: string) {
+  openTargetDetailsDrawer(item: any, selectedIndicator: any) {
     const selectedCurrentItem = {
       ...item,
-      indicators: item.indicators.filter((indicator: any) => indicator.indicator_id === currentItemId)
+      indicators: [selectedIndicator]
     };
 
+    this.entityAowService.targetDetailsSelectedCenterId.set(
+      this.resolveTargetDetailsCenterId(selectedIndicator)
+    );
     this.entityAowService.showTargetDetailsDrawer.set(true);
     this.entityAowService.currentTargetToView.set(selectedCurrentItem);
+  }
+
+  private resolveTargetDetailsCenterId(indicator: any): string | number | null {
+    if (indicator?.center_id != null) {
+      return indicator.center_id;
+    }
+
+    const reportingYear = String(this.entityAowService.reportingPhaseYear ?? '').trim();
+    const targetValue = indicator?.target_value_sum ?? indicator?.target_value;
+
+    if (!reportingYear || targetValue == null || `${targetValue}`.trim() === '') {
+      return null;
+    }
+
+    const normalizedTarget = String(targetValue);
+    const centers = indicator?.targets_by_center?.centers ?? [];
+
+    const matchedCenter = centers.find((center: any) =>
+      center.targets?.some(
+        (target: any) =>
+          String(target.year) === reportingYear &&
+          String(target.target_value) === normalizedTarget
+      )
+    );
+
+    return matchedCenter?.center_id ?? null;
   }
 
   hasTargets(item: any, indicatorId: string): boolean {

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/components/aow-target-details-drawer/aow-target-details-drawer.component.html
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/components/aow-target-details-drawer/aow-target-details-drawer.component.html
@@ -25,7 +25,7 @@
           <i
             class="pi pi-times"
             style="font-size: 16px; cursor: pointer"
-            (click)="entityAowService.showTargetDetailsDrawer.set(false); entityAowService.targetDetailsDrawerFullScreen.set(false)"></i>
+            (click)="closeDrawer()"></i>
         </div>
       </div>
       <p class="target-details-drawer-header_title">{{ entityAowService.currentTargetToView()?.result_title }}</p>
@@ -52,7 +52,7 @@
         </tr>
       </ng-template>
       <ng-template #body let-row>
-        <tr>
+        <tr [class.selected-row]="isSelectedCenter(row)">
           <td class="center-cell">
             <div class="center-content">
               <i class="pi pi-building"></i>

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/components/aow-target-details-drawer/aow-target-details-drawer.component.scss
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/components/aow-target-details-drawer/aow-target-details-drawer.component.scss
@@ -100,6 +100,26 @@ p {
       }
     }
 
+    .p-datatable-tbody > tr.selected-row > td {
+      background-color: var(--pr-color-primary-25);
+      border-top: 2px solid var(--pr-color-secondary-200);
+      border-bottom: 2px solid var(--pr-color-secondary-200);
+
+      &.center-cell {
+        box-shadow: inset 4px 0 0 var(--pr-color-secondary-200);
+
+        .center-content span {
+          font-weight: 600;
+          color: var(--pr-color-secondary-400);
+        }
+      }
+
+      &.value-cell {
+        font-weight: 600;
+        color: var(--pr-color-secondary-400);
+      }
+    }
+
     .p-datatable-tbody > tr > td {
       padding: 12px 16px;
       border-bottom: 1px solid var(--pr-color-accents-2);

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/components/aow-target-details-drawer/aow-target-details-drawer.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/components/aow-target-details-drawer/aow-target-details-drawer.component.spec.ts
@@ -17,6 +17,7 @@ describe('AowTargetDetailsDrawerComponent', () => {
       currentAowSelected: jest.fn(() => ({ code: 'TEST-AOW', name: 'Test AOW' })),
       showTargetDetailsDrawer: signal<boolean>(true),
       targetDetailsDrawerFullScreen: signal<boolean>(false),
+      targetDetailsSelectedCenterId: signal<string | number | null>(3),
       currentTargetToView: signal<any>({
         result_title: 'Test Result',
         indicators: [
@@ -24,10 +25,21 @@ describe('AowTargetDetailsDrawerComponent', () => {
             indicator_description: 'Test Indicator',
             targets_by_center: {
               centers: [
-                { center_id: '1', center_acronym: 'CIP', center_name: 'International Potato Center' }
-              ],
-              targets: [
-                { number_target: '1', target_value: '10', toc_indicator_target_id: '1', year: '2025' }
+                {
+                  center_id: '1',
+                  center_acronym: 'ABC',
+                  center_name: 'Alliance of Bioversity and CIAT - Headquarter',
+                  targets: [
+                    { number_target: '1', target_value: '95', toc_indicator_target_id: '1', year: '2026' },
+                    { number_target: '1', target_value: '0', toc_indicator_target_id: '2', year: '2025' }
+                  ]
+                },
+                {
+                  center_id: '3',
+                  center_acronym: 'CIP',
+                  center_name: 'International Potato Center',
+                  targets: [{ number_target: '1', target_value: '79', toc_indicator_target_id: '3', year: '2026' }]
+                }
               ]
             }
           }
@@ -43,6 +55,10 @@ describe('AowTargetDetailsDrawerComponent', () => {
       ]
     }).compileComponents();
 
+    jest.spyOn(mockEntityAowService.showTargetDetailsDrawer, 'set');
+    jest.spyOn(mockEntityAowService.targetDetailsDrawerFullScreen, 'set');
+    jest.spyOn(mockEntityAowService.targetDetailsSelectedCenterId, 'set');
+
     fixture = TestBed.createComponent(AowTargetDetailsDrawerComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -50,5 +66,33 @@ describe('AowTargetDetailsDrawerComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should build years from all center targets', () => {
+    expect(component.years()).toEqual(['2025', '2026']);
+  });
+
+  it('should pivot target values per center and year', () => {
+    const rows = component.tableData();
+
+    expect(rows).toHaveLength(2);
+    expect(component.getTargetValue(rows[0], '2026')).toBe('95');
+    expect(component.getTargetValue(rows[0], '2025')).toBe('0');
+    expect(component.getTargetValue(rows[1], '2026')).toBe('79');
+    expect(component.getTargetValue(rows[1], '2025')).toBe('');
+  });
+
+  it('should highlight the selected center row', () => {
+    const rows = component.tableData();
+
+    expect(component.isSelectedCenter(rows[0])).toBe(false);
+    expect(component.isSelectedCenter(rows[1])).toBe(true);
+  });
+
+  it('should clear selected center when drawer closes', () => {
+    component.closeDrawer();
+
+    expect(mockEntityAowService.showTargetDetailsDrawer.set).toHaveBeenCalledWith(false);
+    expect(mockEntityAowService.targetDetailsSelectedCenterId.set).toHaveBeenCalledWith(null);
   });
 });

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/components/aow-target-details-drawer/aow-target-details-drawer.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/components/aow-target-details-drawer/aow-target-details-drawer.component.spec.ts
@@ -95,4 +95,61 @@ describe('AowTargetDetailsDrawerComponent', () => {
     expect(mockEntityAowService.showTargetDetailsDrawer.set).toHaveBeenCalledWith(false);
     expect(mockEntityAowService.targetDetailsSelectedCenterId.set).toHaveBeenCalledWith(null);
   });
+
+  it('should not highlight rows when no center is selected', () => {
+    mockEntityAowService.targetDetailsSelectedCenterId.set(null);
+
+    const rows = component.tableData();
+
+    expect(component.isSelectedCenter(rows[0])).toBe(false);
+    expect(component.isSelectedCenter(rows[1])).toBe(false);
+  });
+
+  it('should clear selected center on destroy', () => {
+    component.ngOnDestroy();
+
+    expect(mockEntityAowService.targetDetailsSelectedCenterId.set).toHaveBeenCalledWith(null);
+    expect(document.body.style.overflow).toBe('auto');
+  });
+
+  it('should ignore invalid targets_by_center shapes', () => {
+    mockEntityAowService.currentTargetToView.set({
+      result_title: 'Test Result',
+      indicators: [{ indicator_description: 'Test', targets_by_center: { centers: null } }]
+    });
+    fixture.detectChanges();
+
+    expect(component.years()).toEqual([]);
+    expect(component.tableData()).toEqual([]);
+  });
+
+  it('should skip targets with empty year or value', () => {
+    mockEntityAowService.currentTargetToView.set({
+      result_title: 'Test Result',
+      indicators: [
+        {
+          indicator_description: 'Test',
+          targets_by_center: {
+            centers: [
+              {
+                center_id: '1',
+                center_acronym: 'ABC',
+                center_name: 'Center A',
+                targets: [
+                  { number_target: '1', target_value: '10', toc_indicator_target_id: '1', year: '' },
+                  { number_target: '1', target_value: '', toc_indicator_target_id: '2', year: '2026' },
+                  { number_target: '1', target_value: '55', toc_indicator_target_id: '3', year: '2027' }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    });
+    fixture.detectChanges();
+
+    expect(component.years()).toEqual(['2026', '2027']);
+    expect(component.getTargetValue(component.tableData()[0], '2026')).toBe('');
+    expect(component.getTargetValue(component.tableData()[0], '2027')).toBe('55');
+  });
 });

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/components/aow-target-details-drawer/aow-target-details-drawer.component.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/components/aow-target-details-drawer/aow-target-details-drawer.component.ts
@@ -4,21 +4,22 @@ import { EntityAowService } from '../../../../../../services/entity-aow.service'
 import { CommonModule } from '@angular/common';
 import { TableModule } from 'primeng/table';
 
-interface Center {
-  center_id: string;
-  center_acronym: string;
-  center_name: string;
-}
-
 interface Target {
   number_target: string;
-  target_value: string;
-  toc_indicator_target_id: string;
-  year: string;
+  target_value: string | number;
+  toc_indicator_target_id: string | number;
+  year: string | number;
+}
+
+interface CenterWithTargets {
+  center_id: string | number;
+  center_acronym: string;
+  center_name: string;
+  targets?: Target[];
 }
 
 interface TableRow {
-  center: Center;
+  center: CenterWithTargets;
   targetsByYear: Map<string, string>;
 }
 
@@ -32,41 +33,32 @@ interface TableRow {
 export class AowTargetDetailsDrawerComponent implements OnInit, OnDestroy {
   entityAowService = inject(EntityAowService);
 
-  years = computed(() => {
-    const targetsByCenter = this.entityAowService.currentTargetToView()?.indicators?.[0]?.targets_by_center;
-    if (!targetsByCenter?.targets) return [];
+  private readonly centersWithTargets = computed(() => {
+    const centers = this.entityAowService.currentTargetToView()?.indicators?.[0]?.targets_by_center?.centers;
+    return Array.isArray(centers) ? (centers as CenterWithTargets[]) : [];
+  });
 
+  years = computed(() => {
     const yearsSet = new Set<string>();
-    targetsByCenter.targets.forEach((target: Target) => {
-      if (target.year) yearsSet.add(target.year);
+
+    this.centersWithTargets().forEach((center: CenterWithTargets) => {
+      center.targets?.forEach((target: Target) => {
+        if (target.year != null && `${target.year}`.trim() !== '') {
+          yearsSet.add(String(target.year));
+        }
+      });
     });
 
-    return Array.from(yearsSet).sort((a, b) => a.localeCompare(b));
+    return Array.from(yearsSet).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
   });
 
   tableData = computed(() => {
-    const targetsByCenter = this.entityAowService.currentTargetToView()?.indicators?.[0]?.targets_by_center;
-    if (!targetsByCenter?.centers || !targetsByCenter?.targets) return [];
-
-    const centers: Center[] = targetsByCenter.centers;
-    const targets: Target[] = targetsByCenter.targets;
-
-    // Create a map of year -> target_value for quick lookup
-    const targetsByYearMap = new Map<string, string>();
-    targets.forEach((target: Target) => {
-      if (target.year && target.target_value) {
-        targetsByYearMap.set(target.year, target.target_value);
-      }
-    });
-
-    return centers.map((center: Center) => {
+    return this.centersWithTargets().map((center: CenterWithTargets) => {
       const targetsByYear = new Map<string, string>();
 
-      // All centers share the same targets by year
-      this.years().forEach(year => {
-        const value = targetsByYearMap.get(year);
-        if (value) {
-          targetsByYear.set(year, value);
+      center.targets?.forEach((target: Target) => {
+        if (target.year != null && target.target_value != null && `${target.target_value}`.trim() !== '') {
+          targetsByYear.set(String(target.year), String(target.target_value));
         }
       });
 
@@ -78,7 +70,22 @@ export class AowTargetDetailsDrawerComponent implements OnInit, OnDestroy {
   });
 
   getTargetValue(row: TableRow, year: string): string {
-    return row.targetsByYear.get(year) || '';
+    return row.targetsByYear.get(year) ?? '';
+  }
+
+  isSelectedCenter(row: TableRow): boolean {
+    const selectedCenterId = this.entityAowService.targetDetailsSelectedCenterId();
+    if (selectedCenterId == null) {
+      return false;
+    }
+
+    return String(row.center.center_id) === String(selectedCenterId);
+  }
+
+  closeDrawer(): void {
+    this.entityAowService.showTargetDetailsDrawer.set(false);
+    this.entityAowService.targetDetailsDrawerFullScreen.set(false);
+    this.entityAowService.targetDetailsSelectedCenterId.set(null);
   }
 
   ngOnInit() {
@@ -87,5 +94,6 @@ export class AowTargetDetailsDrawerComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     document.body.style.overflow = 'auto';
+    this.entityAowService.targetDetailsSelectedCenterId.set(null);
   }
 }

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/services/entity-aow.service.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/services/entity-aow.service.spec.ts
@@ -395,7 +395,25 @@ describe('EntityAowService', () => {
 
       service.getTocResultsByAowId(entityId, aowId);
 
-      expect(mockApiService.resultsSE.GET_TocResultsByAowId).toHaveBeenCalledWith(entityId, aowId);
+      expect(mockApiService.resultsSE.GET_TocResultsByAowId).toHaveBeenCalledWith(entityId, aowId, undefined);
+    });
+
+    it('should call API with reporting phase year when configured', () => {
+      const entityId = 'test-entity-id';
+      const aowId = 'test-aow-id';
+      (mockApiService as any).dataControlSE.reportingCurrentPhase = {
+        phaseId: 34,
+        phaseYear: 2026,
+      };
+      jest.spyOn(mockApiService.resultsSE, 'GET_TocResultsByAowId').mockReturnValue(of(mockTocApiResponse));
+
+      service.getTocResultsByAowId(entityId, aowId);
+
+      expect(mockApiService.resultsSE.GET_TocResultsByAowId).toHaveBeenCalledWith(
+        entityId,
+        aowId,
+        '2026',
+      );
     });
 
     it('should update tocResultsOutputsByAowId and tocResultsOutcomesByAowId and set loading to false on successful API call', () => {
@@ -1013,7 +1031,7 @@ describe('EntityAowService', () => {
       expect(service.tocResultsOutputsByAowId()).toEqual(mockTocResults);
       expect(service.tocResultsOutcomesByAowId()).toEqual([]);
       expect(service.isLoadingTocResultsByAowId()).toBe(false);
-      expect(mockApiService.resultsSE.GET_TocResultsByAowId).toHaveBeenCalledWith(entityId, aowId);
+      expect(mockApiService.resultsSE.GET_TocResultsByAowId).toHaveBeenCalledWith(entityId, aowId, undefined);
     });
 
     it('should maintain state consistency across multiple TOC operations', () => {
@@ -1051,7 +1069,7 @@ describe('EntityAowService', () => {
       expect(service.tocResultsOutputsByAowId()).toEqual(customTocResults);
       expect(service.tocResultsOutcomesByAowId()).toEqual([]);
       expect(service.isLoadingTocResultsByAowId()).toBe(false);
-      expect(mockApiService.resultsSE.GET_TocResultsByAowId).toHaveBeenCalledWith(entityId, aowId2);
+      expect(mockApiService.resultsSE.GET_TocResultsByAowId).toHaveBeenCalledWith(entityId, aowId2, undefined);
     });
 
     it('should handle complete modal workflow', () => {

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/services/entity-aow.service.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/services/entity-aow.service.spec.ts
@@ -189,6 +189,35 @@ describe('EntityAowService', () => {
       expect(service.isLoadingDetails()).toBe(false);
     });
 
+    it('should disable reporting when initiative status returns reporting_enabled false', async () => {
+      service.entityId.set('SP01');
+      jest.spyOn(mockApiService.resultsSE, 'GET_ClarisaGlobalUnits').mockReturnValue(of(mockApiResponse));
+      jest.spyOn(mockApiService.resultsSE, 'GET_IndicatorContributionSummary').mockReturnValue(of(mockIndicatorApiResponse));
+      jest.spyOn(mockApiService.resultsSE, 'GET_phaseInitiativeStatus').mockReturnValue(
+        of({ response: { reporting_enabled: false } })
+      );
+
+      service.getAllDetailsData();
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(mockApiService.resultsSE.GET_phaseInitiativeStatus).toHaveBeenCalledWith(34, 1);
+      expect(service.reportingEnabled()).toBe(false);
+    });
+
+    it('should keep reporting enabled when initiative status request fails', async () => {
+      service.entityId.set('SP01');
+      jest.spyOn(mockApiService.resultsSE, 'GET_ClarisaGlobalUnits').mockReturnValue(of(mockApiResponse));
+      jest.spyOn(mockApiService.resultsSE, 'GET_IndicatorContributionSummary').mockReturnValue(of(mockIndicatorApiResponse));
+      jest.spyOn(mockApiService.resultsSE, 'GET_phaseInitiativeStatus').mockReturnValue(
+        throwError(() => new Error('phase status unavailable'))
+      );
+
+      service.getAllDetailsData();
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(service.reportingEnabled()).toBe(true);
+    });
+
     it('should handle empty units array', async () => {
       service.entityId.set('SP01');
       const responseWithEmptyUnits = {

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/services/entity-aow.service.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/services/entity-aow.service.ts
@@ -52,6 +52,7 @@ export class EntityAowService {
   showTargetDetailsDrawer = signal<boolean>(false);
   targetDetailsDrawerFullScreen = signal<boolean>(false);
   currentTargetToView = signal<any>({});
+  targetDetailsSelectedCenterId = signal<string | number | null>(null);
 
   dashboardData = signal<any>(null);
 
@@ -212,12 +213,19 @@ export class EntityAowService {
     ]);
   }
 
+  private resolveReportingYearQueryParam(): string | undefined {
+    const reportingYear = this.reportingPhaseYear;
+    if (reportingYear === '' || reportingYear == null) return undefined;
+    return String(reportingYear);
+  }
+
   getTocResultsByAowId(entityId: string, aowId: string) {
     if (!entityId || !aowId) return;
 
     this.isLoadingTocResultsByAowId.set(true);
 
-    this.api.resultsSE.GET_TocResultsByAowId(entityId, aowId).subscribe({
+    const year = this.resolveReportingYearQueryParam();
+    this.api.resultsSE.GET_TocResultsByAowId(entityId, aowId, year).subscribe({
       next: ({ response }) => {
         this.tocResultsOutputsByAowId.set(response?.tocResultsOutputs ?? []);
         this.tocResultsOutcomesByAowId.set(response?.tocResultsOutcomes ?? []);

--- a/onecgiar-pr-server/src/api/results-framework-reporting/results-framework-reporting.service.spec.ts
+++ b/onecgiar-pr-server/src/api/results-framework-reporting/results-framework-reporting.service.spec.ts
@@ -63,6 +63,7 @@ const mockTocResultsRepository = {
   findIndicatorById: jest.fn(),
   findUnitAcronymsByProgram: jest.fn(),
   getIndicatorContributions: jest.fn(),
+  findTargetsWithCentersByIndicatorId: jest.fn(),
 };
 
 const defaultTocContext = {
@@ -723,6 +724,105 @@ describe('ResultsFrameworkReportingService', () => {
       expect(
         mockTocResultsRepository.findByCompositeCode,
       ).not.toHaveBeenCalled();
+    });
+
+    it('should enrich indicator targets using the resolved reporting year', async () => {
+      const tocContext = { reportingYear: 2026, phaseUuid: 'PHASE-1' };
+      mockReportingTocContextService.resolve.mockResolvedValueOnce(tocContext);
+      mockTocResultsRepository.findByCompositeCode.mockResolvedValueOnce([
+        {
+          id: 1,
+          category: 'OUTPUT',
+          result_title: 'Result 1',
+          related_node_id: 'NODE-1',
+          indicators: [
+            {
+              indicator_id: 55,
+              indicator_description: 'Indicator 1',
+              target_date: 2026,
+              target_value: 95,
+            },
+          ],
+        },
+      ]);
+      mockTocResultsRepository.findTargetsWithCentersByIndicatorId.mockResolvedValueOnce(
+        [
+          {
+            toc_indicator_target_id: 10,
+            year: 2026,
+            target_value: 95,
+            number_target: '1',
+            centers: [
+              {
+                center_id: 1,
+                center_acronym: 'ABC',
+                center_name: 'Alliance of Bioversity and CIAT - Headquarter',
+              },
+            ],
+          },
+          {
+            toc_indicator_target_id: 11,
+            year: 2026,
+            target_value: 79,
+            number_target: '1',
+            centers: [
+              {
+                center_id: 3,
+                center_acronym: 'CIP',
+                center_name: 'International Potato Center',
+              },
+            ],
+          },
+        ],
+      );
+
+      const result: any = await service.getWorkPackagesByProgramAndArea(
+        'SP01',
+        'AOW01',
+        '2026',
+      );
+
+      expect(
+        mockTocResultsRepository.findTargetsWithCentersByIndicatorId,
+      ).toHaveBeenCalledWith(55, 2026);
+      expect(
+        result.response.tocResultsOutputs[0].indicators[0].targets_by_center,
+      ).toEqual({
+        centers: [
+          {
+            center_id: 1,
+            center_acronym: 'ABC',
+            center_name: 'Alliance of Bioversity and CIAT - Headquarter',
+            targets: [
+              {
+                toc_indicator_target_id: 10,
+                year: 2026,
+                target_value: 95,
+                number_target: '1',
+              },
+            ],
+          },
+          {
+            center_id: 3,
+            center_acronym: 'CIP',
+            center_name: 'International Potato Center',
+            targets: [
+              {
+                toc_indicator_target_id: 11,
+                year: 2026,
+                target_value: 79,
+                number_target: '1',
+              },
+            ],
+          },
+        ],
+      });
+      expect(
+        result.response.tocResultsOutputs[0].indicators[0].center_acronym,
+      ).toBe('ABC');
+      expect(result.response.tocResultsOutputs[0].indicators[0].center_id).toBe(
+        1,
+      );
     });
   });
 

--- a/onecgiar-pr-server/src/api/results-framework-reporting/results-framework-reporting.service.ts
+++ b/onecgiar-pr-server/src/api/results-framework-reporting/results-framework-reporting.service.ts
@@ -302,35 +302,53 @@ export class ResultsFrameworkReportingService {
         const targetsWithCenters =
           await this._tocResultsRepository.findTargetsWithCentersByIndicatorId(
             indicator.indicator_id,
+            resolvedYear,
           );
 
-        const centersMap = new Map<
+        const centerTargetsMap = new Map<
           number,
-          { center_id: number; center_acronym: string; center_name: string }
+          {
+            center_id: number;
+            center_acronym: string;
+            center_name: string;
+            targets: Array<{
+              toc_indicator_target_id: number;
+              year: number;
+              target_value: number;
+              number_target: string;
+            }>;
+          }
         >();
 
-        const targets = targetsWithCenters.map((target) => {
-          target.centers.forEach((center) => {
-            if (!centersMap.has(center.center_id)) {
-              centersMap.set(center.center_id, {
+        for (const target of targetsWithCenters) {
+          for (const center of target.centers ?? []) {
+            if (!center?.center_id) {
+              continue;
+            }
+
+            if (!centerTargetsMap.has(center.center_id)) {
+              centerTargetsMap.set(center.center_id, {
                 center_id: center.center_id,
                 center_acronym: center.center_acronym,
                 center_name: center.center_name,
+                targets: [],
               });
             }
-          });
 
-          return {
-            toc_indicator_target_id: target.toc_indicator_target_id,
-            year: target.year,
-            target_value: target.target_value,
-            number_target: target.number_target,
-          };
-        });
+            centerTargetsMap.get(center.center_id)?.targets.push({
+              toc_indicator_target_id: target.toc_indicator_target_id,
+              year: target.year,
+              target_value: target.target_value,
+              number_target: target.number_target,
+            });
+          }
+        }
 
-        indicator.targets_by_center = centersMap.size
-          ? { targets, centers: Array.from(centersMap.values()) }
+        indicator.targets_by_center = centerTargetsMap.size
+          ? { centers: Array.from(centerTargetsMap.values()) }
           : {};
+
+        this.assignIndicatorCenterContext(indicator, resolvedYear);
       };
 
       const enrichTocResult = async (tocResult: any) => {
@@ -375,6 +393,41 @@ export class ResultsFrameworkReportingService {
     } catch (error) {
       return this._handlersError.returnErrorRes({ error, debug: true });
     }
+  }
+
+  private assignIndicatorCenterContext(
+    indicator: any,
+    resolvedYear: number,
+  ): void {
+    const centers = indicator?.targets_by_center?.centers;
+    if (!Array.isArray(centers) || !centers.length) {
+      return;
+    }
+
+    const reportingYear = String(indicator.target_date ?? resolvedYear);
+    const targetValue =
+      indicator.target_value ?? indicator.target_value_sum ?? null;
+
+    if (targetValue == null || `${targetValue}`.trim() === '') {
+      return;
+    }
+
+    const normalizedTarget = String(targetValue);
+    const matchedCenter = centers.find((center: any) =>
+      center.targets?.some(
+        (target: any) =>
+          String(target.year) === reportingYear &&
+          String(target.target_value) === normalizedTarget,
+      ),
+    );
+
+    if (!matchedCenter) {
+      return;
+    }
+
+    indicator.center_id = matchedCenter.center_id;
+    indicator.center_acronym = matchedCenter.center_acronym;
+    indicator.center_name = matchedCenter.center_name;
   }
 
   async getToc2030Outcomes(programId?: string) {

--- a/onecgiar-pr-server/src/api/results/results-toc-results/repositories/aow-bilateral.repository.spec.ts
+++ b/onecgiar-pr-server/src/api/results/results-toc-results/repositories/aow-bilateral.repository.spec.ts
@@ -453,4 +453,45 @@ describe('AoWBilateralRepository', () => {
       expect(phaseId).toBeNull();
     });
   });
+
+  describe('findTargetsWithCentersByIndicatorId', () => {
+    it('should filter targets from the reporting year onward', async () => {
+      dataSourceQueryMock.mockResolvedValueOnce([
+        {
+          toc_indicator_target_id: 10,
+          year: 2026,
+          target_value: 5,
+          number_target: '1',
+          center_id: 3,
+          center_acronym: 'CIP',
+          center_name: 'International Potato Center',
+        },
+      ]);
+
+      const result = await repository.findTargetsWithCentersByIndicatorId(
+        99,
+        2026,
+      );
+
+      expect(dataSourceQueryMock).toHaveBeenCalledWith(
+        expect.stringContaining('AND trit.target_date >= ?'),
+        [99, 2026],
+      );
+      expect(result).toEqual([
+        {
+          toc_indicator_target_id: 10,
+          year: 2026,
+          target_value: 5,
+          number_target: '1',
+          centers: [
+            {
+              center_id: 3,
+              center_acronym: 'CIP',
+              center_name: 'International Potato Center',
+            },
+          ],
+        },
+      ]);
+    });
+  });
 });

--- a/onecgiar-pr-server/src/api/results/results-toc-results/repositories/aow-bilateral.repository.ts
+++ b/onecgiar-pr-server/src/api/results/results-toc-results/repositories/aow-bilateral.repository.ts
@@ -694,11 +694,15 @@ export class AoWBilateralRepository {
   }
 
   /**
-   * Get all targets for an indicator across all years with their contributing centers
+   * Get all targets for an indicator from the reporting year onward with their contributing centers.
    * @param indicatorId The indicator ID from toc_results_indicators
+   * @param reportingYear Active reporting phase year (from ReportingTocContext)
    * @returns Array of targets with their centers
    */
-  async findTargetsWithCentersByIndicatorId(indicatorId: number) {
+  async findTargetsWithCentersByIndicatorId(
+    indicatorId: number,
+    reportingYear: number,
+  ) {
     const query = `
       SELECT
         trit.toc_indicator_target_id,
@@ -714,12 +718,15 @@ export class AoWBilateralRepository {
       LEFT JOIN ${env.DB_NAME}.clarisa_institutions ci 
         ON tritc.center_id = ci.id
       WHERE trit.id_indicator = ?
-        AND trit.target_date >= 2025
+        AND trit.target_date >= ?
       ORDER BY trit.target_date ASC, ci.acronym ASC
     `;
 
     try {
-      const rows = await this.dataSource.query(query, [indicatorId]);
+      const rows = await this.dataSource.query(query, [
+        indicatorId,
+        reportingYear,
+      ]);
 
       // Group by target_id to consolidate centers
       const targetsMap = new Map<


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Release: staging → master

### App code shipped (production impact)

- **entity-aow / Results Framework Reporting** — Fix per-center targets and improve AoW indicator UX:
  - Nest targets by center in the API (`results-framework-reporting` / `aow-bilateral` repository).
  - Show center chips in the AoW HLO table.
  - Highlight the selected center in Target details drawer.
  - Use table-specific empty states.
- **Tests** — Raise branch coverage for target details and reporting access (drawer edge cases, center resolution fallbacks, phase initiative status error handling).

### Scope

| Area | Change |
|------|--------|
| `aow-hlo-table` (+ drawer) | Center chips, selected-center highlight, empty states |
| `entity-aow.service` | Client support for nested per-center targets |
| `results-framework-reporting.service` | Nest targets by center in API response |
| `aow-bilateral.repository` | Query/support for per-center target data |
| Specs (client + server) | Coverage for UX paths and reporting access |

### Diff summary

- 14 files changed, ~642 insertions / ~73 deletions
- Frontend (`onecgiar-pr-client`) + backend (`onecgiar-pr-server`)

### Commits on staging (not in master)

1. `🔧 fix(entity-aow): fix per-center targets and improve AoW indicator UX`
2. `🧪 test(entity-aow): raise branch coverage for target details and reporting access`

### Validation

- Please confirm CI on this PR (lint, unit tests, SonarCloud, Snyk) before merge to production.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f85b2-75b3-7961-8a63-9fc0594b1eed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f85b2-75b3-7961-8a63-9fc0594b1eed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

