### PR TITLE
✨ feat(results-list) P2-3203: enable opening results in a new tab from the Results Center

### DIFF
--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/bilateral-results/bilateral-results.service.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/bilateral-results/bilateral-results.service.ts
@@ -3,6 +3,16 @@ import { CenterDto } from '../../../../shared/interfaces/center.dto';
 import { ApiService } from '../../../../shared/services/api/api.service';
 import { ResultToReview, GroupedResult } from './components/results-review-table/components/result-review-drawer/result-review-drawer.interfaces';
 
+/** Query param that deep-links a result's review drawer on the results-review screen. */
+export const REVIEW_RESULT_QUERY_PARAM = 'reviewResult';
+
+/**
+ * Result id that goes with REVIEW_RESULT_QUERY_PARAM. Needed because a deep-linked
+ * result may not be part of the review list (e.g. drafts still being edited), and the
+ * drawer loads its detail by id.
+ */
+export const REVIEW_RESULT_ID_QUERY_PARAM = 'reviewResultId';
+
 @Injectable({
   providedIn: 'root'
 })

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/bilateral-results/components/results-review-table/results-review-table.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/bilateral-results/components/results-review-table/results-review-table.component.spec.ts
@@ -1,24 +1,124 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
 import { ResultsReviewTableComponent } from './results-review-table.component';
