### PR TITLE
🚀 Release P2-3178: consistent duplicate title validation on result creation

### DIFF
--- a/onecgiar-pr-client/src/app/pages/results/pages/result-creator/components/report-result-form/report-result-form.component.html
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-creator/components/report-result-form/report-result-form.component.html
@@ -91,17 +91,21 @@
           (ngModelChange)="onTitleChange(this.resultLevelSE.resultBody.result_name)">
         </app-pr-input>
 
-        <!-- Alert for exact title match validation -->
+        <!-- Alert for exact title match validation (MySQL uniqueness) -->
         <div *ngIf="!isKnowledgeProduct && this.resultLevelSE.resultBody.result_name?.trim()?.length > 0" class="title-validation-alert">
           <div *ngIf="loadingDepthSearch()" class="alert-validating">
             <i class="pi pi-spin pi-spinner"></i>
             <span>Validating title, please wait...</span>
           </div>
-          <div *ngIf="!loadingDepthSearch() && exactTitleFound()" class="alert-warning">
+          <div *ngIf="!loadingDepthSearch() && titleCheckFailed()" class="alert-warning">
+            <i class="pi pi-exclamation-triangle"></i>
+            <span>Unable to verify title uniqueness. Please try again before creating this result.</span>
+          </div>
+          <div *ngIf="!loadingDepthSearch() && !titleCheckFailed() && exactTitleFound()" class="alert-warning">
             <i class="pi pi-exclamation-triangle"></i>
             <span>A result with this exact title already exists. Please use a different title or map to the existing result.</span>
           </div>
-          <div *ngIf="!loadingDepthSearch() && !exactTitleFound()" class="alert-success">
+          <div *ngIf="!loadingDepthSearch() && !titleCheckFailed() && !exactTitleFound()" class="alert-success">
             <i class="pi pi-check-circle"></i>
             <span>No existing result found with this exact title. You can proceed to create this result.</span>
           </div>

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-creator/components/report-result-form/report-result-form.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-creator/components/report-result-form/report-result-form.component.spec.ts
@@ -653,6 +653,33 @@ describe('ReportResultFormComponent', () => {
       expect(component.loadingDepthSearch()).toBe(false);
       jest.useRealTimers();
     });
