### PR TITLE
release(staging → master): Intermediate Outcomes shared across Areas of Work are now identified

### DIFF
--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.html
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.html
@@ -1,16 +1,18 @@
-<div class="search_input" style="width: 100%; margin-bottom: 1rem">
-  <i class="material-icons-round">search</i>
-  <input
-    id="aowIndicatorSearchInput"
-    type="text"
-    placeholder="Find indicator..."
-    aria-label="Find indicator"
-    [ngModel]="entityAowService.searchText()"
-    (ngModelChange)="entityAowService.searchText.set($event)" />
-</div>
+@if (showSearch) {
+  <div class="search_input" style="width: 100%; margin-bottom: 1rem">
+    <i class="material-icons-round">search</i>
+    <input
+      id="aowIndicatorSearchInput"
+      type="text"
+      placeholder="Find indicator..."
+      aria-label="Find indicator"
+      [ngModel]="entityAowService.searchText()"
+      (ngModelChange)="entityAowService.searchText.set($event)" />
+  </div>
+}
 
 <p-table
-  id="tocResultsByAowIdTable"
+  [id]="'tocResultsByAowIdTable' + instanceId"
   styleClass="p-datatable-gridlines p-datatable-sm"
   [value]="filteredTableData()"
   [loading]="entityAowService.isLoadingTocResultsByAowId() || entityAowService.isLoadingTocResults2030Outcomes() || entityAowService.isLoadingIntermediateOutcomes()"
@@ -25,11 +27,11 @@
   <ng-template pTemplate="header">
     <tr>
       @for (column of columnOrder(); track column.attr) {
-        <th [id]="column.attr" style="text-align: center" [style.width]="column.width">
+        <th [id]="column.attr + instanceId" style="text-align: center" [style.width]="column.width">
           {{ column.title }}
         </th>
       }
-      <th id="actions" style="text-align: center; width: 16%">Actions</th>
+      <th [id]="'actions' + instanceId" style="text-align: center; width: 16%">Actions</th>
     </tr>
   </ng-template>
 
@@ -46,6 +48,14 @@
               [icon]="expanded ? 'pi pi-chevron-down' : 'pi pi-chevron-right'"></button>
 
             <span style="font-weight: bold">{{ item.result_title }}</span>
+
+            @if (tableType === 'outcomes-non-exclusive') {
+              <span
+                class="tab-content_chip non-exclusive-chip"
+                pTooltip="This Intermediate Outcome is not assigned to a single Area of Work, so it appears under all of them.">
+                Not exclusive to this AoW
+              </span>
+            }
           </div>
         </div>
       </td>
@@ -150,14 +160,16 @@
   </ng-template>
 </p-table>
 