+import { BilateralResultsService, REVIEW_RESULT_ID_QUERY_PARAM, REVIEW_RESULT_QUERY_PARAM } from '../../bilateral-results.service';
+import { ResultToReview } from './components/result-review-drawer/result-review-drawer.interfaces';
 
 describe('ResultsReviewTableComponent', () => {
   let component: ResultsReviewTableComponent;
   let fixture: ComponentFixture<ResultsReviewTableComponent>;
+  let bilateralResultsService: BilateralResultsService;
+  let navigateMock: jest.Mock;
 
-  beforeEach(async () => {
+  const buildResult = (result_code: string): ResultToReview =>
+    ({
+      id: `id-${result_code}`,
+      project_id: 'p1',
+      project_name: 'Project 1',
+      result_code,
+      result_title: `Result ${result_code}`,
+      indicator_category: 'Innovation development',
+      status_name: 'Submitted',
+      acronym: 'ACR',
+      toc_title: 'ToC',
+      indicator: 'Indicator',
+      submission_date: '2026-07-28'
+    }) as ResultToReview;
+
+  const setup = async (queryParams: Record<string, string> = {}) => {
+    TestBed.resetTestingModule();
+    navigateMock = jest.fn().mockResolvedValue(true);
+
     await TestBed.configureTestingModule({
-      imports: [ResultsReviewTableComponent, HttpClientTestingModule, NoopAnimationsModule]
-    })
-    .compileComponents();
+      imports: [ResultsReviewTableComponent, HttpClientTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: convertToParamMap(queryParams) } } },
+        { provide: Router, useValue: { navigate: navigateMock } }
+      ]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ResultsReviewTableComponent);
     component = fixture.componentInstance;
+    bilateralResultsService = TestBed.inject(BilateralResultsService);
+    bilateralResultsService.showReviewDrawer.set(false);
+    bilateralResultsService.currentResultToReview.set(null);
+    bilateralResultsService.tableResults.set([]);
     fixture.detectChanges();
+  };
+
+  it('should create', async () => {
+    await setup();
+    expect(component).toBeTruthy();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('deep-linked review result', () => {
+    it('should open the review drawer for the result referenced in the query param once results load', async () => {
+      await setup({ [REVIEW_RESULT_QUERY_PARAM]: 'R-123' });
+
+      expect(bilateralResultsService.showReviewDrawer()).toBe(false);
+
+      bilateralResultsService.tableResults.set([buildResult('R-999'), buildResult('R-123')]);
+      fixture.detectChanges();
+
+      expect(bilateralResultsService.showReviewDrawer()).toBe(true);
+      expect(bilateralResultsService.currentResultToReview()?.result_code).toBe('R-123');
+    });
+
+    it('should clear the query param after opening the drawer', async () => {
+      await setup({ [REVIEW_RESULT_QUERY_PARAM]: 'R-123' });
+
+      bilateralResultsService.tableResults.set([buildResult('R-123')]);
+      fixture.detectChanges();
+
+      expect(navigateMock).toHaveBeenCalledWith(
+        [],
+        expect.objectContaining({
+          queryParams: { [REVIEW_RESULT_QUERY_PARAM]: null, [REVIEW_RESULT_ID_QUERY_PARAM]: null },
+          queryParamsHandling: 'merge',
+          replaceUrl: true
+        })
+      );
+    });
+
+    it('should not open the drawer when the referenced result is not in the loaded list and no id is given', async () => {
+      await setup({ [REVIEW_RESULT_QUERY_PARAM]: 'R-404' });
+
+      bilateralResultsService.tableResults.set([buildResult('R-123')]);
+      fixture.detectChanges();
+
+      expect(bilateralResultsService.showReviewDrawer()).toBe(false);
+      expect(bilateralResultsService.currentResultToReview()).toBeNull();
+    });
+
+    it('should fall back to the id when the result is not in the review list (drafts being edited)', async () => {
+      await setup({ [REVIEW_RESULT_QUERY_PARAM]: 'R-404', [REVIEW_RESULT_ID_QUERY_PARAM]: '99' });
+
+      bilateralResultsService.tableResults.set([buildResult('R-123')]);
+      fixture.detectChanges();
+
+      expect(bilateralResultsService.showReviewDrawer()).toBe(true);
+      expect(bilateralResultsService.currentResultToReview()).toEqual({ id: '99', result_code: 'R-404' });
+    });
+
+    it('should prefer the object from the list over the id fallback', async () => {
+      await setup({ [REVIEW_RESULT_QUERY_PARAM]: 'R-123', [REVIEW_RESULT_ID_QUERY_PARAM]: '99' });
+
+      bilateralResultsService.tableResults.set([buildResult('R-123')]);
+      fixture.detectChanges();
+
+      expect(bilateralResultsService.currentResultToReview()?.id).toBe('id-R-123');
+    });
+
+    it('should do nothing when there is no query param', async () => {
+      await setup();
+
+      bilateralResultsService.tableResults.set([buildResult('R-123')]);
+      fixture.detectChanges();
+
+      expect(bilateralResultsService.showReviewDrawer()).toBe(false);
+      expect(navigateMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/bilateral-results/components/results-review-table/results-review-table.component.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/bilateral-results/components/results-review-table/results-review-table.component.ts
@@ -5,8 +5,9 @@ import { ButtonModule } from 'primeng/button';
 import { TooltipModule } from 'primeng/tooltip';
 import { ResultReviewDrawerComponent } from './components/result-review-drawer/result-review-drawer.component';
 import { ResultToReview, GroupedResult } from './components/result-review-drawer/result-review-drawer.interfaces';
+import { ActivatedRoute, Router } from '@angular/router';
 import { ApiService } from '../../../../../../shared/services/api/api.service';
-import { BilateralResultsService } from '../../bilateral-results.service';
+import { BilateralResultsService, REVIEW_RESULT_ID_QUERY_PARAM, REVIEW_RESULT_QUERY_PARAM } from '../../bilateral-results.service';
 
 @Component({
   selector: 'app-results-review-table',
@@ -17,6 +18,13 @@ import { BilateralResultsService } from '../../bilateral-results.service';
 export class ResultsReviewTableComponent implements OnDestroy {
   api = inject(ApiService);
   bilateralResultsService = inject(BilateralResultsService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+
+  /** Result code deep-linked through the URL, consumed once the results are loaded. */
+  private pendingReviewResultCode: string | null = this.route.snapshot.queryParamMap.get(REVIEW_RESULT_QUERY_PARAM);
+  /** Id of that same result, used when it is not part of the review list (e.g. drafts). */
+  private readonly pendingReviewResultId: string | null = this.route.snapshot.queryParamMap.get(REVIEW_RESULT_ID_QUERY_PARAM);
 
   canReviewResults = computed(() => {
     if (this.api.rolesSE.isAdmin) {
@@ -100,6 +108,38 @@ export class ResultsReviewTableComponent implements OnDestroy {
     });
     return expanded;
   });
+
+  /**
+   * Abre el drawer del resultado enlazado por URL (?reviewResult=CODE) en cuanto
+   * la tabla termina de cargar, para que el deep link funcione en una pestaña nueva.
+   */
+  openDeepLinkedResult = effect(() => {
+    const results = this.bilateralResultsService.tableResults();
+    if (!this.pendingReviewResultCode || results.length === 0) return;
+
+    const code = this.pendingReviewResultCode;
+    this.pendingReviewResultCode = null;
+
+    // Prefer the object from the list (it is complete). Results that are not part of the
+    // review list — drafts still being edited — fall back to a minimal object built from
+    // the id, which is all the drawer needs to load its detail.
+    const match = results.find(result => String(result.result_code) === String(code));
+    const target = match ?? (this.pendingReviewResultId ? ({ id: this.pendingReviewResultId, result_code: code } as ResultToReview) : null);
+
+    if (target) {
+      this.reviewResult(target);
+    }
+    this.clearReviewResultParam();
+  });
+
+  private clearReviewResultParam(): void {
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { [REVIEW_RESULT_QUERY_PARAM]: null, [REVIEW_RESULT_ID_QUERY_PARAM]: null },
+      queryParamsHandling: 'merge',
+      replaceUrl: true
+    });
+  }
 
   // Acción del botón para abrir el drawer de review
   reviewResult(result: ResultToReview): void {

--- a/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/results-list.component.html
+++ b/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/results-list.component.html
@@ -83,7 +83,11 @@
               [style.min-width]="column.width"
               style="cursor: pointer">
               @for (subResult of result['results']; track subResult) {
-                <a [class]="column.class" (click)="navigateToResult(subResult)">
+                <a
+                  [class]="column.class"
+                  [routerLink]="getResultLink(subResult)"
+                  [queryParams]="getResultQueryParams(subResult)"
+                  (click)="onResultLinkClick($event, subResult)">
                   @if (i == 1) {
                     @if (subResult.is_new && !subResult.legacy_id) {
                       <div class="new_tag">New</div>

--- a/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/results-list.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/results-list.component.spec.ts
@@ -489,7 +489,7 @@ describe('ResultsListComponent', () => {
     });
 
     it('should call navigateToResult on items[2] command', () => {
-      const spy = jest.spyOn(component, 'navigateToResult');
+      const spy = jest.spyOn(component, 'navigateToResult').mockImplementation();
       mockApiService.dataControlSE.currentResult = { id: '1', title: 'Test' };
 
       component.items[2].command();
@@ -498,7 +498,7 @@ describe('ResultsListComponent', () => {
     });
 
     it('should call navigateToResult on itemsWithDelete[2] command', () => {
-      const spy = jest.spyOn(component, 'navigateToResult');
+      const spy = jest.spyOn(component, 'navigateToResult').mockImplementation();
       mockApiService.dataControlSE.currentResult = { id: '1', title: 'Test' };
 
       component.itemsWithDelete[2].command();
@@ -872,9 +872,79 @@ describe('ResultsListComponent', () => {
     });
   });
 
+  describe('getResultLink() / getResultQueryParams()', () => {
+    it('should link a W3/Bilaterals AVISA result to its result detail', () => {
+      const result = { source_name: 'W3/Bilaterals', submitter: 'SGP-02', result_code: 'R-1', version_id: 10 } as any;
+
+      expect(component.getResultLink(result)).toEqual(['/result', 'result-detail', 'R-1', 'general-information']);
+      expect(component.getResultQueryParams(result)).toEqual({ phase: 10 });
+    });
+
+    it('should link an approved W3/Bilaterals result to its result detail', () => {
+      const result = { source_name: 'W3/Bilaterals', submitter: 'OTHER', status_name: 'Approved', result_code: 'R-4', version_id: 11 } as any;
+
+      expect(component.getResultLink(result)).toEqual(['/result', 'result-detail', 'R-4', 'general-information']);
+      expect(component.getResultQueryParams(result)).toEqual({ phase: 11 });
+    });
+
+    it('should link a non-W3/Bilaterals result to its result detail', () => {
+      const result = { source_name: 'Initiative', result_code: 'R-3', version_id: 10 } as any;
+
+      expect(component.getResultLink(result)).toEqual(['/result', 'result-detail', 'R-3', 'general-information']);
+      expect(component.getResultQueryParams(result)).toEqual({ phase: 10 });
+    });
+
+    it('should link a W3/Bilaterals result pending review to the results-review screen carrying its code', () => {
+      const result = { source_name: 'W3/Bilaterals', submitter: 'OTHER', result_code: 'R-2', version_id: 10, id: 'id-2' } as any;
+
+      expect(component.getResultLink(result)).toEqual(['/result-framework-reporting', 'entity-details', 'OTHER', 'results-review']);
+      expect(component.getResultQueryParams(result)).toEqual({ reviewResult: 'R-2', reviewResultId: 'id-2' });
+    });
+
+    it('should return the same object identity for the same result (cached for routerLink)', () => {
+      const result = { source_name: 'Initiative', result_code: 'R-3', version_id: 10 } as any;
+
+      expect(component.getResultLink(result)).toBe(component.getResultLink(result));
+      expect(component.getResultQueryParams(result)).toBe(component.getResultQueryParams(result));
+    });
+  });
+
+  describe('onResultLinkClick()', () => {
+    const bilateralResult = { source_name: 'W3/Bilaterals', submitter: 'OTHER', result_code: 'R-2', version_id: 10, id: 'id-2' } as any;
+
+    beforeEach(() => {
+      component.bilateralResultsService.currentResultToReview.set(null);
+      component.bilateralResultsService.showReviewDrawer.set(false);
+    });
+
+    it('should preload the review drawer state on a plain left click', () => {
+      component.onResultLinkClick({ button: 0 } as MouseEvent, bilateralResult);
+
+      expect(component.bilateralResultsService.currentResultToReview()).toBe(bilateralResult);
+      expect(component.bilateralResultsService.showReviewDrawer()).toBe(true);
+    });
+
+    it('should do nothing when the click opens a new tab (ctrl/cmd/shift/middle)', () => {
+      component.onResultLinkClick({ button: 0, ctrlKey: true } as MouseEvent, bilateralResult);
+      component.onResultLinkClick({ button: 0, metaKey: true } as MouseEvent, bilateralResult);
+      component.onResultLinkClick({ button: 0, shiftKey: true } as MouseEvent, bilateralResult);
+      component.onResultLinkClick({ button: 1 } as MouseEvent, bilateralResult);
+
+      expect(component.bilateralResultsService.currentResultToReview()).toBeNull();
+      expect(component.bilateralResultsService.showReviewDrawer()).toBe(false);
+    });
+
+    it('should do nothing for results that do not use the bilateral review flow', () => {
+      component.onResultLinkClick({ button: 0 } as MouseEvent, { source_name: 'Initiative', result_code: 'R-3', version_id: 10 } as any);
+
+      expect(component.bilateralResultsService.currentResultToReview()).toBeNull();
+      expect(component.bilateralResultsService.showReviewDrawer()).toBe(false);
+    });
+  });
+
   describe('navigateToResult()', () => {
     it('should navigate to result detail for W3/Bilaterals AVISA result', () => {
-      const navigateSpy = jest.spyOn(component.router, 'navigateByUrl').mockResolvedValue(true);
+      const navigateSpy = jest.spyOn(component.router, 'navigate').mockResolvedValue(true);
       const result = {
         source_name: 'W3/Bilaterals',
         submitter: 'SGP-02',
@@ -884,25 +954,28 @@ describe('ResultsListComponent', () => {
 
       component.navigateToResult(result);
 
-      expect(navigateSpy).toHaveBeenCalledWith('/result/result-detail/R-1/general-information?phase=10');
+      expect(navigateSpy).toHaveBeenCalledWith(['/result', 'result-detail', 'R-1', 'general-information'], { queryParams: { phase: 10 } });
     });
 
     it('should navigate to entity-details for W3/Bilaterals non-AVISA result', () => {
-      const navigateSpy = jest.spyOn(component.router, 'navigateByUrl').mockResolvedValue(true);
+      const navigateSpy = jest.spyOn(component.router, 'navigate').mockResolvedValue(true);
       const result = {
         source_name: 'W3/Bilaterals',
         submitter: 'OTHER',
         result_code: 'R-2',
-        version_id: 10
+        version_id: 10,
+        id: 'id-2'
       } as any;
 
       component.navigateToResult(result);
 
-      expect(navigateSpy).toHaveBeenCalledWith('/result-framework-reporting/entity-details/OTHER/results-review');
+      expect(navigateSpy).toHaveBeenCalledWith(['/result-framework-reporting', 'entity-details', 'OTHER', 'results-review'], {
+        queryParams: { reviewResult: 'R-2', reviewResultId: 'id-2' }
+      });
     });
 
     it('should navigate to result detail for non-W3/Bilaterals result', () => {
-      const navigateSpy = jest.spyOn(component.router, 'navigateByUrl').mockResolvedValue(true);
+      const navigateSpy = jest.spyOn(component.router, 'navigate').mockResolvedValue(true);
       const result = {
         source_name: 'Initiative',
         result_code: 'R-3',
@@ -911,11 +984,11 @@ describe('ResultsListComponent', () => {
 
       component.navigateToResult(result);
 
-      expect(navigateSpy).toHaveBeenCalledWith('/result/result-detail/R-3/general-information?phase=10');
+      expect(navigateSpy).toHaveBeenCalledWith(['/result', 'result-detail', 'R-3', 'general-information'], { queryParams: { phase: 10 } });
     });
 
     it('should set currentResultToReview and show review drawer for W3/Bilaterals non-AVISA', async () => {
-      jest.spyOn(component.router, 'navigateByUrl').mockResolvedValue(true);
+      jest.spyOn(component.router, 'navigate').mockResolvedValue(true);
       const result = {
         source_name: 'W3/Bilaterals',
         submitter: 'OTHER',

--- a/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/results-list.component.ts
+++ b/onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/results-list.component.ts
@@ -10,7 +10,16 @@ import { Table } from 'primeng/table';
 import { ResultsNotificationsService } from '../results-notifications/results-notifications.service';
 import { ResultsListFilterService } from './services/results-list-filter.service';
 import { Router } from '@angular/router';
-import { BilateralResultsService } from '../../../../../result-framework-reporting/pages/bilateral-results/bilateral-results.service';
+import {
+  BilateralResultsService,
+  REVIEW_RESULT_ID_QUERY_PARAM,
+  REVIEW_RESULT_QUERY_PARAM
+} from '../../../../../result-framework-reporting/pages/bilateral-results/bilateral-results.service';
+
+interface ResultRoute {
+  commands: unknown[];
+  queryParams: Record<string, unknown>;
+}
 
 interface ItemMenu {
   label: string;
@@ -32,6 +41,8 @@ interface ItemMenu {
 export class ResultsListComponent implements OnInit, AfterViewInit, OnDestroy {
   router = inject(Router);
   bilateralResultsService = inject(BilateralResultsService);
+
+  private readonly resultRouteCache = new Map<string, ResultRoute>();
 
   private readonly selectedPhaseIds = computed(() =>
     this.resultsListFilterSE
@@ -364,24 +375,75 @@ export class ResultsListComponent implements OnInit, AfterViewInit, OnDestroy {
     );
   }
 
-  navigateToResult(result: CurrentResult) {
-    if (this.isW3BilateralsAvisa(result) || result?.status_name === 'Approved') {
-      const url = '/result/result-detail/' + result.result_code + '/general-information?phase=' + result.version_id;
-      this.router.navigateByUrl(url);
-      return;
-    }
+  /**
+   * True when the result must be opened in the bilateral review drawer
+   * instead of the regular result detail page.
+   */
+  private usesBilateralReviewFlow(result: CurrentResult): boolean {
+    if (this.isW3BilateralsAvisa(result) || result?.status_name === 'Approved') return false;
+    return result?.source_name === 'W3/Bilaterals';
+  }
 
-    if (result?.source_name == 'W3/Bilaterals') {
-      const url = '/result-framework-reporting/entity-details/' + result.submitter + '/results-review';
+  /**
+   * Router commands and query params for a result, cached per result so the
+   * template keeps handing routerLink the same object identity on each change
+   * detection run.
+   */
+  private getResultRoute(result: CurrentResult): ResultRoute {
+    const key = [result?.result_code, result?.version_id, result?.status_name, result?.source_name, result?.submitter].join('|');
+    const cached = this.resultRouteCache.get(key);
+    if (cached) return cached;
+
+    const route: ResultRoute = this.usesBilateralReviewFlow(result)
+      ? {
+          commands: ['/result-framework-reporting', 'entity-details', result?.submitter, 'results-review'],
+          queryParams: { [REVIEW_RESULT_QUERY_PARAM]: result?.result_code, [REVIEW_RESULT_ID_QUERY_PARAM]: result?.id }
+        }
+      : {
+          commands: ['/result', 'result-detail', result?.result_code, 'general-information'],
+          queryParams: { phase: result?.version_id }
+        };
+
+    this.resultRouteCache.set(key, route);
+    return route;
+  }
+
+  /** Router commands for the result row link (renders a real href). */
+  getResultLink(result: CurrentResult): unknown[] {
+    return this.getResultRoute(result).commands;
+  }
+
+  /** Query params for the result row link. */
+  getResultQueryParams(result: CurrentResult): Record<string, unknown> {
+    return this.getResultRoute(result).queryParams;
+  }
+
+  /**
+   * Plain left click on a row link: routerLink handles the navigation, this only
+   * preloads the review drawer state, exactly as the previous (click) handler did.
+   * Modified clicks (ctrl/cmd/shift/alt) open a new tab, so they must not touch state.
+   */
+  onResultLinkClick(event: MouseEvent, result: CurrentResult): void {
+    if (event.ctrlKey || event.metaKey || event.shiftKey || event.altKey || event.button !== 0) return;
+    if (!this.usesBilateralReviewFlow(result)) return;
+
+    this.bilateralResultsService.currentResultToReview.set(result);
+    this.bilateralResultsService.showReviewDrawer.set(true);
+  }
+
+  navigateToResult(result: CurrentResult) {
+    const { commands, queryParams } = this.getResultRoute(result);
+
+    if (this.usesBilateralReviewFlow(result)) {
       this.bilateralResultsService.currentResultToReview.set(result);
 
-      this.router.navigateByUrl(url).then(() => {
+      this.router.navigate(commands, { queryParams }).then(() => {
         this.bilateralResultsService.showReviewDrawer.set(true);
       });
       return;
     }
-    const url = '/result/result-detail/' + result.result_code + '/general-information?phase=' + result.version_id;
-    this.router.navigateByUrl(url);
+
+    this.router.navigate(commands, { queryParams });
   }
 
   ngOnDestroy(): void {

--- a/openspec/changes/results-center-open-in-new-tab/.openspec.yaml
+++ b/openspec/changes/results-center-open-in-new-tab/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/results-center-open-in-new-tab/design.md
+++ b/openspec/changes/results-center-open-in-new-tab/design.md
@@ -1,0 +1,111 @@
+## Context
+
+The Results Center table (`results-list.component.html`) renders each cell's content inside `<a [class]="column.class" (click)="navigateToResult(subResult)">` — an anchor with **no `href`**. Browsers only treat an anchor as a link when it has an `href`, so today middle-click and the right-click context menu offer nothing, and navigation exists only as a JS side effect.
+
+`navigateToResult()` (`results-list.component.ts:367-385`) has two branches:
+
+| Case | Condition | Destination |
+|---|---|---|
+| **A** | `isW3BilateralsAvisa(result)` or `status_name === 'Approved'`, plus the default fallback | `/result/result-detail/{result_code}/general-information?phase={version_id}` |
+| **B** | `source_name === 'W3/Bilaterals'` (pending review) | `/result-framework-reporting/entity-details/{submitter}/results-review` **+** `currentResultToReview.set(result)` **+** `showReviewDrawer.set(true)` |
+
+Case B is the hard one: the review drawer opens from **in-memory signals** on `BilateralResultsService`, not from the URL. A new tab boots a fresh Angular app with `currentResultToReview = null`, so the deep link would land on the review list with no drawer.
+
+**Data flow today (Case B):** `GET_ResultToReview(entityId, centers)` → `bilateralResultsService.tableResults` (flattened `ResultToReview[]`) → `results-review-table.component.html` rows → `reviewResult(result)` sets both signals → `<app-result-review-drawer [(visible)] [(resultToReview)]>` renders. The drawer consumes the whole `ResultToReview` object (`status_id`, and more at lines 878 / 1570 / 1604), not just an id — so a new tab must recover the **object**, which is only available after the list request resolves.
+
+**Other consumers of the same signals** (must keep working unchanged):
+- `results-review-table.component.ts:106-107` — the in-screen "review" action.
+- `notification-item.component.ts:130-133` — the notifications entry point.
+- `results-list.component.ts:83` and `:112` — programmatic navigation right after creating/updating a result.
+
+**Constraint:** `RouterModule` is already in `results-list.module.ts:31`, so `routerLink` needs no module change.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Result titles in the Results Center behave as real links: middle-click, ⌘/Ctrl+click and right-click → "Open in new tab" all work natively.
+- Plain left-click keeps the exact current behaviour for both cases (same tab, same destination, drawer opens for Case B).
+- A Case B URL is **self-sufficient**: pasted into a fresh tab it opens the review drawer for the right result.
+- One source of truth for URL construction, shared by the template link and the programmatic navigation.
+
+**Non-Goals:**
+- Changing the review drawer's internals or its data contract.
+- Making the notifications entry point (`notification-item`) deep-linkable — out of scope for this request.
+- Any backend change; no new endpoint, no payload change.
+- Reworking the Results Center table layout or the other columns (the `[href]` on line 139 stays as is).
+
+## Decisions
+
+### D1 — `routerLink` + `queryParams` instead of `[href]` + click interception
+
+Use Angular's `routerLink` on the anchor rather than a raw `[href]` with a manual `(click)` handler.
+
+*Why:* `routerLink` renders a real `href` (which is what unlocks middle-click and the context menu) **and** already intercepts plain left clicks for in-app SPA navigation while deliberately letting modified clicks (Ctrl/⌘/Shift/middle) fall through to the browser. A raw `[href]` would force us to hand-roll that modifier logic in a click handler — more code, easy to get wrong.
+
+*Alternative considered:* `[href]` + `(click)="$event.preventDefault(); navigateToResult(...)"`. Rejected: it reimplements what `routerLink` already does correctly, and a missed modifier check causes a full page reload.
+
+*Alternative considered:* `target="_blank"` by default. Rejected — Ángel asked to **enable** new-tab, not to force it; forcing it would change the default behaviour for every user.
+
+### D2 — Case B carries the result identity in the URL, not only in a signal
+
+Append a query param (e.g. `?reviewResult={result_code}`) to `/result-framework-reporting/entity-details/{submitter}/results-review`.
+
+*Why:* it is the minimum needed to make the link self-sufficient. The destination screen already fetches the full list; matching the param against `tableResults` after the request resolves recovers the same `ResultToReview` object the drawer expects — no new endpoint, no new payload.
+
+*Alternative considered:* serializing the whole result object into the URL or into `sessionStorage`. Rejected: fragile, leaks payload shape into the URL, and breaks as soon as the result changes server-side.
+
+*Alternative considered:* a dedicated `GET result by code` call on the review screen. Rejected as unnecessary — the list request already returns the object; adding a second call would duplicate state and risk drift.
+
+### D3 — The signal path stays as a fallback, it is not replaced
+
+On plain left click the existing `currentResultToReview.set(...)` still runs; the query param is additive. The destination screen only opens the drawer *from the param* when the drawer is not already open.
+
+*Why:* minimal, incremental change (per the project's investigate-before-modify rule). The in-screen action and the notifications entry point keep working untouched, and if the param lookup finds nothing the screen simply shows the list — degraded, never broken.
+
+### D4 — Clean the query param after opening the drawer
+
+Once the drawer opens from the param, replace the URL (`router.navigate([], { queryParams: {…}, replaceUrl: true })`) to drop it.
+
+*Why:* prevents the drawer from re-opening on refresh, back-navigation, or after the user closes it and the screen re-renders.
+
+### D5 — URL builders live in the component, returning `routerLink` + `queryParams` pairs
+
+Extract two small helpers (e.g. `getResultLink(result)` / `getResultQueryParams(result)`) mirroring the existing branch logic; `navigateToResult()` is refactored to consume them.
+
+*Why:* the template and the programmatic path must never drift apart. Keeps the branch logic in one place, testable by unit tests without a DOM.
+
+## Risks / Trade-offs
+
+- **[Case B new tab races the list request]** → the param lookup must run *after* `getResultsToReview()` resolves and `tableResults` is populated, not in `ngOnInit`. Implement as a reaction to the populated signal, guarded so it fires once.
+- **[The result code is not in the loaded list]** (different center filter, already reviewed, or a stale link) → no drawer opens; the user sees the review list. Acceptable degraded state — must not throw or blank the screen.
+- **[This branch already carries bilateral changes]** (`staging-front-upload`) → touching `results-review-table.component.ts` risks conflicts. Mitigated by keeping the addition small and additive (no refactor of existing methods there).
+- **[`<a>` nested inside a `<td>` with `cursor: pointer`]** → the anchor must fill the cell so the clickable area does not shrink; verify styling did not change visually after adding `routerLink`.
+- **[Regression on programmatic navigation]** (`results-list.component.ts:83`, `:112`, after creating a result) → covered by refactoring through the shared builders plus a unit test per branch.
+- **[Client coverage gate: branches 50% / functions 60% / lines 60% / statements 60%]** → new branch logic needs unit tests, or the gate can drop below threshold.
+
+## Migration Plan
+
+Not applicable — no data migration, no API change. Deploy is the normal client build. Rollback = revert the commit; nothing persists in the database or in user state.
+
+## Findings during implementation
+
+### F1 — The review list does not contain every deep-linkable result
+
+Verified against prtest: `GET /api/results/by-program-and-centers?programId=SP01` returns 152 results, and the two W3/Bilaterals rows the Results Center links to (codes 8677 and 8676) are **not among them** — both are in status **`Editing`**, i.e. drafts that were never submitted for review.
+
+This invalidated the original D2 assumption ("the destination screen already fetches the list, so matching by code recovers the object"). Matching by code alone works only for results already in review.
+
+**Consequence:** removing the `(click)` handler in favour of a pure `routerLink` broke the plain-click behaviour for drafts — the drawer stopped opening, because nothing populated `currentResultToReview` and the code was not in the list. Caught by browser verification, not by unit tests.
+
+**Resolution (supersedes part of D2 and D3):**
+1. The Case B link also carries **`reviewResultId={result.id}`**. The drawer loads its content with `loadResultDetail(result.id)`, so the id is enough to render it.
+2. `results-review-table` prefers the object found in the list (complete) and falls back to a minimal `{ id, result_code }` object built from the params when the result is not in the list.
+3. The anchor keeps a `(click)` handler — `onResultLinkClick()` — that only preloads the drawer state on a **plain** left click and returns early on ctrl/cmd/shift/alt or a non-primary button, so opening a new tab never mutates the current tab's state. `routerLink` still owns the navigation.
+
+Verified in the browser: for the same draft, the drawer rendered in a new tab is identical to the one rendered by a plain click.
+
+## Open Questions
+
+- ~~Query param name~~ — **resolved**: `reviewResult` + `reviewResultId`, matching the existing lowercase convention on the bilateral screens (`center`, `search`, `phase`).
+- Should a draft in `Editing` status open in the **review** drawer at all, or in the editing flow? Out of scope here — this change preserves the existing destination — but worth raising with Product.
+- No P2 Jira ticket exists yet for this request. To be created/linked before opening the PR — the commit convention requires a ticket id.

--- a/openspec/changes/results-center-open-in-new-tab/proposal.md
+++ b/openspec/changes/results-center-open-in-new-tab/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+Users cannot open a result from the Results Center in a new browser tab: middle-click and right-click → "Open link in new tab" do nothing, because the result title is rendered as an anchor **without an `href`** and navigation happens only through a JavaScript `(click)` handler.
+
+This blocks a normal review workflow — opening several results side by side in separate tabs — and was requested directly by Ángel Jarrín (Product) on 2026-07-28: *"que cuando se le dé clic a un resultado en el Result Center abra en una nueva pestaña… habilitar el clic derecho new tab, y clic central"*, explicitly *"aplica a los dos"* (both navigation cases).
+
+**Scope: frontend-only.** No backend change is required — both destination URLs already exist and are served by the existing Angular routes.
+
+**Jira ticket:** **P2-3203** (Enhancement) — created from Ángel Jarrín's direct Slack request (DM, 2026-07-28).
+
+## What Changes
+
+- The result title in the Results Center table becomes a **real link** (`routerLink` → renders an `href`), so the browser natively supports:
+  - left click → same-tab navigation (unchanged behaviour),
+  - middle click / ⌘+click / Ctrl+click → new tab,
+  - right click → native "Open link in new tab / new window" context menu.
+- **Case A — standard results and approved W3/Bilaterals (AVISA):** link points to `/result/result-detail/{result_code}/general-information?phase={version_id}`. Behaviour is preserved exactly; only the mechanism changes from `router.navigateByUrl()` to a declarative link.
+- **Case B — W3/Bilaterals results pending review:** today the destination screen relies on an **in-memory signal** (`currentResultToReview`) to open the review drawer, which a fresh tab cannot have. The result identity moves into the **URL as a query param**, and the results-review screen opens the drawer from that param once its data has loaded. This makes the deep link self-sufficient and identical in the current tab and in a new tab.
+- Programmatic navigation after creating a result (`results-list.component.ts` lines 83 and 112) keeps working through the same URL builders — single source of truth, no duplicated URL strings.
+
+No breaking changes: every existing entry point keeps its current behaviour on a plain left click.
+
+## Capabilities
+
+### New Capabilities
+- `results-center-result-links`: how a result row in the Results Center is linked and navigated — real anchors, native new-tab support, and the deep-linkable review drawer for W3/Bilaterals results pending review.
+
+### Modified Capabilities
+<!-- None. No existing spec under openspec/specs/ defines Results Center navigation. -->
+
+## Impact
+
+**Affected code (client only):**
+- `onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/results-list.component.html` — line 86, the `<a (click)=…>` that wraps every cell's content.
+- `onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/results-list.component.ts` — `navigateToResult()` (lines 367-385) refactored into reusable URL builders.
+- `onecgiar-pr-client/src/app/pages/results/pages/results-outlet/pages/results-list/results-list.module.ts` — may need `RouterModule` in `imports` for `routerLink`.
+- `onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/bilateral-results/components/results-review-table/results-review-table.component.ts` — reads the new query param and opens the review drawer once `tableResults` is populated.
+
+**Not affected:** backend, API contracts, database, `result-review-drawer` internals, and the notifications entry point (`notification-item.component`), which keeps its current behaviour.
+
+**Baseline docs consulted:** `docs/system-design/design.md` (navigation and interaction patterns for the client UI) and `docs/detailed-design/detailed-design.md` (frontend state / routing). No module spec under `docs/specs/` currently covers Results Center navigation.
+
+**Risk:** low for Case A (declarative equivalent of existing navigation), moderate for Case B — it touches the bilateral review screen, which already carries changes on the `staging-front-upload` branch. Mitigated by keeping the signal-based path working as a fallback.
+
+**Verification:** browser check with Playwright on `localhost:4200` — plain click, middle click and right-click → "Open link in new tab", for both Case A and Case B.

--- a/openspec/changes/results-center-open-in-new-tab/specs/results-center-result-links/spec.md
+++ b/openspec/changes/results-center-open-in-new-tab/specs/results-center-result-links/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: Result rows in the Results Center are real links
+
+The Results Center table SHALL render each result's clickable content as an anchor with a resolved `href` pointing at that result's destination, so the browser can offer its native link affordances.
+
+#### Scenario: Anchor exposes a real href
+- **WHEN** the Results Center table renders a result row
+- **THEN** the anchor wrapping the row content has an `href` attribute whose value is the same URL a plain left click would navigate to
+
+#### Scenario: Middle click opens a new tab
+- **WHEN** the user middle-clicks (mouse wheel) a result in the Results Center
+- **THEN** the browser opens that result in a new background tab
+- **AND** the current tab stays on the Results Center, unchanged
+
+#### Scenario: Right click offers the native context menu
+- **WHEN** the user right-clicks a result in the Results Center
+- **THEN** the browser context menu offers "Open link in new tab" and "Open link in new window"
+- **AND** choosing "Open link in new tab" loads that result in a new tab
+
+#### Scenario: Modified click opens a new tab
+- **WHEN** the user clicks a result while holding Ctrl (Windows/Linux) or ⌘ (macOS)
+- **THEN** the browser opens that result in a new tab
+- **AND** the application does NOT perform an in-app navigation in the current tab
+
+#### Scenario: Plain left click keeps in-app navigation
+- **WHEN** the user left-clicks a result without modifier keys
+- **THEN** the application navigates in the same tab through the Angular router
+- **AND** the page does NOT perform a full browser reload
+
+### Requirement: Standard results link to their result detail page
+
+For results that are not W3/Bilaterals pending review — standard results, approved results, and approved W3/Bilaterals AVISA results — the link SHALL target the result detail page for that result and reporting phase.
+
+#### Scenario: Link target for a standard result
+- **WHEN** the Results Center renders a standard or approved result
+- **THEN** the anchor's `href` resolves to `/result/result-detail/{result_code}/general-information` with the query param `phase={version_id}`
+
+#### Scenario: New tab lands on the result detail
+- **WHEN** the user opens a standard result in a new tab from the Results Center
+- **THEN** the new tab loads the result detail page for that result and phase, with no extra clicks
+
+### Requirement: W3/Bilaterals results pending review are deep-linkable
+
+For results whose source is W3/Bilaterals and that are pending review, the link SHALL target the entity's results-review screen and SHALL carry the result identity as a query parameter, so the review drawer can be opened from the URL alone.
+
+#### Scenario: Link target carries the result identity
+- **WHEN** the Results Center renders a W3/Bilaterals result pending review
+- **THEN** the anchor's `href` resolves to `/result-framework-reporting/entity-details/{submitter}/results-review` including both the result code and the result id as query parameters
+
+#### Scenario: Result absent from the review list still opens
+- **WHEN** the deep-linked result is not part of the entity's review list, such as a draft in `Editing` status
+- **THEN** the review drawer opens using the result id carried in the URL
+- **AND** the drawer renders the same content it would render from a plain click in the current tab
+
+#### Scenario: New tab opens the review drawer
+- **WHEN** the user opens a W3/Bilaterals result pending review in a new tab
+- **AND** the results-review screen has finished loading its results
+- **THEN** the review drawer opens automatically showing that result
+
+#### Scenario: Same-tab click still opens the drawer
+- **WHEN** the user left-clicks a W3/Bilaterals result pending review in the Results Center
+- **THEN** the application navigates to the results-review screen in the same tab
+- **AND** the review drawer opens showing that result, exactly as before this change
+
+#### Scenario: Query parameter is cleared once used
+- **WHEN** the review drawer has been opened from the query parameter
+- **THEN** the parameter is removed from the URL without adding a history entry
+- **AND** closing the drawer and reloading the page does NOT reopen it
+
+#### Scenario: Unknown or unavailable result degrades safely
+- **WHEN** a results-review URL carries a result code that is not present in the loaded results and no result id
+- **THEN** the results-review screen renders its list normally with no drawer open
+- **AND** no error is thrown and no blank screen is shown
+
+### Requirement: Opening a result in a new tab must not alter the current tab
+
+Clicks that the browser handles as "open in a new tab" SHALL NOT mutate the state of the tab the user clicked from.
+
+#### Scenario: Modified click leaves the current tab untouched
+- **WHEN** the user opens a W3/Bilaterals result in a new tab with ctrl/⌘/shift+click or the middle button
+- **THEN** the review drawer state of the originating tab is left unchanged
+- **AND** the originating tab stays on the Results Center
+
+### Requirement: Programmatic navigation uses the same destinations
+
+Navigation triggered by the application itself — such as after creating or updating a result — SHALL resolve destinations through the same URL construction used by the row links, so links and programmatic navigation cannot drift apart.
+
+#### Scenario: Navigation after creating a result
+- **WHEN** the application navigates to a result programmatically after it is created or updated
+- **THEN** the destination URL is identical to the `href` the Results Center row link would expose for that same result

--- a/openspec/changes/results-center-open-in-new-tab/tasks.md
+++ b/openspec/changes/results-center-open-in-new-tab/tasks.md
@@ -1,0 +1,44 @@
+## 1. Frontend — Case A: real links for standard results
+
+- [x] 1.1 In `results-list.component.ts`, extract the branch logic of `navigateToResult()` into `getResultLink(result)` / `getResultQueryParams(result)`, backed by a private `getResultRoute()` that caches one `ResultRoute` per result so `routerLink` keeps a stable object identity across change detection.
+- [x] 1.2 Refactor `navigateToResult()` to build its URL from those helpers (now `router.navigate(commands, { queryParams })`), keeping the Case B side effects so lines 83 and 112 keep working.
+- [x] 1.3 In `results-list.component.html` line 86, swap the `(click)` navigation for `[routerLink]` + `[queryParams]`. `RouterModule` was already imported in `results-list.module.ts:31` — no module change needed.
+- [x] 1.4 Anchor still fills the cell; no SCSS change was required (verified in the browser, screenshot `final-01-results-center.png`).
+
+## 2. Frontend — Case B: deep-linkable review drawer
+
+- [x] 2.1 Checked the existing convention in `result-framework-reporting` (`center`, `search`, `phase`) → params named **`reviewResult`** (code) and **`reviewResultId`** (id), exported from `bilateral-results.service.ts`.
+- [x] 2.2 In `results-review-table.component.ts`, read both params from `ActivatedRoute` and, once `tableResults()` is populated, open the drawer through the existing `reviewResult()`. Fires once.
+- [x] 2.3 Clear both params afterwards with `router.navigate([], { relativeTo, queryParamsHandling: 'merge', replaceUrl: true })`.
+- [x] 2.4 Miss case handled: the list renders with no drawer and no error when neither the code matches nor an id is given.
+- [x] 2.5 In-screen review action and the notifications entry point left untouched — both verified unchanged.
+- [x] 2.6 **Added after a finding (see design.md F1):** results not present in the review list — drafts in `Editing` status — fall back to a minimal `{ id, result_code }` object built from the params, so the drawer still opens.
+- [x] 2.7 **Regression fix:** the anchor keeps an `onResultLinkClick($event, result)` handler that preloads the drawer state on a plain left click only, returning early on ctrl/cmd/shift/alt or a non-primary button. Without it, plain clicks on drafts stopped opening the drawer.
+
+## 3. Unit tests (client, Jest)
+
+- [x] 3.1 `results-list.component.spec.ts`: `getResultLink` / `getResultQueryParams` for AVISA-approved, `status_name === 'Approved'` and the default fallback → all resolve to the result detail with `phase`.
+- [x] 3.2 Case B branch → resolves to the results-review screen carrying `reviewResult` + `reviewResultId`.
+- [x] 3.3 `navigateToResult()` still sets `currentResultToReview` / `showReviewDrawer` for a W3/Bilaterals result pending review; plus a test asserting the route objects are cached (stable identity).
+- [x] 3.4 `results-review-table.component.spec.ts`: param opens the drawer once results load, params are cleared afterwards, unknown param leaves the drawer closed without throwing, id fallback opens the drawer, and the list object wins over the id fallback.
+- [x] 3.5 New `onResultLinkClick()` tests: plain click preloads state; ctrl/cmd/shift/middle click does not; non-bilateral results do not.
+- [x] 3.6 Full suite green — **378 suites / 3993 tests** — with coverage above the gate (branches 65.34% ≥ 50, functions 81.55% ≥ 60, lines 84.37% ≥ 60, statements 83.91% ≥ 60).
+
+## 4. Verification in the app (Playwright)
+
+> Ports 4200 and 4300 were already in use by other sessions, so the client ran on **4500** (`npm start -- --port 4500`), pointing at the prtest backend. The worktree had no `node_modules` and no `src/environments/` — both were provisioned before running.
+
+- [x] 4.1 Case A — link format `/result/result-detail/{code}/general-information?phase={version}`.
+- [x] 4.2 Case A — plain left click navigates in the same tab, no full reload.
+- [x] 4.3 Case A — middle click opens a new background tab on the result detail; the original tab stays on the Results Center.
+- [x] 4.4 Case A — ctrl/⌘+click opens a new tab. Right-click "Open link in new tab" is covered by the presence of a resolved `href` (the native menu cannot be automated).
+- [x] 4.5 Case B — plain click still opens the drawer for a draft (no regression), and middle click opens it in a new tab with the drawer already open.
+- [x] 4.6 Case B — deep link works for a result in review (code 8339); params are cleared; refreshing does NOT reopen the drawer; a bogus code degrades with no drawer and no console error.
+- [x] 4.7 Screenshots saved to `.local-screenshots/` (gitignored): `final-01` … `final-04`, plus the earlier diagnosis set. `final-02` (plain click) and `final-03` (new tab) are identical for the same draft.
+
+## 5. Gate before handing over
+
+- [x] 5.1 `npm run lint` → **All files pass linting**.
+- [x] 5.2 `npx tsc --noEmit` → 0 errors; `npx jest --coverage` → green, thresholds met.
+- [x] 5.3 Jira ticket created and documented: **P2-3203** — "Results Center - Allow opening a result in a new browser tab (middle click and right click)" (Enhancement, Open, assigned to Yecksin). Handed over to Ángel Jarrín on Slack for testing.
+- [ ] 5.4 Commit with `✨ feat(results-list) P2-3203: …` and push to dev. The AI does not run git write commands — pending on the user.


### PR DESCRIPTION
## What was done

Result titles in the **Results Center** are now real links, so the browser handles them natively:

- **Middle click** (scroll-wheel click) opens the result in a new tab and keeps the list open in the current one.
- **Right click** offers *"Open link in a new tab"*.
- **Ctrl / Cmd + click** opens a new tab.
- **Plain left click** keeps its previous behaviour (same tab).

For **W3/Bilaterals** results pending review, the result identity travels in the URL (`reviewResult` + `reviewResultId`), so the review drawer can open from a fresh tab. The params are cleared once the drawer opens, so refreshing the page does not reopen it.

## Why

Requested by Santiago Sánchez (P2-3111). The title looked like a link but was a click-only handler, so the browser offered nothing on middle or right click — users could not open several results side by side.

## How to verify

1. Go to the **Results Center**.
2. **Middle click** a result title → opens in a new tab; the original tab stays on the list.
3. **Right click** → *"Open link in a new tab"* → loads that result.
4. **Ctrl + click** (Cmd + click on Mac) → new tab.
5. **Plain click** → same tab, as before.
6. Repeat with a **W3/Bilaterals** result (Funding Source column) → in the new tab the review drawer opens by itself, with the same information it shows on a plain click.
7. With the drawer opened from a new tab, **refresh the page** → it must NOT reopen.

## Notes

- This branch was cut clean from `staging` and carries **only** this change. The original commit lived on top of `staging-front-upload`, which also holds unrelated Areas of Work work (Intermediate Outcomes page, indicator center tracking) — those are intentionally left out.

## Test gate

- `npm run lint` → **All files pass linting**
- `npm run test:coverage` → **378 suites / 3988 tests passed**
- Coverage: statements **83.92%**, branches **65.24%**, functions **81.57%**, lines **84.37%** (thresholds 60 / 50 / 60 / 60)

## Technical references

- Branch: `P2-3203-results-center-open-in-new-tab` (from `staging`)
- Commit: `5fee70cf2` — cherry-pick of `11f36bb5b`
- Jira: P2-3203 (parent request P2-3111)

🤖 Generated with [Claude Code](https://claude.com/claude-code)