+
+    it('should resolve gate before slow Elastic finishes', () => {
+      jest.useFakeTimers();
+      fixture.detectChanges();
+      component.allPhases = mockPhases.reporting;
+      const elastic$ = new Subject<any[]>();
+
+      mockApiService.resultsSE.GET_checkTitleUniqueness = jest.fn(() =>
+        of({ response: { isUnique: true, existing: null } })
+      );
+      mockApiService.resultsSE.GET_FindResultsElastic = jest.fn(() => elastic$.asObservable());
+
+      component.onTitleChange('slow elastic title');
+      jest.advanceTimersByTime(500);
+
+      expect(component.loadingDepthSearch()).toBe(false);
+      expect(component.blockingExactTitleFound()).toBe(false);
+      expect(component.titleCheckFailed()).toBe(false);
+      expect(component.depthSearchList).toEqual([]);
+
+      elastic$.next([{ id: 1, title: 'slow elastic title', version_id: 1 }]);
+      elastic$.complete();
+
+      expect(component.depthSearchList.length).toBe(1);
+      expect(component.loadingDepthSearch()).toBe(false);
+      jest.useRealTimers();
+    });
   });
 
   describe('applyPendingResultTypeSelection', () => {

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-creator/components/report-result-form/report-result-form.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-creator/components/report-result-form/report-result-form.component.spec.ts
@@ -59,6 +59,7 @@ describe('ReportResultFormComponent', () => {
         GET_AllInitiatives: jest.fn(() => of({ response: mockInitiatives })),
         GET_cgiarEntityTypes: jest.fn(() => of({ response: mockEntityTypes })),
         GET_FindResultsElastic: jest.fn(() => of([])),
+        GET_checkTitleUniqueness: jest.fn(() => of({ response: { isUnique: true, existing: null } })),
         POST_resultCreateHeader: jest.fn(() => of({ response: { result_code: 'R001', version_id: 1 } })),
         POST_createWithHandle: jest.fn(() => of({ response: { result_code: 'R001', version_id: 1 } })),
         GET_mqapValidation: jest.fn(() => of({ response: { title: 'Test Title' } }))
@@ -280,6 +281,9 @@ describe('ReportResultFormComponent', () => {
         { id: 2, title: 'Another Result', version_id: 2 }
       ];
       mockApiService.resultsSE.GET_FindResultsElastic = jest.fn(() => of(mockResults));
+      mockApiService.resultsSE.GET_checkTitleUniqueness = jest.fn(() =>
+        of({ response: { isUnique: true, existing: null } })
+      );
       component.allPhases = mockPhases.reporting;
 
       component.depthSearch('Test');
@@ -288,25 +292,45 @@ describe('ReportResultFormComponent', () => {
       expect(component.depthSearchList[0].phase).toBeDefined();
     });
 
-    it('should set exactTitleFound when exact match is confirmed after recheck', () => {
-      jest.useFakeTimers();
-      const mockResults = [{ id: 1, title: 'Test Result', version_id: 1 }];
-      mockApiService.resultsSE.GET_FindResultsElastic = jest.fn(() => of(mockResults));
+    it('should set exactTitleFound from MySQL uniqueness check when title conflicts', () => {
+      mockApiService.resultsSE.GET_FindResultsElastic = jest.fn(() => of([]));
+      mockApiService.resultsSE.GET_checkTitleUniqueness = jest.fn(() =>
+        of({
+          response: {
+            isUnique: false,
+            existing: { id: 11115, result_code: 1, title: 'Test Result', version_id: 1 }
+          }
+        })
+      );
       component.allPhases = mockPhases.reporting;
 
       component.depthSearch('Test Result');
-      jest.advanceTimersByTime(700);
 
       expect(component.exactTitleFound()).toBe(true);
       expect(component.blockingExactTitleFound()).toBe(true);
-      jest.useRealTimers();
+      expect(component.titleCheckFailed()).toBe(false);
     });
 
-    it('should handle errors gracefully', () => {
-      mockApiService.resultsSE.GET_FindResultsElastic = jest.fn(() => throwError(() => new Error('Error')));
+    it('should block save and not show green when uniqueness check fails', () => {
+      mockApiService.resultsSE.GET_FindResultsElastic = jest.fn(() => of([]));
+      mockApiService.resultsSE.GET_checkTitleUniqueness = jest.fn(() => throwError(() => new Error('Error')));
       component.depthSearch('Test');
       expect(component.depthSearchList).toEqual([]);
       expect(component.exactTitleFound()).toBe(false);
+      expect(component.titleCheckFailed()).toBe(true);
+      expect(component.blockingExactTitleFound()).toBe(true);
+    });
+
+    it('should keep similar results when Elastic succeeds but uniqueness fails', () => {
+      mockApiService.resultsSE.GET_FindResultsElastic = jest.fn(() =>
+        of([{ id: 1, title: 'Similar', version_id: 1 }])
+      );
+      mockApiService.resultsSE.GET_checkTitleUniqueness = jest.fn(() => throwError(() => new Error('Error')));
+      component.allPhases = mockPhases.reporting;
+      component.depthSearch('Similar');
+      expect(component.depthSearchList.length).toBe(1);
+      expect(component.titleCheckFailed()).toBe(true);
+      expect(component.blockingExactTitleFound()).toBe(true);
     });
   });
 
@@ -560,6 +584,7 @@ describe('ReportResultFormComponent', () => {
       jest.useFakeTimers();
       fixture.detectChanges();
       mockApiService.resultsSE.GET_FindResultsElastic.mockClear();
+      mockApiService.resultsSE.GET_checkTitleUniqueness.mockClear();
 
       component.onTitleChange('test title');
       expect(component.loadingDepthSearch()).toBe(true);
@@ -567,6 +592,7 @@ describe('ReportResultFormComponent', () => {
 
       jest.advanceTimersByTime(500);
       expect(mockApiService.resultsSE.GET_FindResultsElastic).toHaveBeenCalledWith('test title', '');
+      expect(mockApiService.resultsSE.GET_checkTitleUniqueness).toHaveBeenCalledWith('test title');
       jest.useRealTimers();
     });
 
@@ -574,51 +600,56 @@ describe('ReportResultFormComponent', () => {
       jest.useFakeTimers();
       fixture.detectChanges();
       component.allPhases = mockPhases.reporting;
-      const firstRequest$ = new Subject<any[]>();
-      const secondRequest$ = new Subject<any[]>();
+      const firstElastic$ = new Subject<any[]>();
+      const secondElastic$ = new Subject<any[]>();
+      const uniqueness$ = of({ response: { isUnique: true, existing: null } });
 
       mockApiService.resultsSE.GET_FindResultsElastic = jest
         .fn()
-        .mockReturnValueOnce(firstRequest$.asObservable())
-        .mockReturnValueOnce(secondRequest$.asObservable());
+        .mockReturnValueOnce(firstElastic$.asObservable())
+        .mockReturnValueOnce(secondElastic$.asObservable());
+      mockApiService.resultsSE.GET_checkTitleUniqueness = jest.fn(() => uniqueness$);
 
       component.onTitleChange('first title');
       jest.advanceTimersByTime(500);
       component.onTitleChange('second title');
       jest.advanceTimersByTime(500);
 
-      secondRequest$.next([{ id: 2, title: 'second title', version_id: 1 }]);
-      secondRequest$.complete();
-      jest.advanceTimersByTime(700);
+      secondElastic$.next([{ id: 2, title: 'second title', version_id: 1 }]);
+      secondElastic$.complete();
 
       expect(component.exactTitleFound()).toBe(false);
       expect(component.depthSearchList[0]?.title).toBe('second title');
 
-      firstRequest$.next([{ id: 1, title: 'first title', version_id: 1 }]);
-      firstRequest$.complete();
-      jest.advanceTimersByTime(700);
+      firstElastic$.next([{ id: 1, title: 'first title', version_id: 1 }]);
+      firstElastic$.complete();
 
       expect(component.depthSearchList[0]?.title).toBe('second title');
       expect(component.blockingExactTitleFound()).toBe(false);
       jest.useRealTimers();
     });
 
-    it('should clear exact blocking when recheck does not confirm the match', () => {
+    it('should block when MySQL reports title is not unique', () => {
       jest.useFakeTimers();
       fixture.detectChanges();
       component.allPhases = mockPhases.reporting;
 
-      mockApiService.resultsSE.GET_FindResultsElastic = jest
-        .fn()
-        .mockReturnValueOnce(of([{ id: 1, title: 'Exact title', version_id: 1 }]))
-        .mockReturnValueOnce(of([]));
+      mockApiService.resultsSE.GET_FindResultsElastic = jest.fn(() => of([]));
+      mockApiService.resultsSE.GET_checkTitleUniqueness = jest.fn(() =>
+        of({
+          response: {
+            isUnique: false,
+            existing: { id: 1, result_code: 1, title: 'Exact title', version_id: 1 }
+          }
+        })
+      );
 
       component.onTitleChange('Exact title');
       jest.advanceTimersByTime(500);
-      jest.advanceTimersByTime(700);
 
-      expect(component.exactTitleFound()).toBe(false);
-      expect(component.blockingExactTitleFound()).toBe(false);
+      expect(component.exactTitleFound()).toBe(true);
+      expect(component.blockingExactTitleFound()).toBe(true);
+      expect(component.titleCheckFailed()).toBe(false);
       expect(component.loadingDepthSearch()).toBe(false);
       jest.useRealTimers();
     });

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-creator/components/report-result-form/report-result-form.component.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-creator/components/report-result-form/report-result-form.component.ts
@@ -6,7 +6,7 @@ import { ResultBody } from '../../../../../../shared/interfaces/result.interface
 import { PhasesService } from '../../../../../../shared/services/global/phases.service';
 import { TerminologyService } from '../../../../../../internationalization/terminology.service';
 import { EntityAowService } from '../../../../../result-framework-reporting/pages/entity-aow/services/entity-aow.service';
-import { Subject, catchError, debounceTime, distinctUntilChanged, filter, map, of, switchMap, takeUntil, timer } from 'rxjs';
+import { Subject, catchError, debounceTime, distinctUntilChanged, filter, forkJoin, map, of, switchMap, takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-report-result-form',
@@ -18,11 +18,11 @@ export class ReportResultFormComponent implements OnInit, DoCheck, OnDestroy {
   depthSearchList: any[] = [];
   exactTitleFound = signal(false);
   blockingExactTitleFound = signal(false);
+  titleCheckFailed = signal(false);
   loadingDepthSearch = signal(false);
   private readonly titleSearch$ = new Subject<string>();
   private readonly destroy$ = new Subject<void>();
   private readonly titleSearchDebounceMs = 500;
-  private readonly titleRecheckDelayMs = 700;
   mqapJson: {};
   validating = false;
   kpAlertDescription = `Please add the handle generated in <strong>CGSpace</strong>, <strong>MELSpace</strong>, or <strong>WorldFish DSpace</strong> to report your knowledge product. Only knowledge products entered into <strong>one of these repositories</strong> are accepted in the PRMS Reporting Tool.<br><br>
@@ -205,6 +205,7 @@ If you need support to modify any of the harvested metadata from <strong>CGSpace
       this.depthSearchList = [];
       this.exactTitleFound.set(false);
       this.blockingExactTitleFound.set(false);
+      this.titleCheckFailed.set(false);
       this.loadingDepthSearch.set(false);
       return;
     }
@@ -212,15 +213,17 @@ If you need support to modify any of the harvested metadata from <strong>CGSpace
     this.loadingDepthSearch.set(true);
     this.exactTitleFound.set(false);
     this.blockingExactTitleFound.set(false);
+    this.titleCheckFailed.set(false);
     this.titleSearch$.next(title);
   }
 
   depthSearch(title: string) {
     this.loadingDepthSearch.set(true);
-    this.searchResultsWithRecheck(title).subscribe(state => {
+    this.searchResultsWithTitleUniqueness(title).subscribe(state => {
       this.depthSearchList = state.depthSearchList;
       this.exactTitleFound.set(state.exactTitleFound);
       this.blockingExactTitleFound.set(state.blockingExactTitleFound);
+      this.titleCheckFailed.set(state.titleCheckFailed);
       this.loadingDepthSearch.set(false);
     });
   }
@@ -348,59 +351,47 @@ If you need support to modify any of the harvested metadata from <strong>CGSpace
         filter(title => !!title?.trim()),
         debounceTime(this.titleSearchDebounceMs),
         distinctUntilChanged(),
-        switchMap(title => this.searchResultsWithRecheck(title)),
+        switchMap(title => this.searchResultsWithTitleUniqueness(title)),
         takeUntil(this.destroy$)
       )
       .subscribe(state => {
         this.depthSearchList = state.depthSearchList;
         this.exactTitleFound.set(state.exactTitleFound);
         this.blockingExactTitleFound.set(state.blockingExactTitleFound);
+        this.titleCheckFailed.set(state.titleCheckFailed);
         this.loadingDepthSearch.set(false);
       });
   }
 
-  private searchResultsWithRecheck(title: string) {
+  /**
+   * Elastic powers similar-results suggestions; MySQL uniqueness gates create.
+   */
+  private searchResultsWithTitleUniqueness(title: string) {
     const legacyType = this.getLegacyType(this.resultTypeName, this.resultLevelName);
-    return this.api.resultsSE.GET_FindResultsElastic(title, legacyType).pipe(
-      map(response => this.mapDepthSearchResults(response)),
-      switchMap(initialResults => {
-        const hasExactMatch = this.hasExactTitleMatch(initialResults, title);
-        if (!hasExactMatch) {
-          return of({
-            depthSearchList: initialResults,
-            exactTitleFound: false,
-            blockingExactTitleFound: false
-          });
-        }
-
-        // Re-check shortly after an exact match to reduce false positives from stale ES index state.
-        return timer(this.titleRecheckDelayMs).pipe(
-          switchMap(() => this.api.resultsSE.GET_FindResultsElastic(title, legacyType)),
-          map(recheckResponse => {
-            const recheckResults = this.mapDepthSearchResults(recheckResponse);
-            const confirmedExactMatch = this.hasExactTitleMatch(recheckResults, title);
-            return {
-              depthSearchList: recheckResults,
-              exactTitleFound: confirmedExactMatch,
-              blockingExactTitleFound: confirmedExactMatch
-            };
-          }),
-          catchError(() =>
-            of({
-              depthSearchList: initialResults,
-              exactTitleFound: false,
-              blockingExactTitleFound: false
-            })
-          )
-        );
-      }),
-      catchError(() =>
-        of({
-          depthSearchList: [],
-          exactTitleFound: false,
-          blockingExactTitleFound: false
-        })
+    return forkJoin({
+      depthSearchList: this.api.resultsSE.GET_FindResultsElastic(title, legacyType).pipe(
+        map(response => this.mapDepthSearchResults(response)),
+        catchError(() => of([]))
+      ),
+      uniqueness: this.api.resultsSE.GET_checkTitleUniqueness(title).pipe(
+        map(resp => ({
+          isUnique: resp?.response?.isUnique !== false,
+          failed: false
+        })),
+        catchError(() => of({ isUnique: false, failed: true }))
       )
+    }).pipe(
+      map(({ depthSearchList, uniqueness }) => {
+        const titleCheckFailed = uniqueness.failed;
+        const exactTitleFound = !titleCheckFailed && !uniqueness.isUnique;
+        const blockingExactTitleFound = titleCheckFailed || !uniqueness.isUnique;
+        return {
+          depthSearchList,
+          exactTitleFound,
+          blockingExactTitleFound,
+          titleCheckFailed
+        };
+      })
     );
   }
 
@@ -409,11 +400,6 @@ If you need support to modify any of the harvested metadata from <strong>CGSpace
       ...result,
       phase: this.allPhases.find(phase => phase.id === result?.version_id)
     }));
-  }
-
-  private hasExactTitleMatch(results: any[], title: string) {
-    const normalizeTitle = (text: string) => text?.replace(/\s+/g, '')?.toLowerCase();
-    return results.some(result => normalizeTitle(result.title) === normalizeTitle(title));
   }
 
   ngOnDestroy(): void {

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-creator/components/report-result-form/report-result-form.component.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-creator/components/report-result-form/report-result-form.component.ts
@@ -6,7 +6,16 @@ import { ResultBody } from '../../../../../../shared/interfaces/result.interface
 import { PhasesService } from '../../../../../../shared/services/global/phases.service';
 import { TerminologyService } from '../../../../../../internationalization/terminology.service';
 import { EntityAowService } from '../../../../../result-framework-reporting/pages/entity-aow/services/entity-aow.service';
-import { Subject, catchError, debounceTime, distinctUntilChanged, filter, forkJoin, map, of, switchMap, takeUntil } from 'rxjs';
+import { Subject, catchError, debounceTime, distinctUntilChanged, filter, map, merge, of, switchMap, takeUntil } from 'rxjs';
+
+type TitleSearchEvent =
+  | {
+      kind: 'gate';
+      exactTitleFound: boolean;
+      blockingExactTitleFound: boolean;
+      titleCheckFailed: boolean;
+    }
+  | { kind: 'elastic'; depthSearchList: any[] };
 
 @Component({
   selector: 'app-report-result-form',
@@ -219,13 +228,7 @@ If you need support to modify any of the harvested metadata from <strong>CGSpace
 
   depthSearch(title: string) {
     this.loadingDepthSearch.set(true);
-    this.searchResultsWithTitleUniqueness(title).subscribe(state => {
-      this.depthSearchList = state.depthSearchList;
-      this.exactTitleFound.set(state.exactTitleFound);
-      this.blockingExactTitleFound.set(state.blockingExactTitleFound);
-      this.titleCheckFailed.set(state.titleCheckFailed);
-      this.loadingDepthSearch.set(false);
-    });
+    this.searchResultsWithTitleUniqueness(title).subscribe(event => this.applyTitleSearchEvent(event));
   }
 
   getLegacyType(type: string, level: string): string {
@@ -354,45 +357,63 @@ If you need support to modify any of the harvested metadata from <strong>CGSpace
         switchMap(title => this.searchResultsWithTitleUniqueness(title)),
         takeUntil(this.destroy$)
       )
-      .subscribe(state => {
-        this.depthSearchList = state.depthSearchList;
-        this.exactTitleFound.set(state.exactTitleFound);
-        this.blockingExactTitleFound.set(state.blockingExactTitleFound);
-        this.titleCheckFailed.set(state.titleCheckFailed);
-        this.loadingDepthSearch.set(false);
-      });
+      .subscribe(event => this.applyTitleSearchEvent(event));
+  }
+
+  private applyTitleSearchEvent(event: TitleSearchEvent): void {
+    if (event.kind === 'elastic') {
+      this.depthSearchList = event.depthSearchList;
+      return;
+    }
+
+    this.exactTitleFound.set(event.exactTitleFound);
+    this.blockingExactTitleFound.set(event.blockingExactTitleFound);
+    this.titleCheckFailed.set(event.titleCheckFailed);
+    this.loadingDepthSearch.set(false);
   }
 
   /**
    * Elastic powers similar-results suggestions; MySQL uniqueness gates create.
+   * Emits gate and elastic events independently so a slow Elastic response
+   * does not block the uniqueness gate or save button.
    */
   private searchResultsWithTitleUniqueness(title: string) {
     const legacyType = this.getLegacyType(this.resultTypeName, this.resultLevelName);
-    return forkJoin({
-      depthSearchList: this.api.resultsSE.GET_FindResultsElastic(title, legacyType).pipe(
-        map(response => this.mapDepthSearchResults(response)),
-        catchError(() => of([]))
-      ),
-      uniqueness: this.api.resultsSE.GET_checkTitleUniqueness(title).pipe(
-        map(resp => ({
-          isUnique: resp?.response?.isUnique !== false,
-          failed: false
-        })),
-        catchError(() => of({ isUnique: false, failed: true }))
-      )
-    }).pipe(
-      map(({ depthSearchList, uniqueness }) => {
-        const titleCheckFailed = uniqueness.failed;
-        const exactTitleFound = !titleCheckFailed && !uniqueness.isUnique;
-        const blockingExactTitleFound = titleCheckFailed || !uniqueness.isUnique;
+
+    const gate$ = this.api.resultsSE.GET_checkTitleUniqueness(title).pipe(
+      map(resp => {
+        const isUnique = resp?.response?.isUnique !== false;
         return {
-          depthSearchList,
-          exactTitleFound,
-          blockingExactTitleFound,
-          titleCheckFailed
+          kind: 'gate' as const,
+          exactTitleFound: !isUnique,
+          blockingExactTitleFound: !isUnique,
+          titleCheckFailed: false
         };
-      })
+      }),
+      catchError(() =>
+        of({
+          kind: 'gate' as const,
+          exactTitleFound: false,
+          blockingExactTitleFound: true,
+          titleCheckFailed: true
+        })
+      )
     );
+
+    const elastic$ = this.api.resultsSE.GET_FindResultsElastic(title, legacyType).pipe(
+      map(response => ({
+        kind: 'elastic' as const,
+        depthSearchList: this.mapDepthSearchResults(response)
+      })),
+      catchError(() =>
+        of({
+          kind: 'elastic' as const,
+          depthSearchList: []
+        })
+      )
+    );
+
+    return merge(gate$, elastic$);
   }
 
   private mapDepthSearchResults(response: any[]) {

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-creator/result-creator.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-creator/result-creator.component.spec.ts
@@ -312,7 +312,7 @@ describe('ResultCreatorComponent', () => {
       expect(component.exactTitleFound).toBe(true);
     });
 
-    it('should handle Elastic API error and keep uniqueness blocking on uniqueness error', () => {
+    it('should handle uniqueness check error without treating it as a title conflict', () => {
       const title = 'title 1';
       const spy = jest.spyOn(mockApiService.resultsSE, 'GET_FindResultsElastic').mockReturnValue(throwError('API Error'));
       jest
@@ -322,7 +322,8 @@ describe('ResultCreatorComponent', () => {
       component.depthSearch(title);
 
       expect(component.depthSearchList).toEqual([]);
-      expect(component.exactTitleFound).toBe(true);
+      expect(component.exactTitleFound).toBe(false);
+      expect(component.titleCheckFailed).toBe(true);
       expect(spy).toHaveBeenCalled();
     });
   });

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-creator/result-creator.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-creator/result-creator.component.spec.ts
@@ -64,6 +64,7 @@ describe('ResultCreatorComponent', () => {
       resultsSE: {
         GET_AllInitiatives: () => of({ response: myInitiativesList }),
         GET_FindResultsElastic: () => of(mockResponseGET_FindResultsElastic),
+        GET_checkTitleUniqueness: () => of({ response: { isUnique: true, existing: null } }),
         POST_resultCreateHeader: () => of({ response: mockResponsePOST_resultCreateHeader }),
         POST_createWithHandle: () => of({ response: mockResponsePOST_resultCreateHeader }),
         GET_mqapValidation: () => of({ response: { title: 'Title' } }),
@@ -277,6 +278,7 @@ describe('ResultCreatorComponent', () => {
     it('should set depthSearchList and exactTitleFound on successful API response', () => {
       const title = 'title 1';
       const spy = jest.spyOn(mockApiService.resultsSE, 'GET_FindResultsElastic');
+      const uniquenessSpy = jest.spyOn(mockApiService.resultsSE, 'GET_checkTitleUniqueness');
       const mock = [
         {
           id: 1,
@@ -292,17 +294,35 @@ describe('ResultCreatorComponent', () => {
       component.depthSearch(title);
 
       expect(spy).toHaveBeenCalled();
+      expect(uniquenessSpy).toHaveBeenCalledWith(title);
       expect(component.depthSearchList).toEqual(mock);
+      expect(component.exactTitleFound).toBe(false);
     });
 
-    it('should handle API error and reset properties', () => {
+    it('should set exactTitleFound when uniqueness check reports conflict', () => {
+      jest.spyOn(mockApiService.resultsSE, 'GET_checkTitleUniqueness').mockReturnValue(
+        of({
+          response: {
+            isUnique: false,
+            existing: { id: 1, result_code: 1, title: 'title 1', version_id: 1 }
+          }
+        })
+      );
+      component.depthSearch('title 1');
+      expect(component.exactTitleFound).toBe(true);
+    });
+
+    it('should handle Elastic API error and keep uniqueness blocking on uniqueness error', () => {
       const title = 'title 1';
       const spy = jest.spyOn(mockApiService.resultsSE, 'GET_FindResultsElastic').mockReturnValue(throwError('API Error'));
+      jest
+        .spyOn(mockApiService.resultsSE, 'GET_checkTitleUniqueness')
+        .mockReturnValue(throwError('Uniqueness Error'));
 
       component.depthSearch(title);
 
       expect(component.depthSearchList).toEqual([]);
-      expect(component.exactTitleFound).toBe(false);
+      expect(component.exactTitleFound).toBe(true);
       expect(spy).toHaveBeenCalled();
     });
   });

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-creator/result-creator.component.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-creator/result-creator.component.ts
@@ -18,6 +18,7 @@ export class ResultCreatorComponent implements OnInit, DoCheck {
   naratives = internationalizationData.reportNewResult;
   depthSearchList: any[] = [];
   exactTitleFound = false;
+  titleCheckFailed = false;
   mqapJson: {};
   validating = false;
   kpAlertDescription = `Please add the handle generated in your Center's institutional repository (e.g., CGSpace, MELSpace, WorldFish Repository) to report your knowledge product. Only knowledge products entered into these repositories are accepted in the PRMS Reporting Tool.<br><br>
@@ -163,6 +164,7 @@ export class ResultCreatorComponent implements OnInit, DoCheck {
     if (!title?.trim()) {
       this.depthSearchList = [];
       this.exactTitleFound = false;
+      this.titleCheckFailed = false;
       return;
     }
 
@@ -182,11 +184,12 @@ export class ResultCreatorComponent implements OnInit, DoCheck {
 
     this.api.resultsSE.GET_checkTitleUniqueness(title).subscribe({
       next: resp => {
+        this.titleCheckFailed = false;
         this.exactTitleFound = resp?.response?.isUnique === false;
       },
       error: () => {
-        // Do not treat uniqueness check failure as "title free".
-        this.exactTitleFound = true;
+        this.titleCheckFailed = true;
+        this.exactTitleFound = false;
       }
     });
   }

--- a/onecgiar-pr-client/src/app/pages/results/pages/result-creator/result-creator.component.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/result-creator/result-creator.component.ts
@@ -160,7 +160,12 @@ export class ResultCreatorComponent implements OnInit, DoCheck {
   }
 
   depthSearch(title: string) {
-    const cleanSpaces = (text: string) => text?.replace(/\s+/g, '')?.toLowerCase();
+    if (!title?.trim()) {
+      this.depthSearchList = [];
+      this.exactTitleFound = false;
+      return;
+    }
+
     const legacyType = this.getLegacyType(this.resultTypeName, this.resultLevelName);
 
     this.api.resultsSE.GET_FindResultsElastic(title, legacyType).subscribe({
@@ -169,12 +174,19 @@ export class ResultCreatorComponent implements OnInit, DoCheck {
           ...result,
           phase: this.allPhases.find(phase => phase.id === result?.version_id)
         }));
-
-        this.exactTitleFound = !!this.depthSearchList.find(result => cleanSpaces(result.title) === cleanSpaces(title));
       },
       error: () => {
         this.depthSearchList = [];
-        this.exactTitleFound = false;
+      }
+    });
+
+    this.api.resultsSE.GET_checkTitleUniqueness(title).subscribe({
+      next: resp => {
+        this.exactTitleFound = resp?.response?.isUnique === false;
+      },
+      error: () => {
+        // Do not treat uniqueness check failure as "title free".
+        this.exactTitleFound = true;
       }
     });
   }

--- a/onecgiar-pr-client/src/app/shared/services/api/results-api.service.spec.ts
+++ b/onecgiar-pr-client/src/app/shared/services/api/results-api.service.spec.ts
@@ -481,6 +481,41 @@ describe('ResultsApiService', () => {
     });
   });
 
+  describe('GET_checkTitleUniqueness', () => {
+    it('should call check-title-uniqueness with title query param', done => {
+      const title = 'Unique Title';
+      service.GET_checkTitleUniqueness(title).subscribe(response => {
+        expect(response).toEqual(mockResponse);
+        done();
+      });
+
+      const req = httpMock.expectOne(
+        r =>
+          r.url === `${service.apiBaseUrl}check-title-uniqueness` &&
+          r.params.get('title') === title
+      );
+      expect(req.request.method).toBe('GET');
+      expect(req.request.params.get('excludeResultId')).toBeNull();
+      req.flush(mockResponse);
+    });
+
+    it('should include excludeResultId when provided', done => {
+      service.GET_checkTitleUniqueness('Title', 42).subscribe(response => {
+        expect(response).toEqual(mockResponse);
+        done();
+      });
+
+      const req = httpMock.expectOne(
+        r =>
+          r.url === `${service.apiBaseUrl}check-title-uniqueness` &&
+          r.params.get('title') === 'Title' &&
+          r.params.get('excludeResultId') === '42'
+      );
+      expect(req.request.method).toBe('GET');
+      req.flush(mockResponse);
+    });
+  });
+
   describe('GET_ostMeliaStudiesByResultId', () => {
     it('should call GET_ostMeliaStudiesByResultId and return expected data', done => {
       service.GET_ostMeliaStudiesByResultId().subscribe(response => {

--- a/onecgiar-pr-client/src/app/shared/services/api/results-api.service.ts
+++ b/onecgiar-pr-client/src/app/shared/services/api/results-api.service.ts
@@ -77,6 +77,27 @@ export class ResultsApiService {
     return this.http.delete<any>(`${this.baseApiBaseUrl}manage-data/result/${resultIdToDelete}/delete`);
   }
 
+  GET_checkTitleUniqueness(title: string, excludeResultId?: number) {
+    const params: Record<string, string> = { title: title ?? '' };
+    if (excludeResultId !== undefined && excludeResultId !== null) {
+      params['excludeResultId'] = String(excludeResultId);
+    }
+    return this.http.get<{
+      response: {
+        isUnique: boolean;
+        existing?: {
+          id: number;
+          result_code: number;
+          title: string;
+          version_id: number;
+        } | null;
+      };
+      message: string;
+      statusCode?: number;
+      status?: number;
+    }>(`${this.apiBaseUrl}check-title-uniqueness`, { params });
+  }
+
   GET_FindResultsElastic(search?: string, type?: string) {
     const body = {
       size: 20,

--- a/onecgiar-pr-server/src/api/results/result.spec.ts
+++ b/onecgiar-pr-server/src/api/results/result.spec.ts
@@ -2419,4 +2419,65 @@ describe('ResultsService (unit, pure mocks)', () => {
       expect((res as returnFormatService).message).toContain('compatible');
     });
   });
+
+  describe('checkTitleUniqueness', () => {
+    it('returns isUnique true for empty title', async () => {
+      (mockResultRepository.findOne as jest.Mock).mockClear();
+      const res = await resultService.checkTitleUniqueness('   ');
+      expect((res as returnFormatService).status).toBe(HttpStatus.OK);
+      expect((res as returnFormatService).response).toEqual({
+        isUnique: true,
+        existing: null,
+      });
+      expect(mockResultRepository.findOne).not.toHaveBeenCalled();
+    });
+
+    it('returns isUnique true when no active result matches', async () => {
+      (mockResultRepository.findOne as jest.Mock).mockResolvedValueOnce(null);
+      const res = await resultService.checkTitleUniqueness('Brand new title');
+      expect((res as returnFormatService).status).toBe(HttpStatus.OK);
+      expect((res as returnFormatService).response.isUnique).toBe(true);
+      expect((res as returnFormatService).response.existing).toBeNull();
+    });
+
+    it('returns isUnique false with existing when title conflicts', async () => {
+      (mockResultRepository.findOne as jest.Mock).mockResolvedValueOnce({
+        id: 11115,
+        result_code: 999,
+        title: 'Existing Title',
+        version_id: 1,
+      });
+      const res = await resultService.checkTitleUniqueness('Existing Title');
+      expect((res as returnFormatService).status).toBe(HttpStatus.OK);
+      expect((res as returnFormatService).response).toEqual({
+        isUnique: false,
+        existing: {
+          id: 11115,
+          result_code: 999,
+          title: 'Existing Title',
+          version_id: 1,
+        },
+      });
+    });
+
+    it('returns isUnique true when conflict is the excluded result', async () => {
+      (mockResultRepository.findOne as jest.Mock).mockResolvedValueOnce({
+        id: 50,
+        result_code: 10,
+        title: 'Same Title',
+        version_id: 1,
+      });
+      const res = await resultService.checkTitleUniqueness('Same Title', 50);
+      expect((res as returnFormatService).status).toBe(HttpStatus.OK);
+      expect((res as returnFormatService).response.isUnique).toBe(true);
+    });
+
+    it('returns error when active phase is missing', async () => {
+      (
+        mockVersioningService.$_findActivePhase as jest.Mock
+      ).mockResolvedValueOnce(null);
+      const res = await resultService.checkTitleUniqueness('Any');
+      expect((res as returnFormatService).status).toBeGreaterThanOrEqual(400);
+    });
+  });
 });

--- a/onecgiar-pr-server/src/api/results/results.controller.spec.ts
+++ b/onecgiar-pr-server/src/api/results/results.controller.spec.ts
@@ -146,6 +146,28 @@ describe('ResultsController', () => {
     expect(mockService.findAllResultsLegacyNew).toHaveBeenCalledWith('abc');
   });
 
+  it('checkTitleUniqueness delegates to service with optional excludeResultId', async () => {
+    (mockService as any).checkTitleUniqueness = jest
+      .fn()
+      .mockResolvedValue({ status: 200, response: { isUnique: true } });
+    await controller.checkTitleUniqueness('My Title', '42');
+    expect((mockService as any).checkTitleUniqueness).toHaveBeenCalledWith(
+      'My Title',
+      42,
+    );
+  });
+
+  it('checkTitleUniqueness omits exclude when not a finite number', async () => {
+    (mockService as any).checkTitleUniqueness = jest
+      .fn()
+      .mockResolvedValue({ status: 200, response: { isUnique: true } });
+    await controller.checkTitleUniqueness('My Title', 'abc');
+    expect((mockService as any).checkTitleUniqueness).toHaveBeenCalledWith(
+      'My Title',
+      undefined,
+    );
+  });
+
   it('getInstitutions delegates to service', async () => {
     const res = await controller.getInstitutions();
     expect(mockService.getAllInstitutions).toHaveBeenCalled();

--- a/onecgiar-pr-server/src/api/results/results.controller.ts
+++ b/onecgiar-pr-server/src/api/results/results.controller.ts
@@ -311,6 +311,38 @@ export class ResultsController {
     );
   }
 
+  @Get('check-title-uniqueness')
+  @ApiOperation({
+    summary: 'Check result title uniqueness',
+    description:
+      'Validates whether an exact trimmed title is free among active results in the current reporting phase (MySQL). Optional excludeResultId ignores the current result when editing.',
+  })
+  @ApiQuery({ name: 'title', type: String, required: true })
+  @ApiQuery({
+    name: 'excludeResultId',
+    type: Number,
+    required: false,
+    description: 'Result id to exclude (e.g. when updating an existing result)',
+  })
+  @ApiOkResponse({
+    description:
+      'Uniqueness check completed. response.isUnique is true when no conflicting active result exists.',
+  })
+  checkTitleUniqueness(
+    @Query('title') title: string,
+    @Query('excludeResultId') excludeResultId?: string,
+  ) {
+    const parsedExclude =
+      excludeResultId !== undefined && excludeResultId !== null
+        ? Number(excludeResultId)
+        : undefined;
+    const normalizedExclude =
+      typeof parsedExclude === 'number' && Number.isFinite(parsedExclude)
+        ? parsedExclude
+        : undefined;
+    return this.resultsService.checkTitleUniqueness(title, normalizedExclude);
+  }
+
   @Get('get/depth-search/:title')
   @ApiOperation({
     summary: 'Perform deep result search',

--- a/onecgiar-pr-server/src/api/results/results.service.ts
+++ b/onecgiar-pr-server/src/api/results/results.service.ts
@@ -27,6 +27,7 @@ import {
 import { ResultTypesService } from './result_types/result_types.service';
 import { ResultType } from './result_types/entities/result_type.entity';
 import { returnFormatResult } from './dto/return-format-result.dto';
+import { returnFormatService } from '../../shared/extendsGlobalDTO/returnServices.dto';
 import {
   ScienceProgramProgressDto,
   ScienceProgramProgressResponseDto,
@@ -218,6 +219,30 @@ export class ResultsService {
   ) {}
 
   /**
+   * Exact title lookup among active results in a reporting version (MySQL source of truth).
+   */
+  private async findActiveResultByExactTitle(
+    trimmedTitle: string,
+    versionId: number,
+  ): Promise<Pick<
+    Result,
+    'id' | 'result_code' | 'title' | 'version_id'
+  > | null> {
+    if (!trimmedTitle) {
+      return null;
+    }
+    const existing = await this._resultRepository.findOne({
+      where: {
+        title: trimmedTitle,
+        is_active: true,
+        version_id: versionId,
+      },
+      select: ['id', 'result_code', 'title', 'version_id'],
+    });
+    return existing ?? null;
+  }
+
+  /**
    * Blocks duplicate titles among active results within the same reporting version.
    * The same title may exist on another version (same result_code lineage, different id).
    * When updating general information, pass excludeResultId so the row can keep its title.
@@ -231,13 +256,10 @@ export class ResultsService {
     if (!trimmed) {
       return '';
     }
-    const existing = await this._resultRepository.findOne({
-      where: {
-        title: trimmed,
-        is_active: true,
-        version_id: versionId,
-      },
-    });
+    const existing = await this.findActiveResultByExactTitle(
+      trimmed,
+      versionId,
+    );
     if (
       existing?.id &&
       (excludeResultId === undefined || existing.id !== excludeResultId)
@@ -249,6 +271,65 @@ export class ResultsService {
       };
     }
     return trimmed;
+  }
+
+  /**
+   * Lightweight uniqueness check for the result creator UI.
+   * Uses the same MySQL criteria as assertUniqueActiveResultTitle / create.
+   */
+  async checkTitleUniqueness(
+    title: string,
+    excludeResultId?: number,
+  ): Promise<returnFormatService | returnErrorDto> {
+    try {
+      const version = await this._versioningService.$_findActivePhase(
+        AppModuleIdEnum.REPORTING,
+      );
+      if (!version) {
+        throw this._handlersError.returnErrorRes({
+          error: version,
+          debug: true,
+        });
+      }
+
+      const trimmed = (title ?? '').trim();
+      if (!trimmed) {
+        return {
+          response: { isUnique: true, existing: null },
+          message: 'Empty title is treated as unique',
+          status: HttpStatus.OK,
+        };
+      }
+
+      const existing = await this.findActiveResultByExactTitle(
+        trimmed,
+        version.id,
+      );
+      const conflicts = Boolean(
+        existing?.id &&
+          (excludeResultId === undefined || existing.id !== excludeResultId),
+      );
+
+      return {
+        response: {
+          isUnique: !conflicts,
+          existing: conflicts
+            ? {
+                id: existing.id,
+                result_code: existing.result_code,
+                title: existing.title,
+                version_id: existing.version_id,
+              }
+            : null,
+        },
+        message: conflicts
+          ? 'A result with this title already exists.'
+          : 'Title is unique for the active reporting phase.',
+        status: HttpStatus.OK,
+      };
+    } catch (error) {
+      return this._handlersError.returnErrorRes({ error, debug: true });
+    }
   }
 
   async createOwnerResult(

--- a/onecgiar-pr-server/src/elastic/elastic.service.spec.ts
+++ b/onecgiar-pr-server/src/elastic/elastic.service.spec.ts
@@ -1,0 +1,48 @@
+import { HttpStatus } from '@nestjs/common';
+import { of, throwError } from 'rxjs';
+import { ElasticService } from './elastic.service';
+
+describe('ElasticService', () => {
+  const mockHttp = {
+    post: jest.fn(),
+  };
+  const mockHandlersError = {
+    returnErrorRes: jest.fn().mockReturnValue({
+      response: { error: true },
+      message: 'INTERNAL_SERVER_ERROR',
+      status: HttpStatus.INTERNAL_SERVER_ERROR,
+    }),
+  };
+  const mockResultRepository = {} as any;
+
+  let service: ElasticService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ElasticService(
+      mockHttp as any,
+      mockHandlersError as any,
+      mockResultRepository,
+    );
+  });
+
+  describe('sendBulkOperationToElastic', () => {
+    it('returns OK when all bulk posts succeed', async () => {
+      mockHttp.post.mockReturnValue(of({ data: { errors: false } }));
+      const res = await service.sendBulkOperationToElastic(['op1', 'op2']);
+      expect(res.status).toBe(HttpStatus.OK);
+      expect(res.response).toBe(2);
+      expect(mockHttp.post).toHaveBeenCalledTimes(2);
+    });
+
+    it('logs via HandlersError and rethrows on failure', async () => {
+      const failure = { response: { data: { error: 'bulk failed' } } };
+      mockHttp.post.mockReturnValue(throwError(() => failure));
+
+      await expect(service.sendBulkOperationToElastic(['op1'])).rejects.toEqual(
+        failure,
+      );
+      expect(mockHandlersError.returnErrorRes).toHaveBeenCalled();
+    });
+  });
+});

--- a/onecgiar-pr-server/src/elastic/elastic.service.ts
+++ b/onecgiar-pr-server/src/elastic/elastic.service.ts
@@ -152,10 +152,13 @@ export class ElasticService {
         status: HttpStatus.OK,
       };
     } catch (error) {
-      return this._handlersError.returnErrorRes({
-        error: error.response?.data,
+      // Log via HandlersError, then rethrow so callers' try/catch can warn
+      // without treating a soft error DTO as success.
+      this._handlersError.returnErrorRes({
+        error: error?.response?.data ?? error,
         debug: true,
       });
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Release summary
Promotes **P2-3178** from `staging` to `master` (production). It is the only change ahead of master (P2-3175 already shipped in #729).

## What was done
- Fixes **inconsistent duplicate-title validation** when creating a result: the screen now checks title uniqueness against the **same MySQL source of truth** the server uses on create (instead of a possibly-stale Elasticsearch copy).
- The **Save button is no longer blocked** while the Elastic search completes.

## Why
- The create screen used to query Elasticsearch while the server validated against MySQL, so the UI could show a title as free (green) and then reject it on save — a contradiction reported in QA.

## Scope
- **Backend (NestJS):** `results.controller.ts`, `results.service.ts`, `elastic.service.ts` (+ specs).
- **Client (Angular):** result-creator title validation (+ specs).

## How to verify in production
1. Create a result with an existing title → correctly flagged as duplicate.
2. Create a result with a new title → allowed.
3. Save button not blocked while the search runs.

## QA & checks
- ✅ QA approved by María Camila Giraldo (prtest) → moved to `To Be Deployed`.
- ✅ SonarCloud Quality Gate passed (1.2% duplication on new code comes from unit tests, well under the 3% gate — documented in #730).

## Author / review
- Fix authored by **Juan David Delgado (@JuanGuzman-io)**; PR opened by the reporting team at his request. @JuanGuzman-io to validate.

## Technical references
- Jira: P2-3178
- Commits: `381e948b8`, `1004a5176` (via #730 into staging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)