### PR TITLE
🚀 Release P2-3175: move Evidence section to end of result form

### DIFF
--- a/onecgiar-pr-client/src/app/shared/routing/routing-data.ts
+++ b/onecgiar-pr-client/src/app/shared/routing/routing-data.ts
@@ -349,13 +349,13 @@ export const resultDetailRouting: PrRoute[] = [
     loadChildren: () =>
       import('../../pages/results/pages/result-detail/pages/rd-links-to-results/rd-links-to-results.module').then(m => m.RdLinksToResultsModule)
   },
+  ...rdResultTypesPages,
   {
     prName: 'Evidence',
     path: 'evidences',
     underConstruction: false,
     loadChildren: () => import('../../pages/results/pages/result-detail/pages/rd-evidences/rd-evidences.module').then(m => m.RdEvidencesModule)
   },
-  ...rdResultTypesPages,
   { prName: '', path: '**', pathMatch: 'full', redirectTo: 'general-information' }
 ];
 

--- a/openspec/changes/p2-3175-move-evidence-section-to-end/.openspec.yaml
+++ b/openspec/changes/p2-3175-move-evidence-section-to-end/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/p2-3175-move-evidence-section-to-end/design.md
+++ b/openspec/changes/p2-3175-move-evidence-section-to-end/design.md
@@ -1,0 +1,42 @@
+# Design — P2-3175: Move the Evidence section to the end of the result form
+
+## Context
+
+The Result Detail form's section order is defined by a single source of truth: the `resultDetailRouting: PrRoute[]` array in `onecgiar-pr-client/src/app/shared/routing/routing-data.ts` (lines 318-378). Two consumers read the same array:
+
+1. `result-detail-routing.module.ts` — registers the entries as Angular child routes (resolved by `path`).
+2. `panel-menu.component.ts` — feeds the side panel menu (`navigationOptions = resultDetailRouting`), filtered per result by `panel-menu.pipe.ts` (`prHide` = result_type_id, `portfolioAcronym` = P22/P25). `Array.filter` preserves order, numbering is `{{ $index + 1 }}`.
+
+Today Evidence (lines 370-375) sits before the `...rdResultTypesPages` spread (line 376), so type-specific sections (Innovation Use/Dev, KP, Policy, CapSharing) render after Evidence. There is **no Previous/Next navigation** between sections (verified by grep; AC4 confirmed N/A by ticket author). Green checks are matched by `section_name` string, not index.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Evidence is the last visible section for all 5 result types and both portfolios.
+- Zero behavioral change to Evidence itself (routes, data, validations, green checks).
+
+**Non-Goals:**
+- Adding Previous/Next navigation (does not exist; out of scope).
+- Backend changes (green-checks completeness logic is position-agnostic; verify read-only).
+- Any change to the Evidence module (`rd-evidences/`) internals.
+
+## Decisions
+
+- **D1 — Reorder the array, nothing else.** Move the Evidence object to after `...rdResultTypesPages` and before the `**` wildcard. Alternative considered: per-type conditional ordering in the pipe — rejected as needless complexity; the ticket asks for Evidence last for *all* applicable types and one shared list already models that.
+- **D2 — Keep the `**` wildcard as the physical last entry.** The Angular router matches wildcards in declaration order; it must remain last.
+- **D3 — No test-file surgery.** `routing-data*.ts` is excluded from Jest coverage; validation is done via the existing panel-menu pipe spec (if order assertions exist) plus in-browser verification of the 5 result types.
+
+## Risks / Trade-offs
+
+- [Deep links / bookmarks to `/evidences`] → None: routes resolve by `path`, unaffected by order.
+- [User muscle memory: Evidence moves visually] → Intended by the ticket; QA (author) drives the UX decision.
+- [Hidden consumer assuming Evidence's index] → Searched: no index-based consumers found (menu, pipe, green checks, router are all name/path-based). Residual risk covered by browser verification of all 5 types.
+- [Backend green-checks iteration order] → Read-only check only; matching is by `section_name`, and no order dependency was found client-side.
+
+## Migration Plan
+
+Single-file client change, no data migration. Deploy with the normal branch → dev flow; rollback = revert the commit.
+
+## Open Questions
+
+None — AC4 (Previous/Next) resolved as N/A with the ticket author (Slack, 2026-07-22).

--- a/openspec/changes/p2-3175-move-evidence-section-to-end/proposal.md
+++ b/openspec/changes/p2-3175-move-evidence-section-to-end/proposal.md
@@ -1,0 +1,29 @@
+# Proposal — P2-3175: Move the Evidence section to the end of the result form
+
+## Why
+
+In several result types, the Evidence section currently appears before the final type-specific section (e.g., before Innovation Use or Innovation Development), yet the evidence a user provides often depends on the data entered in those later sections. Placing Evidence last gives a logical, intuitive completion order: fill in all result information first, then attach supporting evidence (Jira P2-3175, QA Enhancement, parent epic P2-3174).
+
+## What Changes
+
+- The Evidence section becomes the **last** section of the result creation/editing form for all applicable result types.
+- The side panel menu (the only inter-section navigation — there are no Previous/Next buttons, confirmed N/A by the ticket author) reflects the new order automatically, including its `1. 2. 3.` numbering.
+- No changes to Evidence functionality, stored data, validations, or green checks — position only.
+
+## Capabilities
+
+### New Capabilities
+- `result-form-section-order`: Defines the ordered list of sections in the Result Detail form and requires Evidence to always be the final visible section for every result type and portfolio.
+
+### Modified Capabilities
+
+<!-- none — existing evidence specs (card layout, deletion persistence, alert messaging) are unaffected; only section position changes -->
+
+## Impact
+
+- **Code**: `onecgiar-pr-client/src/app/shared/routing/routing-data.ts` — move the Evidence entry (currently lines 370-375 of `resultDetailRouting`) to after the `...rdResultTypesPages` spread and before the `**` wildcard (which must remain last).
+- **Consumers of the array** (no code change needed, behavior follows the array order):
+  - `result-detail-routing.module.ts` — Angular child routes (resolved by `path`, order-safe).
+  - `panel-menu.component.ts/.html` — side menu; numbering is `$index + 1`, recomputed automatically.
+  - `panel-menu.pipe.ts` — filters by `prHide`/`portfolioAcronym` preserving array order; green checks matched by `section_name` string, position-independent.
+- **Out of scope**: Previous/Next navigation (does not exist — AC4 confirmed N/A by ticket author on Slack, 2026-07-22); backend green-checks logic (read-only verification only); Evidence module internals.

--- a/openspec/changes/p2-3175-move-evidence-section-to-end/specs/result-form-section-order/spec.md
+++ b/openspec/changes/p2-3175-move-evidence-section-to-end/specs/result-form-section-order/spec.md
@@ -1,0 +1,29 @@
+# result-form-section-order — Delta Spec (P2-3175)
+
+## ADDED Requirements
+
+### Requirement: Evidence is the last section of the result form
+The Result Detail form SHALL display the Evidence section as the last visible section of the section menu for every applicable result type (Capacity Sharing for Development, Innovation Development, Innovation Use, Knowledge Product, Policy Change) and for both portfolios (P22 and P25). The type-specific section (e.g., Innovation Use info) SHALL appear before Evidence.
+
+#### Scenario: Evidence appears last for a type-specific result
+- **WHEN** a user opens a result whose type has a type-specific section (e.g., Innovation Development, result_type_id 7)
+- **THEN** the side panel menu lists the type-specific section before Evidence, and Evidence is the final item in the menu
+
+#### Scenario: Evidence appears last for every result type
+- **WHEN** a user opens a result of any of the 5 result types (ids 1, 2, 5, 6, 7) in either portfolio (P22 or P25)
+- **THEN** Evidence is always the last item of the side panel menu for that result
+
+#### Scenario: Menu numbering reflects the new order
+- **WHEN** the side panel menu renders after the reorder
+- **THEN** the visible numbering (`1.`, `2.`, …) is sequential with Evidence holding the highest number, with no gaps or duplicates
+
+### Requirement: Section order is defined solely by the routing array
+The order of the Result Detail sections SHALL be defined exclusively by the order of entries in the `resultDetailRouting` array (`shared/routing/routing-data.ts`), with the `**` wildcard redirect remaining the last entry of the array. No consumer SHALL depend on the numeric position of a section.
+
+#### Scenario: Wildcard remains last
+- **WHEN** the `resultDetailRouting` array is evaluated by the Angular router
+- **THEN** the `**` redirect to `general-information` is the final entry, after Evidence
+
+#### Scenario: Reordering does not affect functionality
+- **WHEN** the Evidence section is moved to the end of the array
+- **THEN** the Evidence route (`evidences`), its stored data, its validations, and its green check (matched by `section_name`, not by position) behave exactly as before

--- a/openspec/changes/p2-3175-move-evidence-section-to-end/tasks.md
+++ b/openspec/changes/p2-3175-move-evidence-section-to-end/tasks.md
@@ -1,0 +1,22 @@
+# Tasks — P2-3175: Move the Evidence section to the end of the result form
+
+## 1. Branch setup
+
+- [x] 1.1 Create branch `P2-3175-move-evidence-section-to-end` from `staging` (verify with `git branch --show-current` before any commit)
+
+## 2. Implementation
+
+- [x] 2.1 In `onecgiar-pr-client/src/app/shared/routing/routing-data.ts`, move the Evidence entry (`prName: 'Evidence'`, `path: 'evidences'`) from before `...rdResultTypesPages` to after it, keeping the `**` wildcard as the last array entry
+
+## 3. Verification
+
+- [x] 3.1 Run client unit tests (`npm run test`) — expect green, no order-dependent failures
+- [x] 3.2 Run lint (`npm run lint`) — clean
+- [x] 3.3 In-browser check (`npm start`, prtest backend): open one result per type (Policy Change 1, Innovation Use 2, CapSharing 5, Knowledge Product 6, Innovation Dev 7) and confirm Evidence is the last item of the side menu with sequential numbering; spot-check a P25 result too
+- [x] 3.4 Confirm Evidence still works unchanged: open the section, green check renders, deep link `/result/result-detail/<id>/evidences` resolves
+- [x] 3.5 Read-only check that server green-checks logic has no section-order dependency (no code change)
+
+## 4. Delivery
+
+- [x] 4.1 Commit with project convention (`🎨 style(routing-data) P2-3175: move Evidence section to end of result form` or `♻️ refactor(...)`) — English message
+- [x] 4.2 Push branch and merge to `dev` per team flow; notify QA (Cami) with verification steps; document on the Jira ticket (What was done / Why / How to verify, noting AC4 = N/A per author)


### PR DESCRIPTION
## Release summary
This PR promotes **P2-3175** from `staging` to `master` (production). It is the **only** change ahead of master.

## What was done
- The **Evidence** section is now the **last section** of the Result Detail form for all result types (Policy Change, Innovation Use, Capacity Sharing, Knowledge Product, Innovation Development) and both portfolios (P22/P25).
- The type-specific section (e.g., Innovation Dev info) now appears **before** Evidence in the left side menu; the menu order and numbering update automatically.
- Evidence functionality, stored data, validations and green checks remain **unchanged** — only its position moved.

## Why
- Evidence often depends on information entered in the type-specific sections, so it should be completed last for a more logical reporting flow (parent epic P2-3174).

## Scope of the change
- **1 line of production code**: in `onecgiar-pr-client/src/app/shared/routing/routing-data.ts`, the Evidence entry was moved after the `...rdResultTypesPages` spread in `resultDetailRouting`; the `**` wildcard remains last.
- The rest of the diff is the OpenSpec change documentation (markdown only, no runtime impact).

## Risk assessment — very low
- No new logic. Angular routes resolve by `path` (order-independent); green checks match by `section_name` (position-independent); the side-menu numbering is `$index + 1` (auto-recomputed).
- No backend changes, no data migration.
- Rollback = revert the single commit.

## How to verify in production
1. Open any result (each of the 5 result types applies).
2. Left side menu: **Evidence is the last section**, numbered after the type-specific section.
3. Open Evidence and confirm it loads/saves as usual (green check included).

## QA status
- ✅ QA approved by María Camila Giraldo (dev/prtest): _"It is observed that the issue has indeed been corrected"_ — ticket moved to `To Be Deployed`.

## Notes
- AC "Previous/Next navigation is updated" is **N/A**: the form has no Previous/Next buttons — navigation is via the side menu only (confirmed with the reporter).

## Technical references
- Jira: P2-3175 (epic P2-3174)
- Commit: `798fcbabf`
- Feature branch: `P2-3175-move-evidence-section-to-end` (merged to staging via #728)

🤖 Generated with [Claude Code](https://claude.com/claude-code)