-@if (entityAowService.showReportResultModal()) {
-  <app-aow-hlo-create-modal></app-aow-hlo-create-modal>
-}
+@if (renderOverlays) {
+  @if (entityAowService.showReportResultModal()) {
+    <app-aow-hlo-create-modal></app-aow-hlo-create-modal>
+  }
 
-@if (entityAowService.showViewResultDrawer()) {
-  <app-aow-view-results-drawer></app-aow-view-results-drawer>
-}
+  @if (entityAowService.showViewResultDrawer()) {
+    <app-aow-view-results-drawer></app-aow-view-results-drawer>
+  }
 
-@if (entityAowService.showTargetDetailsDrawer()) {
-  <app-aow-target-details-drawer></app-aow-target-details-drawer>
+  @if (entityAowService.showTargetDetailsDrawer()) {
+    <app-aow-target-details-drawer></app-aow-target-details-drawer>
+  }
 }

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.scss
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.scss
@@ -20,6 +20,15 @@ p {
   color: var(--pr-color-secondary-200);
 }
 
+.non-exclusive-chip {
+  flex: 0 0 auto;
+  background-color: var(--pr-color-blue-50);
+  border-color: var(--pr-color-blue-200);
+  color: var(--pr-color-blue-700);
+  cursor: help;
+  white-space: nowrap;
+}
+
 .kpi-statement-cell {
   display: flex;
   flex-direction: column;

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.spec.ts
@@ -165,6 +165,10 @@ describe('AowHloTableComponent', () => {
       getTocResultsByAowId: jest.fn(),
       tocResultsOutputsByAowId: signal<any[]>([]),
       tocResultsOutcomesByAowId: signal<any[]>([]),
+      // The real service derives these from `tocResultsOutcomesByAowId` via the `is_aow` flag; the
+      // derivation itself is asserted in entity-aow.service.spec.ts.
+      tocResultsOutcomesExclusiveByAowId: signal<any[]>([]),
+      tocResultsOutcomesNonExclusiveByAowId: signal<any[]>([]),
       tocResults2030Outcomes: signal<any[]>([]),
       tocResultsIntermediateOutcomes: signal<any[]>([]),
       searchText: signal<string>(''),
@@ -384,6 +388,10 @@ describe('AowHloTableComponent', () => {
       // Reset mock signals to empty arrays
       mockEntityAowService.tocResultsOutputsByAowId.set([]);
       mockEntityAowService.tocResultsOutcomesByAowId.set([]);
+      // Cast: on the real service these two are `computed` (read-only Signals), so the typed mock
+      // does not expose `set` even though the test double is a writable signal.
+      (mockEntityAowService.tocResultsOutcomesExclusiveByAowId as any).set([]);
+      (mockEntityAowService.tocResultsOutcomesNonExclusiveByAowId as any).set([]);
       mockEntityAowService.tocResults2030Outcomes.set([]);
     });
 
@@ -400,17 +408,37 @@ describe('AowHloTableComponent', () => {
       expect(result).toEqual(mockOutputsData);
     });
 
-    it('should return outcomes data when tableType is "outcomes"', () => {
+    it('should return the AoW-exclusive outcomes when tableType is "outcomes"', () => {
       const mockOutcomesData = [
         { id: 'outcome-1', title: 'Outcome 1', type: 'outcome' },
         { id: 'outcome-2', title: 'Outcome 2', type: 'outcome' }
       ];
-      mockEntityAowService.tocResultsOutcomesByAowId.set(mockOutcomesData);
+      (mockEntityAowService.tocResultsOutcomesExclusiveByAowId as any).set(mockOutcomesData);
       component.tableType = 'outcomes';
 
       const result = component.tableData();
 
       expect(result).toEqual(mockOutcomesData);
+    });
+
+    it('should return the non-exclusive outcomes when tableType is "outcomes-non-exclusive"', () => {
+      const mockSharedOutcomes = [{ id: 'outcome-3', title: 'Shared Outcome', type: 'outcome' }];
+      (mockEntityAowService.tocResultsOutcomesNonExclusiveByAowId as any).set(mockSharedOutcomes);
+      component.tableType = 'outcomes-non-exclusive';
+
+      const result = component.tableData();
+
+      expect(result).toEqual(mockSharedOutcomes);
+    });
+
+    it('should not mix the two outcome lists', () => {
+      // `tableType` is a plain @Input set once by the host, so it is read here on a single instance.
+      (mockEntityAowService.tocResultsOutcomesExclusiveByAowId as any).set([{ id: 'own' }]);
+      (mockEntityAowService.tocResultsOutcomesNonExclusiveByAowId as any).set([{ id: 'shared' }]);
+      component.tableType = 'outcomes';
+
+      expect(component.tableData()).toEqual([{ id: 'own' }]);
+      expect(component.tableData()).not.toContainEqual({ id: 'shared' });
     });
 
     it('should return 2030 outcomes data when tableType is "2030-outcomes"', () => {
@@ -511,6 +539,65 @@ describe('AowHloTableComponent', () => {
       expect(component.emptyStateMessage()).toBe(
         'There are no Intermediate Outcomes configured for this program in the current reporting phase.'
       );
+    });
+
+    it('should return the shared-outcomes message for outcomes-non-exclusive table', () => {
+      component.tableType = 'outcomes-non-exclusive';
+      expect(component.emptyStateMessage()).toBe(
+        'There are no Intermediate Outcomes shared with other Areas of Work.'
+      );
+    });
+  });
+
+  // A second instance of this table renders on the Outcomes tab. The search box and the
+  // modal/drawers are driven by shared service signals, so they must render only once.
+  describe('secondary instance inputs', () => {
+    it('should render the search input and the overlays by default', () => {
+      fixture.detectChanges();
+
+      expect(component.showSearch).toBe(true);
+      expect(component.renderOverlays).toBe(true);
+      expect(component.instanceId).toBe('');
+      expect(fixture.nativeElement.querySelector('#aowIndicatorSearchInput')).toBeTruthy();
+    });
+
+    it('should not render the search input when showSearch is false', () => {
+      component.showSearch = false;
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('#aowIndicatorSearchInput')).toBeNull();
+    });
+
+    it('should not render the report-result modal when renderOverlays is false', () => {
+      mockEntityAowService.showReportResultModal.set(true);
+      component.renderOverlays = false;
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('app-aow-hlo-create-modal')).toBeNull();
+    });
+
+    it('should not render the view-results drawer when renderOverlays is false', () => {
+      mockEntityAowService.showViewResultDrawer.set(true);
+      component.renderOverlays = false;
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('app-aow-view-results-drawer')).toBeNull();
+    });
+
+    it('should not render the target-details drawer when renderOverlays is false', () => {
+      mockEntityAowService.showTargetDetailsDrawer.set(true);
+      component.renderOverlays = false;
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('app-aow-target-details-drawer')).toBeNull();
+    });
+
+    it('should suffix the table id with instanceId so two instances stay unique', () => {
+      component.instanceId = 'NonExclusive';
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('#tocResultsByAowIdTableNonExclusive')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('#tocResultsByAowIdTable')).toBeNull();
     });
   });
 

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.ts
@@ -40,14 +40,29 @@ export class AowHloTableComponent {
   entityAowService = inject(EntityAowService);
   resultLevelService = inject(ResultLevelService);
 
-  @Input() tableType: 'outputs' | 'outcomes' | '2030-outcomes' | 'intermediate-outcomes' = 'outputs';
+  @Input() tableType:
+    | 'outputs'
+    | 'outcomes'
+    | 'outcomes-non-exclusive'
+    | '2030-outcomes'
+    | 'intermediate-outcomes' = 'outputs';
+
+  // Set to false on secondary instances: the search box and the modal/drawers below are driven by
+  // shared service signals, so rendering them twice would duplicate the input and stack the dialogs.
+  @Input() showSearch = true;
+  @Input() renderOverlays = true;
+
+  // Suffix appended to the table and column header ids so two instances on the same page stay unique.
+  @Input() instanceId = '';
 
   tableData = computed(() => {
     switch (this.tableType) {
       case 'outputs':
         return this.entityAowService.tocResultsOutputsByAowId();
       case 'outcomes':
-        return this.entityAowService.tocResultsOutcomesByAowId();
+        return this.entityAowService.tocResultsOutcomesExclusiveByAowId();
+      case 'outcomes-non-exclusive':
+        return this.entityAowService.tocResultsOutcomesNonExclusiveByAowId();
       case '2030-outcomes':
         return this.entityAowService.tocResults2030Outcomes();
       case 'intermediate-outcomes':
@@ -91,6 +106,8 @@ export class AowHloTableComponent {
     switch (this.tableType) {
       case 'outcomes':
         return 'There are no Intermediate Outcomes indicators found.';
+      case 'outcomes-non-exclusive':
+        return 'There are no Intermediate Outcomes shared with other Areas of Work.';
       case '2030-outcomes':
         return 'There are no 2030 Outcomes indicators configured for this program in the current reporting phase.';
       case 'intermediate-outcomes':

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/entity-aow-aow.component.html
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/entity-aow-aow.component.html
@@ -37,15 +37,43 @@
       </div>
     }
     @case ('outcomes') {
-      <div class="tab-content_header">
-        <h3>Intermediate Outcomes Indicators</h3>
-        <div class="tab-content_header_dot"></div>
-        <h3 class="tab-content_header_phase">Reporting Phase {{ entityAowService.reportingPhaseYear }}</h3>
-      </div>
+      <!-- Hidden only when every Outcome of this AoW is program-level: the section below already
+           lists them, so an empty table on top would read as "no data". -->
+      @if (entityAowService.tocResultsOutcomesExclusiveByAowId().length || !entityAowService.tocResultsOutcomesNonExclusiveByAowId().length) {
+        <div class="tab-content_header">
+          <h3>Intermediate Outcomes Indicators</h3>
+          <div class="tab-content_header_dot"></div>
+          <h3 class="tab-content_header_phase">Reporting Phase {{ entityAowService.reportingPhaseYear }}</h3>
+        </div>
 
-      <div class="tab-content">
-        <app-aow-hlo-table tableType="outcomes"></app-aow-hlo-table>
-      </div>
+        <div class="tab-content">
+          <app-aow-hlo-table tableType="outcomes"></app-aow-hlo-table>
+        </div>
+      }
+
+      @if (entityAowService.tocResultsOutcomesNonExclusiveByAowId().length) {
+        <div class="tab-content_header aow-non-exclusive-header">
+          <h3>Intermediate Outcomes not exclusive to this Area of Work</h3>
+        </div>
+
+        <div class="aow-non-exclusive-note">
+          <span class="material-icons-round aow-non-exclusive-note_icon">info</span>
+          <p class="aow-non-exclusive-note_text">
+            The Intermediate Outcomes below are not assigned to a specific Area of Work. They belong to
+            the Science Program as a whole, so they also appear under every other Area of Work.
+          </p>
+        </div>
+
+        <div class="tab-content">
+          <!-- The search box and the modal/drawers stay with the table above, which shares the same
+               service signals — except when that table is hidden and this one has to host them. -->
+          <app-aow-hlo-table
+            tableType="outcomes-non-exclusive"
+            instanceId="NonExclusive"
+            [showSearch]="false"
+            [renderOverlays]="!entityAowService.tocResultsOutcomesExclusiveByAowId().length"></app-aow-hlo-table>
+        </div>
+      }
     }
     @default {
       <div class="tab-content">

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/entity-aow-aow.component.scss
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-aow/entity-aow-aow.component.scss
@@ -102,3 +102,35 @@ p {
 .tab-content {
   padding: 25px;
 }
+
+// Second Outcomes section: the program-level Intermediate Outcomes shared across every AoW.
+.aow-non-exclusive-header {
+  border-top: 1px solid var(--pr-color-accents-2);
+}
+
+.aow-non-exclusive-note {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  margin: 20px 25px 0;
+  padding: 12px 15px;
+  border-radius: 9px;
+  background-color: var(--pr-color-blue-50);
+  border: 1px solid var(--pr-color-blue-200);
+}
+
+.aow-non-exclusive-note_icon {
+  flex: 0 0 auto;
+  font-size: 20px;
+  color: var(--pr-color-blue-500);
+}
+
+.aow-non-exclusive-note_text {
+  @include fonts.pr-typography('body-2');
+  color: var(--pr-color-blue-800);
+  line-height: 1.5;
+}
+
+.aow-non-exclusive-header + .aow-non-exclusive-note + .tab-content {
+  padding-top: 15px;
+}

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-unplanned/entity-aow-unplanned.component.html
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-unplanned/entity-aow-unplanned.component.html
@@ -5,6 +5,17 @@
     <h3 class="entity-aow-unplanned_content_header_phase">Reporting Phase {{ entityAowService.reportingPhaseYear }}</h3>
   </div>
 
+  <div class="entity-aow-unplanned_note">
+    <span class="material-icons-round entity-aow-unplanned_note_icon">info</span>
+    <p class="entity-aow-unplanned_note_text">
+      These are the Theory of Change entries of your Science Program that are
+      <strong>not assigned to a specific Area of Work</strong>. Because they belong to the program as a
+      whole, they are gathered here in one place and also appear — clearly tagged — inside every Area of
+      Work. The Outcomes you see when you open an Area of Work are the ones planned for that Area of
+      Work only.
+    </p>
+  </div>
+
   <div class="entity-aow-unplanned_content_table">
     <app-aow-hlo-table tableType="intermediate-outcomes"></app-aow-hlo-table>
   </div>

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-unplanned/entity-aow-unplanned.component.html
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-unplanned/entity-aow-unplanned.component.html
@@ -8,11 +8,9 @@
   <div class="entity-aow-unplanned_note">
     <span class="material-icons-round entity-aow-unplanned_note_icon">info</span>
     <p class="entity-aow-unplanned_note_text">
-      These are the Theory of Change entries of your Science Program that are
-      <strong>not assigned to a specific Area of Work</strong>. Because they belong to the program as a
-      whole, they are gathered here in one place and also appear — clearly tagged — inside every Area of
-      Work. The Outcomes you see when you open an Area of Work are the ones planned for that Area of
-      Work only.
+      These are the Intermediate Outcomes of your Science Program/Accelerator that are
+      <strong>not assigned to a specific Area of Work</strong>. They are displayed here and within the
+      Areas of Work to which they are mapped.
     </p>
   </div>
 

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-unplanned/entity-aow-unplanned.component.scss
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/pages/entity-aow-unplanned/entity-aow-unplanned.component.scss
@@ -39,6 +39,37 @@ p {
   color: var(--pr-color-accents-5);
 }
 
+.entity-aow-unplanned_note {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  margin: 20px 25px 0;
+  padding: 12px 15px;
+  border-radius: 9px;
+  background-color: var(--pr-color-blue-50);
+  border: 1px solid var(--pr-color-blue-200);
+}
+
+.entity-aow-unplanned_note_icon {
+  flex: 0 0 auto;
+  font-size: 20px;
+  color: var(--pr-color-blue-500);
+}
+
+.entity-aow-unplanned_note_text {
+  @include fonts.pr-typography('body-2');
+  color: var(--pr-color-blue-800);
+  line-height: 1.5;
+
+  strong {
+    font-weight: 600;
+  }
+}
+
 .entity-aow-unplanned_content_table {
   padding: 25px;
+}
+
+.entity-aow-unplanned_note + .entity-aow-unplanned_content_table {
+  padding-top: 15px;
 }

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/services/entity-aow.service.spec.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/services/entity-aow.service.spec.ts
@@ -773,6 +773,58 @@ describe('EntityAowService', () => {
     });
   });
 
+  // The server marks every ToC node it returns for an AoW with `is_aow`. `false` means the node is
+  // not linked to any Area of Work, so it is returned under every AoW of the program.
+  describe('Outcomes split by the is_aow flag', () => {
+    const own = { toc_result_id: 1, result_title: 'Own outcome', is_aow: true };
+    const shared = { toc_result_id: 2, result_title: 'Shared outcome', is_aow: false };
+
+    it('should keep only the AoW-exclusive outcomes in the exclusive list', () => {
+      service.tocResultsOutcomesByAowId.set([own, shared]);
+
+      expect(service.tocResultsOutcomesExclusiveByAowId()).toEqual([own]);
+    });
+
+    it('should keep only the non-exclusive outcomes in the shared list', () => {
+      service.tocResultsOutcomesByAowId.set([own, shared]);
+
+      expect(service.tocResultsOutcomesNonExclusiveByAowId()).toEqual([shared]);
+    });
+
+    it('should treat a missing is_aow as exclusive so the previous single-list behaviour is kept', () => {
+      const legacy = { toc_result_id: 3, result_title: 'No flag' };
+      service.tocResultsOutcomesByAowId.set([legacy]);
+
+      expect(service.tocResultsOutcomesExclusiveByAowId()).toEqual([legacy]);
+      expect(service.tocResultsOutcomesNonExclusiveByAowId()).toEqual([]);
+    });
+
+    it('should return empty lists when there are no outcomes', () => {
+      service.tocResultsOutcomesByAowId.set([]);
+
+      expect(service.tocResultsOutcomesExclusiveByAowId()).toEqual([]);
+      expect(service.tocResultsOutcomesNonExclusiveByAowId()).toEqual([]);
+    });
+
+    it('should handle an AoW whose outcomes are all non-exclusive', () => {
+      service.tocResultsOutcomesByAowId.set([shared]);
+
+      expect(service.tocResultsOutcomesExclusiveByAowId()).toEqual([]);
+      expect(service.tocResultsOutcomesNonExclusiveByAowId()).toEqual([shared]);
+    });
+
+    it('should not mutate the source signal', () => {
+      const source = [own, shared];
+      service.tocResultsOutcomesByAowId.set(source);
+
+      service.tocResultsOutcomesExclusiveByAowId();
+      service.tocResultsOutcomesNonExclusiveByAowId();
+
+      expect(service.tocResultsOutcomesByAowId()).toEqual([own, shared]);
+      expect(service.tocResultsOutcomesByAowId().length).toBe(2);
+    });
+  });
+
   describe('Additional signals', () => {
     it('should update w3BilateralProjects signal', () => {
       const mockProjects = [

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/services/entity-aow.service.ts
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-aow/services/entity-aow.service.ts
@@ -35,6 +35,19 @@ export class EntityAowService {
 
   tocResultsOutputsByAowId = signal<any[]>([]);
   tocResultsOutcomesByAowId = signal<any[]>([]);
+
+  // Outcomes exclusive to the current AoW. The server flags every ToC node it returns for an AoW
+  // with `is_aow`: `false` means the node is not linked to any Area of Work
+  // (`toc_results.wp_id IS NULL`), so it is returned under EVERY AoW of the program.
+  // A missing flag is treated as exclusive, which keeps the previous single-list behaviour.
+  tocResultsOutcomesExclusiveByAowId = computed(() =>
+    this.tocResultsOutcomesByAowId().filter((item: any) => item?.is_aow !== false)
+  );
+
+  // Program-level Outcomes shown inside every AoW — rendered in their own tagged section.
+  tocResultsOutcomesNonExclusiveByAowId = computed(() =>
+    this.tocResultsOutcomesByAowId().filter((item: any) => item?.is_aow === false)
+  );
   tocResults2030Outcomes = signal<any[]>([]);
   tocResultsIntermediateOutcomes = signal<any[]>([]);
   searchText = signal<string>('');

--- a/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-details/entity-details.component.html
+++ b/onecgiar-pr-client/src/app/pages/result-framework-reporting/pages/entity-details/entity-details.component.html
@@ -92,7 +92,7 @@
                    [routerLink]="'/result-framework-reporting/entity-details/' + entityAowService.entityId() + '/aow/unplanned'">
                 <div class="entity-special-card__info">
                   <span class="entity-special-card__title">Intermediate Outcomes</span>
-                  <span class="entity-special-card__sub">TOC outcomes not assigned to an Area of Work</span>
+                  <span class="entity-special-card__sub">Intermediate Outcomes assigned to more than one Area of Work</span>
                 </div>
                 <div class="entity-special-card__right">
                   <span class="entity-special-card__count">{{ entityAowService.intermediateOutcomes()?.count }} outcomes</span>

--- a/onecgiar-pr-server/src/api/results/results-toc-results/repositories/aow-bilateral.repository.ts
+++ b/onecgiar-pr-server/src/api/results/results-toc-results/repositories/aow-bilateral.repository.ts
@@ -26,6 +26,7 @@ interface TocResultRow {
   result_type_id?: number | null;
   result_type_name?: string | null;
   result_level_id?: number | null;
+  is_aow?: number | null;
   center_id?: number | null;
   center_acronym?: string | null;
 }
@@ -36,6 +37,8 @@ export interface TocResultResponse {
   result_title: string;
   related_node_id: string | null;
   result_level_id?: number | null;
+  /** True when the ToC node is explicitly linked to the queried AOW (wp_id IS NOT NULL and matched). False for program-level nodes that appear under all AOWs. */
+  is_aow?: boolean;
   indicators: Array<{
     indicator_id: number;
     indicator_description: string | null;
@@ -379,6 +382,7 @@ export class AoWBilateralRepository {
         tr.category,
         tr.result_title AS result_title,
         tr.related_node_id AS related_node_id,
+        ${options.areaAcronym ? '(wp.toc_id IS NOT NULL)' : 'NULL'} AS is_aow,
         tri.id AS indicator_id,
         tri.indicator_description,
         tri.toc_result_indicator_id,
@@ -503,6 +507,7 @@ export class AoWBilateralRepository {
           result_title: row.result_title,
           related_node_id: row.related_node_id,
           result_level_id: row.result_level_id ?? null,
+          is_aow: Boolean(row.is_aow),
           indicators: [],
         });
       }
@@ -534,7 +539,11 @@ export class AoWBilateralRepository {
       }
     }
 
-    return Array.from(grouped.values());
+    const results = Array.from(grouped.values());
+    if (results.some((r) => r.is_aow)) {
+      results.sort((a, b) => Number(b.is_aow) - Number(a.is_aow));
+    }
+    return results;
   }
 
   async findResultById(tocResultId: number, phaseUuid: string) {

--- a/openspec/changes/non-exclusive-intermediate-outcomes-tag/.openspec.yaml
+++ b/openspec/changes/non-exclusive-intermediate-outcomes-tag/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-03

--- a/openspec/changes/non-exclusive-intermediate-outcomes-tag/design.md
+++ b/openspec/changes/non-exclusive-intermediate-outcomes-tag/design.md
@@ -1,0 +1,60 @@
+## Context
+
+`GET /api/results-framework-reporting/toc-results?program=&areaOfWork=` returns, for one AoW, both the ToC nodes linked to that AoW and the ones linked to none. The server distinguishes them with the `is_aow` boolean added in commit `3620284f3` (`aow-bilateral.repository.ts`): the SELECT projects `(wp.toc_id IS NOT NULL) AS is_aow`, `groupTocRows` maps it with `Boolean(row.is_aow)`, and the grouped list is sorted so `is_aow: false` comes last.
+
+The client already renders that list through a single `AowHloTableComponent` instance per tab. Two earlier changes live in that same component and must keep working: the search filter (P2-3141) and the pre-expanded groups.
+
+## Goals / Non-Goals
+
+**Goals**
+- Separate program-level Intermediate Outcomes from AoW-exclusive ones on the Outcomes tab, and tag them.
+- Explain, on `/aow/unplanned`, what those entries are.
+- Keep the change additive: no existing behaviour altered.
+
+**Non-Goals**
+- Tagging non-exclusive **OUTPUT** nodes on the High-Level Outputs tab. The same criterion applies and the flag is already there, but the request covers Outcomes only. Deliberately out of scope, not a technical limitation.
+- Re-deriving the rule client-side. The flag is the single source of truth.
+- Porting to `origin/performance-refactor`. Tracked separately (see Risks).
+
+## Decisions
+
+### 1. Two `computed` lists on the service, not a mutation
+
+`tocResultsOutcomesExclusiveByAowId` and `tocResultsOutcomesNonExclusiveByAowId` derive from the existing `tocResultsOutcomesByAowId` signal. The source signal is never mutated or re-fetched, so the tab counters keep reporting the unfiltered total and `getTocResultsByAowId` is untouched.
+
+**A missing `is_aow` counts as exclusive** (`item?.is_aow !== false`). Until the server deploy lands, or against any older payload, the page renders exactly as it does today — the feature degrades to the current single list instead of moving every Outcome into the "not exclusive" section.
+
+### 2. A new `tableType` instead of a new component
+
+`AowHloTableComponent` already switches its data source on `tableType`. Adding `'outcomes-non-exclusive'` reuses the whole table — columns, status chips, action buttons, expand behaviour, and the P2-3141 search filter — for free, because `filteredTableData` and `expandedRowKeys` both derive from `tableData()`.
+
+### 3. Three new inputs, because the component hosts shared UI
+
+The search box **and** the Report-Result modal / View-Results drawer / Target-Details drawer live inside this component's template but are driven by root-singleton service signals. A second instance would therefore render a second search input writing the same signal, and a second copy of each dialog the moment its flag flips.
+
+- `showSearch` — `false` on the second instance. The single remaining input still filters both tables, since both read `searchText`.
+- `renderOverlays` — hosts the dialogs. Bound to `!exclusive.length`, so the overlays always exist exactly once: normally on the main table, and on the second table when the main one is hidden. Without that binding, an AoW with only non-exclusive Outcomes would render zero overlays and the Report-result button would do nothing.
+- `instanceId` — suffixes the table and `<th>` ids, which are hardcoded and would otherwise duplicate. HTML-validity and a11y only.
+
+### 4. Hide the main table only when it would be empty AND the section is not
+
+If every Outcome of an AoW is program-level, the main table would render `There are no Intermediate Outcomes indicators found.` directly above a populated section. It is hidden in that case. When both lists are empty the main table stays, so the tab keeps its normal empty state instead of a blank panel.
+
+### 5. Hardcoded English copy
+
+There is no `term` pipe usage anywhere under `pages/result-framework-reporting/`; every string in this tree is a template or TS literal, including the P2-3052 banner. `TerminologyService` is a 7-key P22↔P25 vocabulary switch, not a string catalog, and this copy does not vary by portfolio. Following the surrounding code.
+
+### 6. Info tone, not warning
+
+The P2-3052 yellow banner already sits above the tabs. A second yellow block would read as two equal-severity warnings, so the new note and the tag use the blue `--pr-color-blue-*` tokens.
+
+## Risks / Trade-offs
+
+- **The flag was not in prtest at implementation time.** Validated in the browser by intercepting the response and injecting `is_aow` with the exact semantics of `3620284f3` (7208/7258 → `false` for SP05). Must be re-verified against the real payload once deployed.
+- **`GROUP BY` on the server does not list `wp.toc_id`.** The projected expression depends on it; under `ONLY_FULL_GROUP_BY` that can raise MySQL error 1055. It runs in the author's environment, so this is an environment-parity risk to confirm on prtest/production, not a client-side one.
+- **Two near-copies of the note SCSS** (AoW page + unplanned page), matching the existing `.aow-repeated-note` precedent. Promoting one shared block to `src/styles/` is the clean follow-up, after the presentation.
+- **`origin/performance-refactor` rewrote `aow-hlo-table.component.html`** onto an in-house `app-pr-group-table`. The logic ports 1:1 but that template must be re-authored, not merged. That branch also adds `dashboard-lab/`, which renders its own per-AoW Outcomes list from the same endpoint and would need the same treatment — scope to confirm with the requesters.
+
+## Migration Plan
+
+Frontend-only and additive; no migration, no feature flag. The `is_aow !== false` default means client and server can deploy in either order.

--- a/openspec/changes/non-exclusive-intermediate-outcomes-tag/proposal.md
+++ b/openspec/changes/non-exclusive-intermediate-outcomes-tag/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+A Theory of Change node that is **not linked to any Area of Work** (`toc_results.wp_id IS NULL`) is program-level by design, so the AoW query deliberately returns it under **every** AoW of the Science Program (`aow-bilateral.repository.ts`, the `AND (wp.toc_id IS NOT NULL OR tr.wp_id IS NULL)` predicate). The very same nodes are also listed on the sidebar page **Intermediate Outcomes** (`/aow/unplanned`, the `intermediateOnly` predicate `AND tr.wp_id IS NULL`).
+
+Verified on prtest with `SP05`: `toc_result_id` **7208** and **7258** are returned by all six AoW (AOW01–AOW06) and are exactly the set returned by `/toc-results/intermediate-outcomes`. Every other outcome is returned by a single AoW.
+
+Today the UI shows both kinds in one undifferentiated list, so a user inside AOW06 cannot tell that an Outcome is shared with the whole program rather than owned by their AoW. Reported on Slack (2026-08-03) by **Ángel Jarrín**, with mockups from **Héctor Tobón**, for a stakeholder presentation on 2026-08-04.
+
+## What Changes
+
+- On the AoW page **Outcomes** tab, split the single list in two: the Outcomes **exclusive to that AoW** stay in the main table; the ones that are **not exclusive** move to a **separate section below it**, under its own heading.
+- Each group in that new section carries a **tag** (`Not exclusive to this AoW`) with a tooltip explaining that the node is not assigned to a single Area of Work, plus a short info note above the section.
+- On the sidebar page **Intermediate Outcomes** (`/aow/unplanned`), add a **descriptive note** explaining what those entries are and why they differ from the Outcomes shown inside an AoW.
+- The split is driven by the backend flag **`is_aow`** (`false` ⇒ not exclusive), added by Juan David Delgado in commit `3620284f3` on this branch. The client only reads the flag; it does not re-derive the rule.
+
+## Capabilities
+
+### New Capabilities
+- `aow-non-exclusive-outcomes`: On the AoW Outcomes tab, program-level Intermediate Outcomes are separated into their own tagged section below the AoW-exclusive ones, and the Intermediate Outcomes page explains what those entries are.
+
+### Modified Capabilities
+<!-- None. `aow-indicator-search` (P2-3141) and `aow-repeated-indicator-banner` (P2-3052) keep their current behaviour; the search filter applies to each table instance independently. -->
+
+## Impact
+
+- **Frontend** (`onecgiar-pr-client`). The backend flag already shipped on this branch — no further server change is required for this proposal.
+- Affected files:
+  - `.../entity-aow/services/entity-aow.service.ts` — two derived lists split by `is_aow`.
+  - `.../entity-aow-aow/components/aow-hlo-table/aow-hlo-table.component.{ts,html,scss}` — new `tableType`, the tag, and two inputs (`showSearch`, `renderOverlays`) so a second instance does not duplicate the search box or the modal/drawers.
+  - `.../entity-aow-aow/entity-aow-aow.component.{html,scss}` — the second section below the main table.
+  - `.../entity-aow-unplanned/entity-aow-unplanned.component.{html,scss}` — the descriptive note.
+- **Behaviour preserved:** tab counts keep showing the unfiltered total; the High-Level Outputs tab, the 2030 Outcomes page and the Intermediate Outcomes page are untouched in behaviour; the P2-3141 search filter and the pre-expanded groups keep working on both tables.
+- No routing, guard, interceptor, API, data-model or migration change. No new dependency.
+- Copy is authored in **English, hardcoded in the templates** — the `result-framework-reporting` tree does not use the terminology pipe anywhere, and this copy does not vary between P22 and P25.

--- a/openspec/changes/non-exclusive-intermediate-outcomes-tag/specs/aow-non-exclusive-outcomes/spec.md
+++ b/openspec/changes/non-exclusive-intermediate-outcomes-tag/specs/aow-non-exclusive-outcomes/spec.md
@@ -1,0 +1,55 @@
+# Spec — aow-non-exclusive-outcomes
+
+## ADDED Requirements
+
+### Requirement: Separate section for Outcomes that are not exclusive to the AoW
+On the AoW page Outcomes tab, the indicators view SHALL render two tables. The first SHALL list only the Outcomes flagged as belonging to the queried Area of Work (`is_aow` other than `false`). Below it, when at least one Outcome is flagged `is_aow: false`, a second section SHALL be rendered under the heading `Intermediate Outcomes not exclusive to this Area of Work`, preceded by an informational note explaining that those entries are not assigned to a specific Area of Work and therefore appear under every one of them. An Outcome arriving without the `is_aow` field SHALL be treated as exclusive.
+
+#### Scenario: An AoW with both kinds of Outcomes
+- **WHEN** a user opens the Outcomes tab of an AoW whose payload mixes `is_aow: true` and `is_aow: false` entries
+- **THEN** the main table lists only the `is_aow: true` Outcomes, and a separate section below lists the `is_aow: false` ones
+
+#### Scenario: An AoW with no shared Outcomes
+- **WHEN** every Outcome of the AoW is flagged `is_aow: true`
+- **THEN** only the main table is rendered and no additional section appears
+
+#### Scenario: An AoW whose Outcomes are all shared
+- **WHEN** every Outcome of the AoW is flagged `is_aow: false`
+- **THEN** the main table is not rendered, and the separate section lists all of them — so the user never sees an empty table above a populated section
+
+#### Scenario: Payload without the flag
+- **WHEN** the response contains no `is_aow` field (older server build)
+- **THEN** every Outcome is rendered in the main table and no additional section appears, matching the previous behaviour
+
+### Requirement: Tag on each non-exclusive Outcome
+Every group header inside the separate section SHALL display the tag `Not exclusive to this AoW`, carrying the tooltip `This Intermediate Outcome is not assigned to a single Area of Work, so it appears under all of them.` The tag SHALL NOT be rendered in the main Outcomes table, the High-Level Outputs tab, the 2030 Outcomes page, or the Intermediate Outcomes page.
+
+#### Scenario: Tag visible only in the separate section
+- **WHEN** the Outcomes tab renders both tables
+- **THEN** each group of the second table shows the tag, and no group of the first table does
+
+### Requirement: Shared controls render exactly once
+The search input and the three overlays hosted by the indicators table (Report-Result modal, View-Results drawer, Target-Details drawer) are driven by shared state, so they SHALL be rendered by exactly one table instance per view. The single search input SHALL keep filtering both tables. Table and column-header ids SHALL remain unique across the two instances. Tab counters SHALL keep reporting the total number of Outcomes, unaffected by the split.
+
+#### Scenario: Only one search input on the Outcomes tab
+- **WHEN** both tables are rendered
+- **THEN** exactly one `Find indicator...` input exists, and typing in it filters both tables
+
+#### Scenario: Reporting a result from the separate section
+- **WHEN** the user clicks `Report result` on a row of the non-exclusive section
+- **THEN** exactly one Report-Result modal is rendered
+
+#### Scenario: Overlays still reachable when the main table is hidden
+- **WHEN** every Outcome is non-exclusive, so the main table is not rendered
+- **THEN** the separate section hosts the overlays, and `Report result` still opens the modal
+
+#### Scenario: Tab counter unchanged
+- **WHEN** an AoW has 6 Outcomes of which 2 are non-exclusive
+- **THEN** the tab still reads `Outcomes (6)`
+
+### Requirement: Description on the Intermediate Outcomes page
+The sidebar page `Intermediate Outcomes` (`/aow/unplanned`) SHALL display, above its table, a note stating that these are the Science Program's Theory of Change entries not assigned to a specific Area of Work, that they are gathered there and also appear tagged inside every Area of Work, and that the Outcomes shown when opening an Area of Work are the ones planned for that Area of Work only.
+
+#### Scenario: Note visible on the page
+- **WHEN** a user opens the Intermediate Outcomes page from the sidebar
+- **THEN** the explanatory note is rendered above the indicators table, and the table itself behaves exactly as before

--- a/openspec/changes/non-exclusive-intermediate-outcomes-tag/specs/aow-non-exclusive-outcomes/spec.md
+++ b/openspec/changes/non-exclusive-intermediate-outcomes-tag/specs/aow-non-exclusive-outcomes/spec.md
@@ -48,7 +48,7 @@ The search input and the three overlays hosted by the indicators table (Report-R
 - **THEN** the tab still reads `Outcomes (6)`
 
 ### Requirement: Description on the Intermediate Outcomes page
-The sidebar page `Intermediate Outcomes` (`/aow/unplanned`) SHALL display, above its table, a note stating that these are the Science Program's Theory of Change entries not assigned to a specific Area of Work, that they are gathered there and also appear tagged inside every Area of Work, and that the Outcomes shown when opening an Area of Work are the ones planned for that Area of Work only.
+The sidebar page `Intermediate Outcomes` (`/aow/unplanned`) SHALL display, above its table, a note stating that these are the Intermediate Outcomes of the Science Program/Accelerator that are not assigned to a specific Area of Work, and that they are displayed both there and within the Areas of Work to which they are mapped. Wording approved by the requesters on 2026-08-03.
 
 #### Scenario: Note visible on the page
 - **WHEN** a user opens the Intermediate Outcomes page from the sidebar

--- a/openspec/changes/non-exclusive-intermediate-outcomes-tag/tasks.md
+++ b/openspec/changes/non-exclusive-intermediate-outcomes-tag/tasks.md
@@ -1,0 +1,39 @@
+# Tasks — Intermediate Outcomes not exclusive to an AoW
+
+Frontend-only (`onecgiar-pr-client/`). The backend flag `is_aow` shipped separately in commit `3620284f3`.
+
+## 1. Split the Outcomes list (service)
+
+- [x] 1.1 In `.../entity-aow/services/entity-aow.service.ts`, add `tocResultsOutcomesExclusiveByAowId` and `tocResultsOutcomesNonExclusiveByAowId` as `computed` over `tocResultsOutcomesByAowId`, keyed on the `is_aow` flag. Treat a missing flag as exclusive so the page keeps its current behaviour against a payload without the field. Do not mutate or re-fetch the source signal.
+
+## 2. Host the second list (table component)
+
+- [x] 2.1 In `.../aow-hlo-table/aow-hlo-table.component.ts`, extend `tableType` with `'outcomes-non-exclusive'`, point `case 'outcomes'` at the exclusive computed and add the new case; add the matching `emptyStateMessage()` string.
+- [x] 2.2 Add `@Input() showSearch = true`, `@Input() renderOverlays = true`, `@Input() instanceId = ''`.
+- [x] 2.3 In `aow-hlo-table.component.html`, wrap the search block in `@if (showSearch)` and the three overlay blocks (create modal, view-results drawer, target-details drawer) in `@if (renderOverlays)`; suffix the table id and the `<th>` ids with `instanceId`.
+- [x] 2.4 In the group-header template, render the `Not exclusive to this AoW` chip with its tooltip when `tableType === 'outcomes-non-exclusive'`, reusing `.tab-content_chip`.
+- [x] 2.5 Add `.non-exclusive-chip` in `aow-hlo-table.component.scss` using `--pr-color-blue-*` tokens (no hex literals).
+
+## 3. Render the separate section (AoW page)
+
+- [x] 3.1 In `entity-aow-aow.component.html` `@case ('outcomes')`, hide the main table only when the exclusive list is empty AND the non-exclusive list is not.
+- [x] 3.2 Add the section below it — heading, info note, and a second `app-aow-hlo-table` with `tableType="outcomes-non-exclusive"`, `instanceId="NonExclusive"`, `[showSearch]="false"` and `[renderOverlays]="!exclusive.length"` — gated on the non-exclusive list being non-empty.
+- [x] 3.3 Style the heading and the note in `entity-aow-aow.component.scss` with the blue tokens.
+
+## 4. Describe the sidebar page
+
+- [x] 4.1 Add the info note above the table in `entity-aow-unplanned.component.html`, explaining what these entries are and how they differ from an AoW's Outcomes.
+- [x] 4.2 Style it in `entity-aow-unplanned.component.scss`, matching the AoW note.
+
+## 5. Tests
+
+- [x] 5.1 `entity-aow.service.spec.ts` — 6 cases for the split: exclusive only, non-exclusive only, missing flag treated as exclusive, both lists empty, all non-exclusive, source signal not mutated.
+- [x] 5.2 `aow-hlo-table.component.spec.ts` — add the two new computeds to the hand-rolled service mock; update the existing `tableType: 'outcomes'` case to the exclusive computed; add the `'outcomes-non-exclusive'` case, the new empty-state string, and 5 DOM cases for `showSearch` / `renderOverlays` / `instanceId`.
+
+## 6. Verification
+
+- [x] 6.1 `npx jest src/app/pages/result-framework-reporting/pages/entity-aow` → 317 passed.
+- [x] 6.2 `npm run lint` → all files pass.
+- [x] 6.3 Browser check on `SP05/AOW06` with Playwright: main list shows the 4 AoW-exclusive Outcomes; the section below shows 7208 and 7258, each tagged; exactly **1** search input and **1** modal instance when reporting from the new section; tab still reads `Outcomes (6)`; the `/aow/unplanned` note renders.
+- [ ] 6.4 Re-verify against the real payload once `is_aow` is live on prtest (currently absent — validated via response interception).
+- [x] 6.5 `npm run test:coverage` → 378 suites / 4012 tests passed. Statements 83.9%, branches 65.3%, functions 81.51%, lines 84.35% — all above the 50/60/60/60 thresholds.


### PR DESCRIPTION
## Summary

Release of the single change currently sitting on `staging` ahead of `master` (4 commits + the merge of #738).

A ToC node with no Area of Work (`toc_results.wp_id IS NULL`) is program-level, so the AoW query deliberately returns it under **every** AoW of the Science Program. Those Outcomes were rendered in the same list as the AoW's own ones, with nothing to tell them apart. The server now projects an `is_aow` flag on the ToC results payload and the client uses it to split the Outcomes tab in two: AoW-exclusive Outcomes stay in the main table, program-level ones move to their own section below, each tagged `Not exclusive to this AoW`. The Intermediate Outcomes page and the card that links to it gained copy describing what those entries are.

Requested on Slack by Ángel Jarrín and Héctor Tobón (2026-08-03).

## What ships

| Commit | Change |
|--------|--------|
| `3620284f3` | Server: projects `is_aow` in `buildTocQuery`, maps it in `groupTocRows`, sorts program-level nodes last |
| `0c153a116` | Client: splits the Outcomes tab, adds the tag, the new section and the page note (+20 tests) |
| `762c0cdba` | Approved wording for the Intermediate Outcomes page note |
| `c53d1b3ed` | Reworded the Intermediate Outcomes card subtitle |

## Risk assessment

**Additive and reversible.** No migration — `is_aow` is a derived SELECT expression over an existing column, so there is no schema change to roll back. The client treats a missing flag as exclusive (`item?.is_aow !== false`), which means an older payload renders exactly as it does today; server and client are not coupled by deploy order.

**Blast radius is one tab.** Only the Outcomes tab of an Area of Work changes layout. The High-Level Outputs tab, the 2030 Outcomes page and the Intermediate Outcomes page keep their current behaviour; tab counters still report unfiltered totals and the indicator search still filters from a single input.

**The known sharp edge, handled:** the search box and the Report-Result modal / View-Results / Target-Details drawers live inside the table component but are driven by root-singleton signals, so a second instance would duplicate them. `showSearch` / `renderOverlays` keep them single, and `renderOverlays` is bound so the overlays follow the visible table — the report action stays reachable even when every Outcome of an AoW is program-level.

## Verification before this PR

- **Real data on prtest, SP05:** `toc_result_id` 7208 and 7258 return `is_aow: false` in all six AoW (AOW01–AOW06) with zero missing values, matching exactly the set returned by `/toc-results/intermediate-outcomes`.
- **Browser:** exactly one search input and one modal instance when reporting from the new section; tab still reads `Outcomes (6)`.
- **Gate:** `ng lint` clean · 4012 tests / 378 suites pass · coverage 83.9 / 65.3 / 81.51 / 84.35 (thresholds 50/60/60/60).
- **Already validated on `dev`** (merges `77e008c96`, `8e23aae34`, `595282ca4`) and reviewed on `staging` via #738.

Release note (draft, Notion "Achievements"): *Intermediate Outcomes Shared Across Areas of Work Now Clearly Identified*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)